### PR TITLE
Fix simplewallet not working on windows, incorrectly opening after wrong password entry

### DIFF
--- a/src/SimpleWallet/ParseArguments.cpp
+++ b/src/SimpleWallet/ParseArguments.cpp
@@ -85,7 +85,7 @@ Config parseArguments(int argc, char **argv)
             {
                 config.port = std::stoi(port);
             }
-            catch (const std::invalid_argument &e)
+            catch (const std::invalid_argument)
             {
                 std::cout << "Failed to parse daemon port!" << std::endl;
                 config.exit = true;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -640,7 +640,7 @@ void welcomeMsg()
               << "file doesn't get corrupted." << std::endl << std::endl;
 }
 
-std::string getInput(std::shared_ptr<WalletInfo> &walletInfo)
+std::string getInputAndDoWorkWhileIdle(std::shared_ptr<WalletInfo> &walletInfo)
 {
     auto lastUpdated = std::chrono::system_clock::now();
 
@@ -665,7 +665,7 @@ std::string getInput(std::shared_ptr<WalletInfo> &walletInfo)
         auto currentTime = std::chrono::system_clock::now();
 
         /* Otherwise check if we need to update the wallet cache */
-        if ((lastUpdated - currentTime) > std::chrono::seconds(5))
+        if ((currentTime - lastUpdated) > std::chrono::seconds(5))
         {
             lastUpdated = currentTime;
             checkForNewTransactions(walletInfo);
@@ -683,7 +683,7 @@ void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node)
     {
         std::cout << getPrompt(walletInfo);
 
-        std::string command = getInput(walletInfo);
+        std::string command = getInputAndDoWorkWhileIdle(walletInfo);
 
         /* Split into args to support legacy transfer command, for example
            transfer 5 TRTLxyz... 100, sends 100 TRTL to TRTLxyz... with a mixin

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -973,6 +973,8 @@ bool shutdown(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
     wallet.shutdown();
     node.shutdown();
 
+    finishedShutdown = true;
+
     /* Wait for shutdown watcher to finish */
     timelyShutdown.join();
 
@@ -1151,7 +1153,7 @@ void findNewTransactions(CryptoNote::INode &node,
         }
 
         /* Should be around a minute */
-        if (stuckCounter > 60)
+        if (stuckCounter > 20)
         {
             std::cout << WarningMsg("It looks like syncing might have got "
                                     "stuck...") << std::endl
@@ -1204,7 +1206,7 @@ void findNewTransactions(CryptoNote::INode &node,
             transactionCount = tmpTransactionCount;
         }
 
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
     }
 
     std::cout << SuccessMsg("Finished scanning blockchain!") << std::endl

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -113,6 +113,8 @@ void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node)
                   << InformationMsg("Hit any key to exit: ");
 
         std::cin.get();
+
+        shutdown(walletInfo->wallet, node, threadHandler);
     }
     else
     {

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -97,7 +97,7 @@ bool isValidMnemonic(std::string &mnemonic_phrase,
 bool shutdown(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
               bool &alreadyShuttingDown);
 
-std::string getInput(std::shared_ptr<WalletInfo> &walletInfo);
+std::string getInputAndDoWorkWhileIdle(std::shared_ptr<WalletInfo> &walletInfo);
 
 std::string getNewWalletFileName();
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -16,6 +16,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <cctype>
+#include <future>
 
 #include "INode.h"
 #include "version.h"
@@ -49,6 +50,7 @@ struct ThreadHandler {
     bool shouldDie = false;
     bool shouldPause = false;
     bool havePaused = false;
+    bool doWorkOnMainThread = false;
 };
 
 enum Action {Open, Generate, Import, SeedImport, ViewWallet};
@@ -104,6 +106,9 @@ void viewWalletMsg();
 
 bool isValidMnemonic(std::string &mnemonic_phrase, 
                      Crypto::SecretKey &private_spend_key);
+
+std::string getInput(ThreadHandler &threadHandler,
+                     CryptoNote::WalletGreen &wallet);
 
 std::string getNewWalletFileName();
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -51,6 +51,7 @@ struct ThreadHandler {
     bool shouldPause = false;
     bool havePaused = false;
     bool doWorkOnMainThread = false;
+    bool isTxWatcherAlive = false;
 };
 
 enum Action {Open, Generate, Import, SeedImport, ViewWallet};
@@ -74,9 +75,6 @@ void inputLoop(std::shared_ptr<WalletInfo> walletInfo, CryptoNote::INode &node,
                ThreadHandler &threadHandler);
 
 void exportKeys(std::shared_ptr<WalletInfo> walletInfo);
-
-void shutdown(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
-              ThreadHandler &threadHandler);
 
 void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node);
 
@@ -106,6 +104,9 @@ void viewWalletMsg();
 
 bool isValidMnemonic(std::string &mnemonic_phrase, 
                      Crypto::SecretKey &private_spend_key);
+
+bool shutdown(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
+              ThreadHandler &threadHandler);
 
 std::string getInput(ThreadHandler &threadHandler,
                      CryptoNote::WalletGreen &wallet);

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -75,7 +75,7 @@ void listTransfers(bool incoming, bool outgoing,
                    CryptoNote::WalletGreen &wallet);
 
 void findNewTransactions(CryptoNote::INode &node, 
-                         CryptoNote::WalletGreen &wallet);
+                         std::shared_ptr<WalletInfo> &walletInfo);
 
 void reset(CryptoNote::INode &node, std::shared_ptr<WalletInfo> &walletInfo);
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -46,14 +46,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #include <boost/thread/thread.hpp>
 
-struct ThreadHandler {
-    bool shouldDie = false;
-    bool shouldPause = false;
-    bool havePaused = false;
-    bool doWorkOnMainThread = false;
-    bool isTxWatcherAlive = false;
-};
-
 enum Action {Open, Generate, Import, SeedImport, ViewWallet};
 
 Action getAction();
@@ -71,10 +63,9 @@ void welcomeMsg();
 
 void help(bool viewWallet);
 
-void inputLoop(std::shared_ptr<WalletInfo> walletInfo, CryptoNote::INode &node,
-               ThreadHandler &threadHandler);
+void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node);
 
-void exportKeys(std::shared_ptr<WalletInfo> walletInfo);
+void exportKeys(std::shared_ptr<WalletInfo> &walletInfo);
 
 void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node);
 
@@ -86,15 +77,13 @@ void listTransfers(bool incoming, bool outgoing,
 void findNewTransactions(CryptoNote::INode &node, 
                          CryptoNote::WalletGreen &wallet);
 
-void reset(CryptoNote::INode &node, std::shared_ptr<WalletInfo> walletInfo,
-           ThreadHandler &threadHandler);
+void reset(CryptoNote::INode &node, std::shared_ptr<WalletInfo> &walletInfo);
 
 void printOutgoingTransfer(CryptoNote::WalletTransaction t);
 
 void printIncomingTransfer(CryptoNote::WalletTransaction t);
 
-void transactionWatcher(std::shared_ptr<WalletInfo> walletInfo,
-                        ThreadHandler &threadHandler);
+void checkForNewTransactions(std::shared_ptr<WalletInfo> &walletInfo);
 
 void confirmPassword(std::string);
 
@@ -106,10 +95,9 @@ bool isValidMnemonic(std::string &mnemonic_phrase,
                      Crypto::SecretKey &private_spend_key);
 
 bool shutdown(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
-              ThreadHandler &threadHandler);
+              bool &alreadyShuttingDown);
 
-std::string getInput(ThreadHandler &threadHandler,
-                     CryptoNote::WalletGreen &wallet);
+std::string getInput(std::shared_ptr<WalletInfo> &walletInfo);
 
 std::string getNewWalletFileName();
 
@@ -118,8 +106,8 @@ std::string getExistingWalletFileName();
 std::string getWalletPassword(bool verifyPwd);
 
 std::shared_ptr<WalletInfo> importFromKeys(CryptoNote::WalletGreen &wallet, 
-                           Crypto::SecretKey privateSpendKey,
-                           Crypto::SecretKey privateViewKey);
+                                           Crypto::SecretKey privateSpendKey,
+                                           Crypto::SecretKey privateViewKey);
 
 std::shared_ptr<WalletInfo> openWallet(CryptoNote::WalletGreen &wallet);
 
@@ -137,4 +125,4 @@ std::shared_ptr<WalletInfo> handleAction(CryptoNote::WalletGreen &wallet,
 
 Crypto::SecretKey getPrivateKey(std::string outputMsg);
 
-ColouredMsg getPrompt(std::shared_ptr<WalletInfo> walletInfo);
+ColouredMsg getPrompt(std::shared_ptr<WalletInfo> &walletInfo);

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -114,6 +114,8 @@ void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
                       << " of " << InformationMsg(std::to_string(numTxs))
                       << std::endl;
 
+            wallet.updateInternalCache();
+
             uint64_t neededBalance = tx.destinations[0].amount + tx.fee;
 
             if (neededBalance < wallet.getActualBalance())
@@ -381,6 +383,8 @@ bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold)
               << std::endl << std::endl;
     }
 
+    wallet.updateInternalCache();
+
     /* Short sleep to ensure it's in the transaction pool when we poll it */
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
@@ -447,6 +451,8 @@ bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold)
                       << std::endl;
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
+
+            wallet.updateInternalCache();
         }
         else
         {

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -490,6 +490,17 @@ void fusionTX(CryptoNote::WalletGreen &wallet,
         }
         else
         {
+            while (wallet.getActualBalance() < p.destinations[0].amount + p.fee)
+            {
+                std::cout << WarningMsg("Optimization completed, but balance "
+                                        "is not fully unlocked yet!")
+                          << std::endl
+                          << SuccessMsg("Will try again in 5 seconds...")
+                          << std::endl;
+
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+            }
+
             size_t id = wallet.transfer(p);
             CryptoNote::WalletTransaction tx = wallet.getTransaction(id);
 

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -756,7 +756,7 @@ void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                       << std::endl << "Try lowering the amount you are "
                       << "sending in one transaction." << std::endl
                       << "Alternatively, you can try lowering the mixin count "
-                      << "to 0, but this will compromise privacy." << std::endl
+                      << "to 0, but this will compromise privacy." << std::endl;
         }
         else
         {

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -490,8 +490,25 @@ void fusionTX(CryptoNote::WalletGreen &wallet,
         }
         else
         {
+            auto startTime = std::chrono::system_clock::now();
+
             while (wallet.getActualBalance() < p.destinations[0].amount + p.fee)
             {
+                /* Break after a minute just in case something has gone wrong */
+                if ((std::chrono::system_clock::now() - startTime) > 
+                     std::chrono::minutes(1))
+                {
+                    std::cout << WarningMsg("Fusion transactions have "
+                                            "completed, however available "
+                                            "balance is less than transfer "
+                                            "amount specified.") << std::endl
+                              << WarningMsg("Transfer aborted, please review "
+                                            "and start a new transfer.")
+                              << std::endl;
+
+                    return;
+                }
+
                 std::cout << WarningMsg("Optimization completed, but balance "
                                         "is not fully unlocked yet!")
                           << std::endl

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -190,8 +190,9 @@ void splitTx(CryptoNote::WalletGreen &wallet,
            We then check at the end that each transaction is small enough, and
            if not, we up the numTxMultiplier and try again with more
            transactions. */
-        int numTransactions = numTxMultiplier * 
-                              (std::ceil(double(txSize) / double(maxSize)));
+        int numTransactions 
+            = int(numTxMultiplier * 
+                 (std::ceil(double(txSize) / double(maxSize))));
 
         /* Split the requested fee over each transaction, i.e. if a fee of 200
            TRTL was requested and we split it into 4 transactions each one will
@@ -276,7 +277,7 @@ size_t makeFusionTransaction(CryptoNote::WalletGreen &wallet,
                                               CryptoNote::parameters
                                                         ::DEFAULT_MIXIN);
     }
-    catch (const std::runtime_error &e)
+    catch (const std::runtime_error)
     {
         return CryptoNote::WALLET_INVALID_TRANSACTION_ID;
     }
@@ -965,7 +966,7 @@ bool parseMixin(std::string mixinString)
         std::stoi(mixinString);
         return true;
     }
-    catch (const std::invalid_argument &e)
+    catch (const std::invalid_argument)
     {
         std::cout << WarningMsg("Failed to parse mixin! Ensure you entered the "
                                 "value correctly.") << std::endl;

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -756,7 +756,7 @@ void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                       << std::endl << "Try lowering the amount you are "
                       << "sending in one transaction." << std::endl
                       << "Alternatively, you can try lowering the mixin count "
-                      << "to 0, but this will compromise privacy.";
+                      << "to 0, but this will compromise privacy." << std::endl
         }
         else
         {

--- a/src/SimpleWallet/Transfer.h
+++ b/src/SimpleWallet/Transfer.h
@@ -42,10 +42,14 @@ struct WalletInfo {
                viewWallet(viewWallet),
                wallet(wallet) {}
 
+    size_t knownTransactionCount = 0;
+
     std::string walletFileName;
     std::string walletPass;
     std::string walletAddress;
+
     bool viewWallet;
+
     CryptoNote::WalletGreen &wallet;
 };
 

--- a/src/Wallet/WalletSerializationV1.cpp
+++ b/src/Wallet/WalletSerializationV1.cpp
@@ -338,7 +338,17 @@ void WalletSerializerV1::loadWalletV1(Common::IInputStream& source, const Crypto
   CryptoNote::BinaryInputStreamSerializer serializer(decryptedStream);
 
   loadWalletV1Keys(serializer);
-  checkKeys();
+
+  try
+  {
+    checkKeys();
+  }
+  /* Remove the partially (incorrectly) parsed wallet, pass is wrong */
+  catch (const std::system_error &e)
+  {
+    m_walletsContainer.clear();
+    throw(e);
+  }
 
   subscribeWallets();
 


### PR DESCRIPTION
If you were upgrading from a legacy wallet, and entered your password incorrectly, then re-entered the password correctly, the spend secret key would be different and hence a different wallet would be imported. This is fixed by just clearing the partially imported wallet when we fail to import.

Thanks to @ereptor81 for finding the issue and helping with debugging.

If you were running the wallet on windows, it would crash upon updating internal cache on another thread. See https://github.com/turtlecoin/turtlecoin/issues/108 for more info. This is now fixed by only doing it on the main thread.

I think this patch is now OK to merge.