### PR TITLE
Add import keys function during generate container

### DIFF
--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -43,6 +43,8 @@ struct WalletConfiguration {
   std::string walletFile;
   std::string walletPassword;
   bool syncFromZero;
+  std::string secretViewKey;
+  std::string secretSpendKey;
 };
 
 void generateNewWallet(const CryptoNote::Currency& currency, const WalletConfiguration& conf, Logging::ILogger& logger, System::Dispatcher& dispatcher);

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -109,7 +109,9 @@ WalletConfiguration PaymentGateService::getWalletConfig() const {
   return WalletConfiguration{
     config.gateConfiguration.containerFile,
     config.gateConfiguration.containerPassword,
-    config.gateConfiguration.syncFromZero
+    config.gateConfiguration.syncFromZero,
+	config.gateConfiguration.secretViewKey,
+	config.gateConfiguration.secretSpendKey
   };
 }
 

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -40,6 +40,8 @@ Configuration::Configuration() {
   logLevel = Logging::INFO;
   bindAddress = "";
   bindPort = 0;
+  secretViewKey = "";
+  secretSpendKey = "";
 }
 
 void Configuration::initOptions(boost::program_options::options_description& desc) {
@@ -49,6 +51,8 @@ void Configuration::initOptions(boost::program_options::options_description& des
       ("container-file,w", po::value<std::string>(), "container file")
       ("container-password,p", po::value<std::string>(), "container password")
       ("generate-container,g", "generate new container file with one wallet and exit")
+	  ("view-key", po::value<std::string>(), "generate a container with this secret key view")
+	  ("spend-key", po::value<std::string>(), "generate a container with this secret spend key")
       ("daemon,d", "run as daemon in Unix or as service in Windows")
 #ifdef _WIN32
       ("register-service", "register service and exit (Windows only)")
@@ -116,6 +120,24 @@ void Configuration::init(const boost::program_options::variables_map& options) {
 
   if (options.count("generate-container") != 0) {
     generateNewContainer = true;
+  }
+
+  if (options.count("view-key") != 0)
+  {
+	if (!generateNewContainer)
+	{
+	  throw ConfigurationError("generate-container parameter is required");
+	}
+	secretViewKey = options["view-key"].as<std::string>();
+  }
+
+  if (options.count("spend-key") != 0)
+  {
+	if (!generateNewContainer)
+	{
+	  throw ConfigurationError("generate-container parameter is required");
+	}
+	secretSpendKey = options["spend-key"].as<std::string>();
   }
 
   if (options.count("address") != 0) {

--- a/src/PaymentGateService/PaymentServiceConfiguration.h
+++ b/src/PaymentGateService/PaymentServiceConfiguration.h
@@ -41,6 +41,8 @@ struct Configuration {
 
   std::string containerFile;
   std::string containerPassword;
+  std::string secretViewKey;
+  std::string secretSpendKey;
   std::string logFile;
   std::string serverRoot;
 


### PR DESCRIPTION
Add "--view-key" and "--spend-key" arguments to walletd.

- requires "--generate-container" option and is very much dependent that generate-container will self-destruct (which it currently does). I already feel weird if someone posted their keys as a command argument for privacy reasons so if there's a better mechanic here, please advise.
- If these keys are empty, initialize a wallet like it is today; else, try to create the wallet from keys with said keys.

`.\walletd -w test.wallet -p test -g --view-key SECRET_VIEW_KEY --spend-key SECRET_SPEND_KEY`

tips or donations: TRTLuxz9AmQQofRGzM98gf1C9Bix3BraefWK4KcPMEZHZ2MpeaEzrYriMHPRKvBpK9HYyGUcjw4krbmFNrmeiy7E1WiHsRLSLbk
