### PR TITLE
Wait for input before dying on error

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -126,6 +126,23 @@ JsonValue buildLoggerConfiguration(Level level, const std::string& logfile) {
   return loggerConfiguration;
 }
 
+/* Wait for input so users can read errors before the window closes is they
+   launch from a GUI rather than a terminal */
+void pause_for_input(int argc) {
+  /* if they passed arguments they're probably in a terminal so the errors will
+     stay visible */
+  if (argc == 1) {
+    #if defined(WIN32)
+    if (_isatty(_fileno(stdout)) && _isatty(_fileno(stdin))) {
+    #else
+    if(isatty(fileno(stdout)) && isatty(fileno(stdin))) {
+    #endif
+      std::cout << "Press any key to close the program: ";
+      getchar();
+    }
+  }
+}
+
 int main(int argc, char* argv[])
 {
 
@@ -238,6 +255,7 @@ currencyBuilder.isBlockexplorer(blockexplorer_mode);
       currencyBuilder.currency();
     } catch (std::exception&) {
       std::cout << "GENESIS_COINBASE_TX_HEX constant has an incorrect value. Please launch: " << CryptoNote::CRYPTONOTE_NAME << "d --" << arg_print_genesis_tx.name;
+      pause_for_input(argc);
       return 1;
     }
     CryptoNote::Currency currency = currencyBuilder.currency();
@@ -261,6 +279,7 @@ currencyBuilder.isBlockexplorer(blockexplorer_mode);
 
     if (dbConfig.isConfigFolderDefaulted()) {
       if (!Tools::create_directories_if_necessary(dbConfig.getDataDir())) {
+        pause_for_input(argc);
         throw std::runtime_error("Can't create directory: " + dbConfig.getDataDir());
       }
     } else {
@@ -306,6 +325,7 @@ currencyBuilder.isBlockexplorer(blockexplorer_mode);
     logger(INFO) << "Initializing p2p server...";
     if (!p2psrv.init(netNodeConfig)) {
       logger(ERROR, BRIGHT_RED) << "Failed to initialize p2p server.";
+      pause_for_input(argc);
       return 1;
     }
 
@@ -344,6 +364,7 @@ rpcServer.enableCors(command_line::get_arg(vm, arg_enable_cors));
 
   } catch (const std::exception& e) {
     logger(ERROR, BRIGHT_RED) << "Exception: " << e.what();
+    pause_for_input(argc);
     return 1;
   }
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -102,6 +102,7 @@ bool new_wallet(Crypto::SecretKey &secret_key, Crypto::SecretKey &view_key, cons
     bool is_valid_mnemonic(std::string &, Crypto::SecretKey &);
 
     void printConnectionError() const;
+    void pause_for_input(int argc);
 
     //---------------- IWalletLegacyObserver -------------------------
     virtual void initCompleted(std::error_code result) override;


### PR DESCRIPTION
Fixes #51 and also applies this to turtlecoind.

Lets the user read the error message if launching from a GUI, but tries to not display it if they launched normally from a terminal, or if they're piping the input or output. I have not managed to test this on windows as I can't seem to get TurtleCoin to compile following the latest instructions.

I believe if it compiles it should work... It should also work on mac, as it looks like mac has the <unistd.h> header.

Hopefully I put all of these in the right places, some simple ones I can confirm it catches is things like having two copies of turtlecoind open (IO Error), and importing a wallet with the same filename as the old one, but if some functions throw exceptions it might not catch all possible errors.