### PR TITLE
Change checkpoint log message colour to yellow

### DIFF
--- a/src/CryptoNoteCore/Checkpoints.cpp
+++ b/src/CryptoNoteCore/Checkpoints.cpp
@@ -53,7 +53,7 @@ bool Checkpoints::checkBlock(uint32_t index, const Crypto::Hash &h,
     return true;
 
   if (it->second == h) {
-    logger(Logging::INFO, Logging::GREEN) 
+    logger(Logging::INFO, BRIGHT_YELLOW) 
       << "CHECKPOINT PASSED FOR INDEX " << index << " " << h;
     return true;
   } else {


### PR DESCRIPTION
Fixes some users being confused by the green colour and thinking syncing is completed