### PR TITLE
"Improvements" to simplewallet

### DIFF
--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -88,6 +88,7 @@ public:
   virtual void initWithKeys(const AccountKeys& accountKeys, const std::string& password) = 0;
   virtual void shutdown() = 0;
   virtual void reset() = 0;
+  virtual void reset(uint64_t height) = 0;
 
   virtual void save(std::ostream& destination, bool saveDetailed = true, bool saveCache = true) = 0;
 
@@ -111,7 +112,7 @@ public:
   virtual std::error_code cancelTransaction(size_t transferId) = 0;
 
   virtual void getAccountKeys(AccountKeys& keys) = 0;
-  virtual void syncAll(bool syncWalletFromZero = 0) = 0;
+  virtual void syncAll(bool syncWalletFromZero = 0, uint64_t height = 0) = 0;
 };
 
 }

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -165,6 +165,7 @@ std::string m_import_new;
 
     std::string m_wallet_file;
     bool sync_from_zero;
+    bool exit_after_generate;
     uint64_t sync_from_height; 
 
     std::unique_ptr<std::promise<std::error_code>> m_initResultPromise;

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -165,6 +165,7 @@ std::string m_import_new;
 
     std::string m_wallet_file;
     bool sync_from_zero;
+    uint64_t sync_from_height; 
 
     std::unique_ptr<std::promise<std::error_code>> m_initResultPromise;
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -164,6 +164,8 @@ std::string m_import_new;
     uint16_t m_daemon_port;
 
     std::string m_wallet_file;
+    std::string m_restore_view;
+    std::string m_restore_spend;
     bool sync_from_zero;
     bool exit_after_generate;
     uint64_t sync_from_height; 

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -109,9 +109,9 @@ void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest& request, C
       { "get_transfers", makeMemberMethod(&wallet_rpc_server::on_get_transfers) },
       { "get_height", makeMemberMethod(&wallet_rpc_server::on_get_height) },
       { "reset", makeMemberMethod(&wallet_rpc_server::on_reset) },
-      { "stop_wallet", makeMemberMethod(&wallet_rpc_server::on_stop_wallet) }
-      //{ "get_address", makeMemberMethod(&wallet_rpc_server::on_get_address) },
-      //{ "view_keys", makeMemberMethod(&wallet_rpc_server::on_view_keys) }
+      { "stop_wallet", makeMemberMethod(&wallet_rpc_server::on_stop_wallet) },
+      { "get_address", makeMemberMethod(&wallet_rpc_server::on_get_address) },
+      { "view_keys", makeMemberMethod(&wallet_rpc_server::on_view_keys) }
     };
 
     auto it = s_methods.find(jsonRequest.getMethod());
@@ -296,7 +296,7 @@ bool wallet_rpc_server::on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& r
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-bool wallet_rpc_server::on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res) {
+bool wallet_rpc_server::on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::request& req, wallet_rpc::COMMAND_RPC_STOP::response& res) {
   try {
     WalletHelper::storeWallet(m_wallet, m_walletFilename);
   } catch (std::exception& e) {
@@ -307,4 +307,23 @@ bool wallet_rpc_server::on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::reque
 
   return true;
 }
+
+bool wallet_rpc_server::on_get_address(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res) {
+  
+  res.address = m_wallet.getAddress();
+  return true;
+
+}
+
+bool wallet_rpc_server::on_view_keys(const wallet_rpc::COMMAND_RPC_VIEW_KEYS::request& req, wallet_rpc::COMMAND_RPC_VIEW_KEYS::response& res) {
+  
+  AccountKeys keys;
+  m_wallet.getAccountKeys(keys);
+  res.view_key = Common::podToHex(keys.viewSecretKey);
+  res.spend_key = Common::podToHex(keys.spendSecretKey);
+
+  return true;
+
+}
+
 }

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -43,19 +43,19 @@ void wallet_rpc_server::init_options(boost::program_options::options_description
 }
 //------------------------------------------------------------------------------------------------------------------------------
 wallet_rpc_server::wallet_rpc_server(
-  System::Dispatcher& dispatcher, 
-  Logging::ILogger& log, 
+  System::Dispatcher& dispatcher,
+  Logging::ILogger& log,
   CryptoNote::IWalletLegacy&w,
-  CryptoNote::INode& n, 
-  CryptoNote::Currency& currency, 
+  CryptoNote::INode& n,
+  CryptoNote::Currency& currency,
   const std::string& walletFile)
-  : 
-  HttpServer(dispatcher, log), 
-  logger(log, "WalletRpc"), 
-  m_dispatcher(dispatcher), 
-  m_stopComplete(dispatcher), 
+  :
+  HttpServer(dispatcher, log),
+  logger(log, "WalletRpc"),
+  m_dispatcher(dispatcher),
+  m_stopComplete(dispatcher),
   m_wallet(w),
-  m_node(n), 
+  m_node(n),
   m_currency(currency),
   m_walletFilename(walletFile) {
 }
@@ -108,7 +108,11 @@ void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest& request, C
       { "get_payments", makeMemberMethod(&wallet_rpc_server::on_get_payments) },
       { "get_transfers", makeMemberMethod(&wallet_rpc_server::on_get_transfers) },
       { "get_height", makeMemberMethod(&wallet_rpc_server::on_get_height) },
-      { "reset", makeMemberMethod(&wallet_rpc_server::on_reset) }
+      { "reset", makeMemberMethod(&wallet_rpc_server::on_reset) },
+      { "reset_from", makeMemberMethod(&wallet_rpc_server::on_reset_from) }
+      //{ "stop_wallet", makeMemberMethod(&wallet_rpc_server::on_stop_wallet) },
+      //{ "get_address", makeMemberMethod(&wallet_rpc_server::on_get_address) },
+      //{ "view_keys", makeMemberMethod(&wallet_rpc_server::on_view_keys) }
     };
 
     auto it = s_methods.find(jsonRequest.getMethod());
@@ -149,7 +153,7 @@ bool wallet_rpc_server::on_transfer(const wallet_rpc::COMMAND_RPC_TRANSFER::requ
 
     Crypto::Hash payment_id;
     if (!CryptoNote::parsePaymentId(payment_id_str, payment_id)) {
-      throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID, 
+      throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID,
         "Payment id has invalid format: \"" + payment_id_str + "\", expected 64-character string");
     }
 
@@ -288,6 +292,11 @@ bool wallet_rpc_server::on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::
 }
 
 bool wallet_rpc_server::on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& req, wallet_rpc::COMMAND_RPC_RESET::response& res) {
+  m_wallet.reset();
+  return true;
+}
+
+bool wallet_rpc_server::on_reset_from(const wallet_rpc::COMMAND_RPC_RESET_FROM::request& req, wallet_rpc::COMMAND_RPC_RESET_FROM::response& res) {
   m_wallet.reset();
   return true;
 }

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -109,8 +109,7 @@ void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest& request, C
       { "get_transfers", makeMemberMethod(&wallet_rpc_server::on_get_transfers) },
       { "get_height", makeMemberMethod(&wallet_rpc_server::on_get_height) },
       { "reset", makeMemberMethod(&wallet_rpc_server::on_reset) },
-      { "reset_from", makeMemberMethod(&wallet_rpc_server::on_reset_from) }
-      //{ "stop_wallet", makeMemberMethod(&wallet_rpc_server::on_stop_wallet) },
+      { "stop_wallet", makeMemberMethod(&wallet_rpc_server::on_stop_wallet) }
       //{ "get_address", makeMemberMethod(&wallet_rpc_server::on_get_address) },
       //{ "view_keys", makeMemberMethod(&wallet_rpc_server::on_view_keys) }
     };
@@ -296,9 +295,16 @@ bool wallet_rpc_server::on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& r
   return true;
 }
 
-bool wallet_rpc_server::on_reset_from(const wallet_rpc::COMMAND_RPC_RESET_FROM::request& req, wallet_rpc::COMMAND_RPC_RESET_FROM::response& res) {
-  m_wallet.reset();
+//------------------------------------------------------------------------------------------------------------------------------
+bool wallet_rpc_server::on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res) {
+  try {
+    WalletHelper::storeWallet(m_wallet, m_walletFilename);
+  } catch (std::exception& e) {
+    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR, std::string("Couldn't save wallet: ") + e.what());
+  }
+
+  wallet_rpc_server::send_stop_signal();
+
   return true;
 }
-
 }

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -62,6 +62,7 @@ namespace Tools
     bool on_getbalance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req, wallet_rpc::COMMAND_RPC_GET_BALANCE::response& res);
     bool on_transfer(const wallet_rpc::COMMAND_RPC_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_TRANSFER::response& res);
     bool on_store(const wallet_rpc::COMMAND_RPC_STORE::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res);
+    bool on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::request& req, wallet_rpc::COMMAND_RPC_STOP::response& res);
     bool on_get_payments(const wallet_rpc::COMMAND_RPC_GET_PAYMENTS::request& req, wallet_rpc::COMMAND_RPC_GET_PAYMENTS::response& res);
     bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res);
     bool on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res);

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -68,8 +68,9 @@ namespace Tools
     bool on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res);
     bool on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& req, wallet_rpc::COMMAND_RPC_RESET::response& res);
     bool on_reset_from(const wallet_rpc::COMMAND_RPC_RESET_FROM::request& req, wallet_rpc::COMMAND_RPC_RESET_FROM::response& res);
-
     bool handle_command_line(const boost::program_options::variables_map& vm);
+    bool on_get_address(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res);
+    bool on_view_keys(const wallet_rpc::COMMAND_RPC_VIEW_KEYS::request& req, wallet_rpc::COMMAND_RPC_VIEW_KEYS::response& res);
 
     Logging::LoggerRef logger;
     CryptoNote::IWalletLegacy& m_wallet;

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -76,6 +76,7 @@ namespace Tools
     CryptoNote::IWalletLegacy& m_wallet;
     CryptoNote::INode& m_node;
     uint16_t m_port;
+    bool m_allow_extended_rpc;
     std::string m_bind_ip;
     CryptoNote::Currency& m_currency;
     const std::string m_walletFilename;

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -37,17 +37,17 @@ namespace Tools
   public:
 
     wallet_rpc_server(
-      System::Dispatcher& dispatcher, 
+      System::Dispatcher& dispatcher,
       Logging::ILogger& log,
-      CryptoNote::IWalletLegacy &w, 
-      CryptoNote::INode &n, 
+      CryptoNote::IWalletLegacy &w,
+      CryptoNote::INode &n,
       CryptoNote::Currency& currency,
       const std::string& walletFilename);
 
 
     static void init_options(boost::program_options::options_description& desc);
     bool init(const boost::program_options::variables_map& vm);
-    
+
     bool run();
     void send_stop_signal();
 
@@ -66,6 +66,7 @@ namespace Tools
     bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res);
     bool on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res);
     bool on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& req, wallet_rpc::COMMAND_RPC_RESET::response& res);
+    bool on_reset_from(const wallet_rpc::COMMAND_RPC_RESET_FROM::request& req, wallet_rpc::COMMAND_RPC_RESET_FROM::response& res);
 
     bool handle_command_line(const boost::program_options::variables_map& vm);
 

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -182,5 +182,21 @@ using CryptoNote::ISerializer;
     typedef CryptoNote::EMPTY_STRUCT request;
     typedef CryptoNote::EMPTY_STRUCT response;
   };
+
+  struct COMMAND_RPC_RESET_FROM {
+
+    struct request
+    {
+    uint64_t height;
+
+      void serialize(ISerializer& s) {
+        KV_MEMBER(height)
+      }
+    };
+
+    typedef CryptoNote::EMPTY_STRUCT response;
+
+  };
+
 }
 }

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -94,6 +94,12 @@ using CryptoNote::ISerializer;
     typedef CryptoNote::EMPTY_STRUCT response;
   };
 
+  struct COMMAND_RPC_STOP
+  {
+    typedef CryptoNote::EMPTY_STRUCT request;
+    typedef CryptoNote::EMPTY_STRUCT response;
+  };
+
   struct payment_details
   {
     std::string tx_hash;

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -204,5 +204,36 @@ using CryptoNote::ISerializer;
 
   };
 
+  struct COMMAND_RPC_GET_ADDRESS
+  {
+    typedef CryptoNote::EMPTY_STRUCT request;
+
+    struct response
+    {
+      std::string address;
+
+      void serialize(ISerializer& s) {
+        KV_MEMBER(address)
+      }
+    };
+  };
+
+  struct COMMAND_RPC_VIEW_KEYS
+  {
+    typedef CryptoNote::EMPTY_STRUCT request;
+
+    struct response
+    {
+      std::string view_key;
+      std::string spend_key;
+
+      void serialize(ISerializer& s) {
+        KV_MEMBER(view_key)
+        KV_MEMBER(spend_key)
+      }
+
+    };
+  };
+
 }
 }

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -203,8 +203,12 @@ void WalletLegacy::initSync() {
   sub.transactionSpendableAge = 1;
   sub.syncStart.height = 0;
   sub.syncStart.timestamp = m_account.get_createtime() - ACCOUN_CREATE_TIME_ACCURACY;
-  if (m_syncAll == 1)
+  if (m_syncAll == 1) {
     sub.syncStart.timestamp = 0;
+    if (m_syncStartHeight) {
+      sub.syncStart.height = m_syncStartHeight;
+    }
+  }
   std::cout << "Sync from timestamp: " << sub.syncStart.timestamp << std::endl;
   
   auto& subObject = m_transfersSync.addSubscription(sub);
@@ -309,6 +313,12 @@ void WalletLegacy::reset() {
   } catch (std::exception& e) {
     std::cout << "exception in reset: " << e.what() << std::endl;
   }
+}
+
+void WalletLegacy::reset(uint64_t height) {
+  m_syncAll = 1;
+  m_syncStartHeight = height;
+  reset();
 }
 
 void WalletLegacy::save(std::ostream& destination, bool saveDetailed, bool saveCache) {
@@ -598,8 +608,13 @@ void WalletLegacy::notifyIfBalanceChanged() {
 
 }
 
-void WalletLegacy::syncAll(bool syncWalletFromZero) {
+void WalletLegacy::syncAll(bool syncWalletFromZero, uint64_t height) {
   m_syncAll = syncWalletFromZero;
+  if (height) {
+    m_syncStartHeight = height;
+  } else {
+    m_syncStartHeight = 0;
+  }
 }
 void WalletLegacy::getAccountKeys(AccountKeys& keys) {
   if (m_state == NOT_INITIALIZED) {

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -62,6 +62,7 @@ public:
   virtual void initWithKeys(const AccountKeys& accountKeys, const std::string& password) override;
   virtual void shutdown() override;
   virtual void reset() override;
+  virtual void reset(uint64_t height) override;
 
   virtual void save(std::ostream& destination, bool saveDetailed = true, bool saveCache = true) override;
 
@@ -84,7 +85,7 @@ public:
   virtual TransactionId sendTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
   virtual std::error_code cancelTransaction(size_t transactionId) override;
 
-  void syncAll(bool syncWalletFromZero) override;
+  void syncAll(bool syncWalletFromZero, uint64_t height) override;
   virtual void getAccountKeys(AccountKeys& keys) override;
 
 private:
@@ -141,7 +142,8 @@ private:
   Tools::ObserverManager<CryptoNote::IWalletLegacyObserver> m_observerManager;
 
   std::unique_ptr<SyncStarter> m_onInitSyncStarter;
-bool m_syncAll = 0;
+  bool m_syncAll = 0;
+  uint64_t m_syncStartHeight = 0;
 };
 
 } //namespace CryptoNote


### PR DESCRIPTION
Added the following functionality to the simplewallet:

Ability to restore a wallet from the command line using two new command line parameters, `--restore-spend-key` and `--restore-view-key`.  To be used with `--wallet-file`, this implies the generation of a new wallet.

Added parameter to dump straight out of the wallet after creating it. `--exit-after-generate`.

Added new RPC methods, which are restricted (for security reasons) until `--allow-extended-rpc` is specified which are: `reset`, `stop_wallet`, `get_address`, `view_keys`.

Fixed one bug where wallets would not re-sync from 0, when there was no timestamp known to the requester.