### PR TITLE
Add CI for windows, linux, and mac

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+os: Visual Studio 2015
+
+environment:
+    BOOST_ROOT: C:\Libraries\boost_1_59_0
+    BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14
+
+build_script:
+    - md build
+    - cd build
+    - cmake -G "Visual Studio 14 Win64" ..
+    - MSBuild ByteCoin.sln /p:Configuration=Release /m

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: true
+
+language: cpp
+
+compiler:
+    - gcc
+
+matrix:
+    include:
+    - os: linux
+      addons:
+        apt:
+            sources:
+            - ubuntu-toolchain-r-test
+            packages:
+            - g++-4.9
+            - libboost1.55-all-dev
+      env:
+      - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9
+    - os: osx
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:giskou/librocksdb -y  ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -q                            ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install librocksdb -y                ; fi
+
+script:
+    - export CXXFLAGS="-std=gnu++11"
+    - mkdir build
+    - cd build
+    - cmake ..
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: true
-
 language: cpp
-
-compiler:
-    - gcc
+compiler: gcc
+    
+env:
+    - CXXFLAGS="-std=gnu++11"
 
 matrix:
     include:
@@ -20,13 +20,12 @@ matrix:
     - os: osx
 
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:giskou/librocksdb -y  ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:ethcore/ethcore -y    ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -q                            ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install librocksdb -y                ; fi
+    
+install:
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install librocksdb-dev -y            ; fi
 
 script:
-    - export CXXFLAGS="-std=gnu++11"
-    - mkdir build
-    - cd build
-    - cmake ..
-    - make
+    - mkdir build && cd build
+    - cmake .. && make

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ### Build Status
 
-Linux + OSX - [![Build Status](https://travis-ci.org/ZedPea/turtlecoin.svg?branch=master)](https://travis-ci.org/ZedPea/turtlecoin)
-Windows - [![Build status](https://ci.appveyor.com/api/projects/status/a1efx1ynae1qpxe4?svg=true)](https://ci.appveyor.com/project/ZedPea/turtlecoin)
+[![Build Status](https://travis-ci.org/ZedPea/turtlecoin.svg?branch=master)](https://travis-ci.org/ZedPea/turtlecoin)
+[![Build status](https://ci.appveyor.com/api/projects/status/a1efx1ynae1qpxe4?svg=true)](https://ci.appveyor.com/project/ZedPea/turtlecoin)
 
 ### How To Compile 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ![image](https://user-images.githubusercontent.com/34389545/35821974-62e0e25c-0a70-11e8-87dd-2cfffeb6ed47.png)
 
-### How To Compile
+### Build Status
+
+Linux + OSX - https://travis-ci.org/ZedPea/turtlecoin.svg?branch=master
+Windows - https://ci.appveyor.com/api/projects/status/a1efx1ynae1qpxe4?svg=true
+
+### How To Compile 
 
 #### Ubuntu 16.04+ and MacOS 10.10+
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ### Build Status
 
-Linux + OSX - https://travis-ci.org/ZedPea/turtlecoin.svg?branch=master
-Windows - https://ci.appveyor.com/api/projects/status/a1efx1ynae1qpxe4?svg=true
+Linux + OSX - [![Build Status](https://travis-ci.org/ZedPea/turtlecoin.svg?branch=master)](https://travis-ci.org/ZedPea/turtlecoin)
+Windows - [![Build status](https://ci.appveyor.com/api/projects/status/a1efx1ynae1qpxe4?svg=true)](https://ci.appveyor.com/project/ZedPea/turtlecoin)
 
 ### How To Compile 
 


### PR DESCRIPTION
As the title says this enables automated builds for windows, linux, and mac.

Linux and mac are provided by travis - http://travis-ci.org/
Windows is provided by appveyor - https://ci.appveyor.com/

This PR unfortunately requires a bit of interaction on your end - You will have to login via github on both of those websites, and enable builds. I believe on travis it is opt in - you have to flick on the switch to build turtlecoin, whereas I think on appveyor it is enabled for all repositories and you have to disable it for those you don't want it to build for.

Can't say for sure i'm afraid, as I setup travis ages ago and I have a terrible memory even though I setup appveyor a few hours ago.

Then, you can get the fancy icons on the readme to show that the build is succeeding or failing, and a link to view the build log, which I currently have pointing towards my travis/appveyor. 

To get the markdown for these, for travis:

Go onto this page - https://travis-ci.org/turtlecoin/turtlecoin/builds/ - once you've enabled it that is - then click the build button:

![selection_001](https://user-images.githubusercontent.com/22151537/36312726-5b365ab8-1327-11e8-9373-898215f4c3d3.png)

the bit on the right - and it should pop up a box which lets you choose markdown:

![selection_002](https://user-images.githubusercontent.com/22151537/36312751-6d6096b8-1327-11e8-9640-f39dff558642.png)

you can then just paste that into the readme, replacing the one I have setup for my account.

For appveyor:

Go onto this page - https://ci.appveyor.com/project/turtlecoin/turtlecoin/settings/badges - once you've enabled it again - and copy the sample markdown code, again replacing the one i have setup for my account in the readme.

If you did it right, you'll get these nice fancy buttons in the README:

![selection_004](https://user-images.githubusercontent.com/22151537/36313911-11a5f12a-132b-11e8-8330-0537edc62986.png)

It shows as failing on the travis one because travis by default displays the master branch - which I haven't pushed the .travis.yml to.

I believe we should be able to extend both of these to also pop the compiled binaries somewhere, but I'm not sure where that somewhere would be. I'll be happy to try out regarding that once we know how we're doing it, though I must admit i'm quite a novice at these build scripts, and it took me around 40 commits of me tearing my hair out to get it all working haha.

This PR also includes the fixes included in my other PR, to make windows build successfully. I needed that to test out the windows builds under appveyor, hopefully it won't break my other PR but I will of course fix that if it does.

Once/if this is merged, it should automatically build the repo on every commit so people can tell if it broke the build. I believe it also works on pull requests, so you can tell before merging that it won't break the build. 

Currently it takes around 30 minutes to build the mac+linux builds, and about 20 minutes for the windows build. It should be possible to lower this by caching the previous build files but when I attempted this I couldn't get it working.

Hope you enjoyed my blog post.