### PR TITLE
Dockerfile enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Run with docker run -it
+# run screen and then start the daemon and simplewallet in /usr/src/app/turtlecoin/build
+# remember to backup your wallet.dat and blockchain db with docker export
+# Pull base image.
+FROM ubuntu:16.04
+
+# Install.
+RUN apt-get update && \
+apt-get install -y screen build-essential python-dev gcc-4.9 g++-4.9 git cmake libboost1.58-all-dev librocksdb-dev
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Clone repo and build
+RUN export CXXFLAGS="-std=gnu++11" && \
+git clone https://github.com/turtlecoin/turtlecoin /usr/src/app/turtlecoin && \
+mkdir build
+
+WORKDIR /usr/src/app/turtlecoin/build
+RUN cmake ..  && make
+
+# Set environment variables.
+ENV HOME /root
+
+# Define working directory.
+WORKDIR /root
+
+# Define default command.
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,77 @@
-# Run with docker run -it
-# run screen and then start the daemon and simplewallet in /usr/src/app/turtlecoin/build
-# remember to backup your wallet.dat and blockchain db with docker export
-# Pull base image.
+# daemon runs in the background
+# run something like tail /var/log/turtlecoind/current to see the status
+# be sure to run with volumes, ie:
+# docker run -v $(pwd)/turtlecoind:/var/lib/turtlecoind -v $(pwd)/wallet:/home/turtlecoin --rm -ti turtlecoin:0.2.2
 FROM ubuntu:16.04
 
-# Install.
+ADD https://github.com/just-containers/s6-overlay/releases/download/v1.21.2.2/s6-overlay-amd64.tar.gz /tmp/
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /
+
+ADD https://github.com/just-containers/socklog-overlay/releases/download/v2.1.0-0/socklog-overlay-amd64.tar.gz /tmp/
+RUN tar xzf /tmp/socklog-overlay-amd64.tar.gz -C /
+
+ARG TURTLECOIN_VERSION=v0.2.2
+
+# install build dependencies
+# checkout the latest tag
+# build and install
 RUN apt-get update && \
-apt-get install -y screen build-essential python-dev gcc-4.9 g++-4.9 git cmake libboost1.58-all-dev librocksdb-dev
+    apt-get install -y \
+      build-essential \
+      python-dev \
+      gcc-4.9 \
+      g++-4.9 \
+      git cmake \
+      libboost1.58-all-dev \
+      librocksdb-dev && \
+    git clone https://github.com/turtlecoin/turtlecoin.git /src/turtlecoin && \
+    cd /src/turtlecoin && \
+    git checkout $TURTLECOIN_VERSION && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_CXX_FLAGS="-g0 -Os -fPIC -std=gnu++11" .. && \
+    make -j$(nproc) && \
+    mkdir -p /usr/local/bin && \
+    cp src/TurtleCoind /usr/local/bin/TurtleCoind && \
+    cp src/walletd /usr/local/bin/walletd && \
+    cp src/simplewallet /usr/local/bin/simplewallet && \
+    cp src/miner /usr/local/bin/miner && \
+    cp src/connectivity_tool /usr/local/bin/connectivity_tool && \
+    cd / && \
+    rm -rf /src/turtlecoin && \
+    apt-get remove -y build-essential python-dev gcc-4.9 g++-4.9 git cmake libboost1.58-all-dev librocksdb-dev && \
+    apt-get autoremove -y && \
+    apt-get install -y  \
+      libboost-system1.58.0 \
+      libboost-filesystem1.58.0 \
+      libboost-thread1.58.0 \
+      libboost-date-time1.58.0 \
+      libboost-chrono1.58.0 \
+      libboost-regex1.58.0 \
+      libboost-serialization1.58.0 \
+      libboost-program-options1.58.0 \
+      libicu55
 
-# Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+# setup the turtlecoind service
+RUN useradd -r -s /usr/sbin/nologin -m -d /var/lib/turtlecoind turtlecoind && \
+    useradd -s /bin/bash -m -d /home/turtlecoin turtlecoin && \
+    mkdir -p /etc/services.d/turtlecoind/log && \
+    mkdir -p /var/log/turtlecoind && \
+    echo "#!/usr/bin/execlineb" > /etc/services.d/turtlecoind/run && \
+    echo "fdmove -c 2 1" >> /etc/services.d/turtlecoind/run && \
+    echo "cd /var/lib/turtlecoind" >> /etc/services.d/turtlecoind/run && \
+    echo "export HOME /var/lib/turtlecoind" >> /etc/services.d/turtlecoind/run && \
+    echo "s6-setuidgid turtlecoind /usr/local/bin/TurtleCoind" >> /etc/services.d/turtlecoind/run && \
+    chmod +x /etc/services.d/turtlecoind/run && \
+    chown nobody:nogroup /var/log/turtlecoind && \
+    echo "#!/usr/bin/execlineb" > /etc/services.d/turtlecoind/log/run && \
+    echo "logutil-service /var/log/turtlecoind" >> /etc/services.d/turtlecoind/log/run && \
+    chmod +x /etc/services.d/turtlecoind/log/run && \
+    echo "/var/lib/turtlecoind true turtlecoind 0644 0755" > /etc/fix-attrs.d/turtlecoind-home && \
+    echo "/home/turtlecoin true turtlecoin 0644 0755" > /etc/fix-attrs.d/turtlecoin-home && \
+    echo "/var/log/turtlecoind true nobody 0644 0755" > /etc/fix-attrs.d/turtlecoind-logs
 
-# Clone repo and build
-RUN export CXXFLAGS="-std=gnu++11" && \
-git clone https://github.com/turtlecoin/turtlecoin /usr/src/app/turtlecoin && \
-mkdir build
+VOLUME ["/var/lib/turtlecoind", "/home/turtlecoin","/var/log/turtlecoind"]
 
-WORKDIR /usr/src/app/turtlecoin/build
-RUN cmake ..  && make
-
-# Set environment variables.
-ENV HOME /root
-
-# Define working directory.
-WORKDIR /root
-
-# Define default command.
-CMD ["bash"]
+ENTRYPOINT ["/init"]
+CMD ["/usr/bin/execlineb", "-P", "-c", "emptyenv cd /home/turtlecoin export HOME /home/turtlecoin s6-setuidgid turtlecoin /bin/bash"]


### PR DESCRIPTION
This is based on the work done by @scottjw in #3 with a few changes:

* reduced the image size by removing the build-deps and replacing with runtime deps in the same layer.
* TurtleCoind runs as a service with the s6-overlay (https://github.com/just-containers/s6-overlay)
* TurtleCoind runs as a dedicated "turtlecoind" user, and bash runs as a non-privileged "turtlecoin" user
* Volumes are used for persistence 
* The version of Turtlecoin to build is a build-time argument. It defaults to 0.2.2, you can override it when building with something like:

`docker build --build-arg TURTLECOIN_VERSION=v0.2.2 -t turtlecoin:0.2.2 .`