### PR TITLE
Add password confirmation on new wallets

### DIFF
--- a/src/SimpleWallet/PasswordContainer.cpp
+++ b/src/SimpleWallet/PasswordContainer.cpp
@@ -96,7 +96,7 @@ namespace Tools
             } else {
               std::cout << "Passwords do not match, try again." << std::endl;
               clear();
-	      return false;
+	      return read_password(true);
             }
           }
 	}

--- a/src/SimpleWallet/PasswordContainer.cpp
+++ b/src/SimpleWallet/PasswordContainer.cpp
@@ -71,27 +71,45 @@ namespace Tools
     m_empty = true;
   }
 
-  bool PasswordContainer::read_password()
-  {
+  bool PasswordContainer::read_password() {
+    return read_password(false);
+  }
+
+  bool PasswordContainer::read_password(bool verify) {
     clear();
 
     bool r;
-    if (is_cin_tty())
-    {
+    if (is_cin_tty()) {
       std::cout << "password: ";
-      r = read_from_tty();
-    }
-    else
-    {
+      if (verify) {
+        std::string password1;
+        std::string password2;
+        r = read_from_tty(password1);
+        if (r) {
+          std::cout << "confirm password: ";
+          r = read_from_tty(password2);
+          if (r) {
+            if (password1 == password2) {
+              m_password = std::move(password2);
+              m_empty = false;
+	      return true;
+            } else {
+              std::cout << "Passwords do not match, try again." << std::endl;
+              clear();
+	      return false;
+            }
+          }
+	}
+      } else {
+	r = read_from_tty(m_password);
+      }
+    } else {
       r = read_from_file();
     }
 
-    if (r)
-    {
+    if (r) {
       m_empty = false;
-    }
-    else
-    {
+    } else {
       clear();
     }
 
@@ -131,7 +149,7 @@ namespace Tools
     }
   }
 
-  bool PasswordContainer::read_from_tty()
+  bool PasswordContainer::read_from_tty(std::string& password)
   {
     const char BACKSPACE = 8;
 
@@ -143,8 +161,8 @@ namespace Tools
     ::SetConsoleMode(h_cin, mode_new);
 
     bool r = true;
-    m_password.reserve(max_password_size);
-    while (m_password.size() < max_password_size)
+    password.reserve(max_password_size);
+    while (password.size() < max_password_size)
     {
       DWORD read;
       char ch;
@@ -161,16 +179,16 @@ namespace Tools
       }
       else if (ch == BACKSPACE)
       {
-        if (!m_password.empty())
+        if (!password.empty())
         {
-          m_password.back() = '\0';
-          m_password.resize(m_password.size() - 1);
+          password.back() = '\0';
+          password.resize(password.size() - 1);
           std::cout << "\b \b";
         }
       }
       else
       {
-        m_password.push_back(ch);
+        password.push_back(ch);
         std::cout << '*';
       }
     }
@@ -207,12 +225,12 @@ namespace Tools
     }
   }
 
-  bool PasswordContainer::read_from_tty()
+  bool PasswordContainer::read_from_tty(std::string& password)
   {
     const char BACKSPACE = 127;
 
-    m_password.reserve(max_password_size);
-    while (m_password.size() < max_password_size)
+    password.reserve(max_password_size);
+    while (password.size() < max_password_size)
     {
       int ch = getch();
       if (EOF == ch)
@@ -226,16 +244,16 @@ namespace Tools
       }
       else if (ch == BACKSPACE)
       {
-        if (!m_password.empty())
+        if (!password.empty())
         {
-          m_password.back() = '\0';
-          m_password.resize(m_password.size() - 1);
+          password.back() = '\0';
+          password.resize(password.size() - 1);
           std::cout << "\b \b";
         }
       }
       else
       {
-        m_password.push_back(ch);
+        password.push_back(ch);
         std::cout << '*';
       }
     }

--- a/src/SimpleWallet/PasswordContainer.h
+++ b/src/SimpleWallet/PasswordContainer.h
@@ -36,10 +36,11 @@ namespace Tools
     const std::string& password() const { return m_password; }
     void password(std::string&& val) { m_password = std::move(val); m_empty = false; }
     bool read_password();
+    bool read_password(bool verify);
 
   private:
     bool read_from_file();
-    bool read_from_tty();
+    bool read_from_tty(std::string& password);
 
   private:
     bool m_empty;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -796,6 +796,23 @@ std::string simple_wallet::generate_mnemonic(Crypto::SecretKey &private_spend_ke
 
   return mnemonic_str;
 }
+std::string simple_wallet::format_mnemonic(std::string mnemonic_str) {
+  std::string spacer ("\n\t\t");
+  std::string formatted_str;
+
+  std::vector<std::string> results;
+  boost::split(results, mnemonic_str, [](char c){return c == ' ';});
+  for (int i=0; i< (int)results.size(); i++) {
+    formatted_str += (i==0 ? spacer : "") + results[i];
+    if ((i+1) % 5 == 0) {
+      formatted_str += spacer;
+    } else {
+      formatted_str += " ";
+    }
+  }
+
+  return formatted_str;
+}
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::log_incorrect_words(std::vector<std::string> words) {
   Language::Base *language = Language::Singleton<Language::English>::instance();
@@ -915,11 +932,11 @@ bool simple_wallet::new_wallet(const std::string &wallet_file, const std::string
     std::cout << "\n\nPlease copy your secret keys and mnemonic seed and store them in a secure location:";
     Common::Console::setTextColor(Common::Console::Color::BrightGreen);
     std::cout <<
-	"\nview key: " << Common::podToHex(keys.viewSecretKey) <<
 	"\nspend key: " << Common::podToHex(keys.spendSecretKey) <<
-  "\nmnemonic seed: " << generate_mnemonic(keys.spendSecretKey);
+	"\nview key: " << Common::podToHex(keys.viewSecretKey) <<
+        "\nmnemonic seed:" << format_mnemonic(generate_mnemonic(keys.spendSecretKey));
     Common::Console::setTextColor(Common::Console::Color::BrightRed);
-    std::cout << "\n\nIf you lose these your wallet cannot be recreated!\n\n";
+    std::cout << "\nIf you lose these your wallet cannot be recreated!\n\n";
     Common::Console::setTextColor(Common::Console::Color::Default);
     std::cout <<
       "**********************************************************************\n" <<
@@ -1206,7 +1223,7 @@ bool simple_wallet::export_keys(const std::vector<std::string>& args/* = std::ve
     wallet code generated random spend and view keys so we can't create a 
     mnemonic key */
   if (deterministic_private_keys) {
-    std::cout << "Mnemonic seed: " << generate_mnemonic(keys.spendSecretKey) << std::endl;
+    std::cout << "Mnemonic seed: " << format_mnemonic(generate_mnemonic(keys.spendSecretKey)) << std::endl;
   }
 
   return true;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -796,23 +796,6 @@ std::string simple_wallet::generate_mnemonic(Crypto::SecretKey &private_spend_ke
 
   return mnemonic_str;
 }
-std::string simple_wallet::format_mnemonic(std::string mnemonic_str) {
-  std::string spacer ("\n\t\t");
-  std::string formatted_str;
-
-  std::vector<std::string> results;
-  boost::split(results, mnemonic_str, [](char c){return c == ' ';});
-  for (int i=0; i< (int)results.size(); i++) {
-    formatted_str += (i==0 ? spacer : "") + results[i];
-    if ((i+1) % 5 == 0) {
-      formatted_str += spacer;
-    } else {
-      formatted_str += " ";
-    }
-  }
-
-  return formatted_str;
-}
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::log_incorrect_words(std::vector<std::string> words) {
   Language::Base *language = Language::Singleton<Language::English>::instance();
@@ -934,9 +917,9 @@ bool simple_wallet::new_wallet(const std::string &wallet_file, const std::string
     std::cout <<
 	"\nspend key: " << Common::podToHex(keys.spendSecretKey) <<
 	"\nview key: " << Common::podToHex(keys.viewSecretKey) <<
-        "\nmnemonic seed:" << format_mnemonic(generate_mnemonic(keys.spendSecretKey));
+        "\nmnemonic seed:" << generate_mnemonic(keys.spendSecretKey);
     Common::Console::setTextColor(Common::Console::Color::BrightRed);
-    std::cout << "\nIf you lose these your wallet cannot be recreated!\n\n";
+    std::cout << "\n\nIf you lose these your wallet cannot be recreated!\n\n";
     Common::Console::setTextColor(Common::Console::Color::Default);
     std::cout <<
       "**********************************************************************\n" <<
@@ -1223,7 +1206,7 @@ bool simple_wallet::export_keys(const std::vector<std::string>& args/* = std::ve
     wallet code generated random spend and view keys so we can't create a 
     mnemonic key */
   if (deterministic_private_keys) {
-    std::cout << "Mnemonic seed: " << format_mnemonic(generate_mnemonic(keys.spendSecretKey)) << std::endl;
+    std::cout << "Mnemonic seed: " << generate_mnemonic(keys.spendSecretKey) << std::endl;
   }
 
   return true;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -616,7 +616,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm) {
   Tools::PasswordContainer pwd_container;
   if (command_line::has_arg(vm, arg_password)) {
     pwd_container.password(command_line::get_arg(vm, arg_password));
-  } else if (!pwd_container.read_password()) {
+  } else if (!pwd_container.read_password(!m_generate_new.empty() || !m_import_new.empty())) {
     fail_msg_writer() << "failed to read wallet password";
     return false;
   }

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -98,7 +98,6 @@ bool new_wallet(Crypto::SecretKey &secret_key, Crypto::SecretKey &view_key, cons
 
     bool ask_wallet_create_if_needed();
     std::string generate_mnemonic(Crypto::SecretKey &);
-    std::string format_mnemonic(std::string mnemonic_str);
     void log_incorrect_words(std::vector<std::string>);
     bool is_valid_mnemonic(std::string &, Crypto::SecretKey &);
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -98,6 +98,7 @@ bool new_wallet(Crypto::SecretKey &secret_key, Crypto::SecretKey &view_key, cons
 
     bool ask_wallet_create_if_needed();
     std::string generate_mnemonic(Crypto::SecretKey &);
+    std::string format_mnemonic(std::string mnemonic_str);
     void log_incorrect_words(std::vector<std::string>);
     bool is_valid_mnemonic(std::string &, Crypto::SecretKey &);
 


### PR DESCRIPTION
Added password confirmation prompt in simplewallet when creating a new wallet. Would appreciate someone else giving these a once over w/ all of the different modes of creating/importing wallets, especially on Windows. 

<img width="711" alt="wallet_changes" src="https://user-images.githubusercontent.com/36076951/36188580-7ff3f2d2-1112-11e8-8415-d8469e17bc53.png">
