### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are using Arch Linux, there is an AUR precompiled package, `turtlecoin-bi
 ```
 sudo add-apt-repository ppa:ethcore/ethcore -y
 sudo apt-get update
-suto apt-get install librocksdb-dev
+sudo apt-get install librocksdb-dev
 ```
 
 ##### Building

--- a/README.md
+++ b/README.md
@@ -16,26 +16,30 @@ This script can be used from inside the git repository to build the project from
 
 See the script for more installation details and please consider extending it for your operating system and distribution!
 
+If the script doesn't work for you:
 
-#### Windows 10
+#### Linux
+
+If you are using Arch Linux, there is an AUR precompiled package, `turtlecoin-bin`, or a build from source version, `turtlecoin-git`.
 
 ##### Prerequisites
-- Install [Visual Studio 2017 Community Edition](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&page=inlineinstall)
-- When installing Visual Studio, it is **required** that you install **Desktop development with C++** and the **VC++ v140 toolchain** when selecting features. The option to install the v140 toolchain can be found by expanding the "Desktop development with C++" node on the right. You will need this for the project to build correctly.
-- Install [Boost 1.59.0](https://sourceforge.net/projects/boost/files/boost-binaries/1.59.0/), ensuring you download the installer for MSVC 14.
+
+- You will need the following packages: boost (1.55 or higher), rocksdb, cmake, git, gcc (4.9 or higher), g++ (4.9 or higher), make, and python. Most of these should already be installed on your system.
+- For example on ubuntu: `sudo apt-get install build-essential python-dev gcc g++ git cmake libboost-all-dev librocksdb-dev`
+- If you are using ubuntu and your version of ubuntu doesn't have librocksdb-dev, you can get it from a ppa instead:
+```
+sudo add-apt-repository ppa:ethcore/ethcore -y
+sudo apt-get update
+suto apt-get install librocksdb-dev
+```
 
 ##### Building
 
-- From the start menu, open 'x64 Native Tools Command Prompt for vs2017'.
-- `cd <your_turtlecoin_directory>`
-- `mkdir build`
-- `cd build`
-- Set the PATH variable for cmake: ie. `set PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin";%PATH%`
-- `cmake -G "Visual Studio 14 Win64" .. -DBOOST_ROOT=D:/Boost/boost_1_59_0` (Or your boost installed dir.)
-- `MSBuild ByteCoin.sln /p:Configuration=Release /m`
-- If all went well, it will complete successfully, and you will find all your binaries in the '..\build\src\Release' directory.
-- Additionally, a `.sln` file will have been created in the `build` directory. If you wish to open the project in Visual Studio with this, you can.
-
+- `git clone https://github.com/turtlecoin/turtlecoin`
+- `cd turtlecoin`
+- `mkdir build && cd $_`
+- `cmake ..`
+- `make`
 
 #### Apple
 
@@ -55,6 +59,25 @@ See the script for more installation details and please consider extending it fo
 - `make`
 
 The binaries will be in `./src` after compilation is complete.
+
+#### Windows 10
+
+##### Prerequisites
+- Install [Visual Studio 2017 Community Edition](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&page=inlineinstall)
+- When installing Visual Studio, it is **required** that you install **Desktop development with C++** and the **VC++ v140 toolchain** when selecting features. The option to install the v140 toolchain can be found by expanding the "Desktop development with C++" node on the right. You will need this for the project to build correctly.
+- Install [Boost 1.59.0](https://sourceforge.net/projects/boost/files/boost-binaries/1.59.0/), ensuring you download the installer for MSVC 14.
+
+##### Building
+
+- From the start menu, open 'x64 Native Tools Command Prompt for vs2017'.
+- `cd <your_turtlecoin_directory>`
+- `mkdir build`
+- `cd build`
+- Set the PATH variable for cmake: ie. `set PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin";%PATH%`
+- `cmake -G "Visual Studio 14 Win64" .. -DBOOST_ROOT=C:/local/boost_1_59_0` (Or your boost installed dir.)
+- `MSBuild ByteCoin.sln /p:Configuration=Release /m`
+- If all went well, it will complete successfully, and you will find all your binaries in the '..\build\src\Release' directory.
+- Additionally, a `.sln` file will have been created in the `build` directory. If you wish to open the project in Visual Studio with this, you can.
 
 #### Thanks
 Cryptonote Developers, Bytecoin Developers, Monero Developers, Forknote Project, TurtleCoin Community


### PR DESCRIPTION
The script doesn't work for everyone, so it's good to have a list of instructions so people don't have to manually read the script.

Also changes the windows boost directory path to the default installation path for ease of use.