### PR TITLE
fix seed node missing port to avoid warning on node start

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -129,7 +129,7 @@ const uint64_t P2P_DEFAULT_INVOKE_TIMEOUT                    = 60 * 2 * 1000; //
 const size_t   P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT          = 5000;          // 5 seconds
 const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
-const char* const SEED_NODES[] = { "104.236.227.176:11897", "46.101.132.184:11897", "163.172.147.52:11897", "51.15.138.214:11897", "51.15.137.77:11897", "174.138.68.141" };
+const char* const SEED_NODES[] = { "104.236.227.176:11897", "46.101.132.184:11897", "163.172.147.52:11897", "51.15.138.214:11897", "51.15.137.77:11897", "174.138.68.141:11897" };
 
 
 struct CheckpointData {


### PR DESCRIPTION
trival fix for warning: `2018-Mar-17 23:01:05.795769 ERROR   Failed to parse seed address from string: '174.138.68.141'`