### PR TITLE
Add view_tx_outputs command

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1323,25 +1323,8 @@ bool simple_wallet::print_outputs_from_transaction(const std::vector<std::string
     if (targetPubKey.key == outputPublicKey)
     {
       uint64_t amount = ourTransaction.outputs[i].output.amount; 
-      short shells = amount % 100;
 
-      std::string trtl = std::to_string(amount / 100) + ".";
-
-      if (shells == 0)
-      {
-        /* Add an extra zero, to make it amount.00 e.g. 123.00 TRTL */
-        trtl += "00";
-      }
-      else if (shells < 10)
-      {
-        /* Add the zero on the front, to make it amount.0shells e.g. 123.02 TRTL */
-        trtl += "0" + std::to_string(shells);
-      }
-      else
-      {
-        /* Add the shells, to make it amount.shells e.g. 123.12 TRTL */
-        trtl += std::to_string(shells);
-      }
+      std::string trtl = m_currency.formatAmount(amount);
 
       sum += amount;
 
@@ -1357,25 +1340,7 @@ bool simple_wallet::print_outputs_from_transaction(const std::vector<std::string
   }
   else
   {
-    short shells = sum % 100;
-    
-    std::string trtl = std::to_string(sum / 100) += ".";
-
-    if (shells == 0)
-    {
-      /* Add an extra zero, to make it amount.00 e.g. 123.00 TRTL */
-      trtl += "00";
-    }
-    else if (shells < 10)
-    {
-      /* Add the zero on the front, to make it amount.0shells e.g. 123.02 TRTL */
-      trtl += "0" + std::to_string(shells);
-    }
-    else
-    {
-      /* Add the shells, to make it amount.shells e.g. 123.12 TRTL */
-      trtl += std::to_string(shells);
-    }
+    std::string trtl = m_currency.formatAmount(sum);
 
     logger(INFO, GREEN) << "Outputs totalling " << trtl << " TRTL were sent to your wallet!";
   }

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1264,7 +1264,7 @@ bool simple_wallet::print_outputs_from_transaction(const std::vector<std::string
   
   if (!Common::fromHex(transactionHashString, &transactionHash, sizeof(transactionHash), size))
   {
-    std::cout << "Failed to parse - please ensure you entered the hash correctly." << std::endl;
+    logger(ERROR, BRIGHT_RED) << "Failed to parse - please ensure you entered the hash correctly.";
     return false;
   }
 

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1323,10 +1323,31 @@ bool simple_wallet::print_outputs_from_transaction(const std::vector<std::string
     if (targetPubKey.key == outputPublicKey)
     {
       uint64_t amount = ourTransaction.outputs[i].output.amount; 
-      logger(INFO, GREEN) << "The transaction output of " << amount / 100 << " TRTL belongs to you!";
+      short shells = amount % 100;
+
+      std::string trtl = std::to_string(amount / 100) + ".";
+
+      if (shells == 0)
+      {
+        /* Add an extra zero, to make it amount.00 e.g. 123.00 TRTL */
+        trtl += "00";
+      }
+      else if (shells < 10)
+      {
+        /* Add the zero on the front, to make it amount.0shells e.g. 123.02 TRTL */
+        trtl += "0" + std::to_string(shells);
+      }
+      else
+      {
+        /* Add the shells, to make it amount.shells e.g. 123.12 TRTL */
+        trtl += std::to_string(shells);
+      }
 
       sum += amount;
+
       found = true;
+
+      logger(INFO, GREEN) << "The transaction output of " << trtl << " TRTL belongs to you!";
     }
   }
 
@@ -1336,7 +1357,27 @@ bool simple_wallet::print_outputs_from_transaction(const std::vector<std::string
   }
   else
   {
-    logger(INFO, GREEN) << "Outputs totalling " << sum / 100 << " TRTL were sent to your wallet!";
+    short shells = sum % 100;
+    
+    std::string trtl = std::to_string(sum / 100) += ".";
+
+    if (shells == 0)
+    {
+      /* Add an extra zero, to make it amount.00 e.g. 123.00 TRTL */
+      trtl += "00";
+    }
+    else if (shells < 10)
+    {
+      /* Add the zero on the front, to make it amount.0shells e.g. 123.02 TRTL */
+      trtl += "0" + std::to_string(shells);
+    }
+    else
+    {
+      /* Add the shells, to make it amount.shells e.g. 123.12 TRTL */
+      trtl += std::to_string(shells);
+    }
+
+    logger(INFO, GREEN) << "Outputs totalling " << trtl << " TRTL were sent to your wallet!";
   }
 
   return true;

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -91,6 +91,7 @@ bool new_wallet(Crypto::SecretKey &secret_key, Crypto::SecretKey &view_key, cons
     bool listTransfers(const std::vector<std::string> &args);
     bool transfer(const std::vector<std::string> &args);
     bool print_address(const std::vector<std::string> &args = std::vector<std::string>());
+    bool print_outputs_from_transaction(const std::vector<std::string> &args);
     bool save(const std::vector<std::string> &args);
     bool reset(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);


### PR DESCRIPTION
Lets you view the outputs of a specific transaction via it's hash, and will print all the outputs that are yours (if any). Useful for ensuring that a specific transaction actually did hit your wallet even if the wallet is playing up.

And here's a picture!

![image](https://user-images.githubusercontent.com/22151537/36075095-817bcaf8-0f41-11e8-869b-bd699b6022b3.png)
