### PR TITLE
Format money with thousand separators

### DIFF
--- a/src/SimpleWallet/Tools.cpp
+++ b/src/SimpleWallet/Tools.cpp
@@ -32,20 +32,66 @@ void confirmPassword(std::string walletPass)
 
 std::string formatAmount(uint64_t amount)
 {
-    std::string s = std::to_string(amount);
+    uint64_t dollars = amount / 100;
+    uint64_t cents = amount % 100;
 
-    size_t numDecimalPlaces = 2;
+    return formatDollars(dollars) + "." + formatCents(cents) + " TRTL";
+}
 
-    if (s.size() < numDecimalPlaces + 1)
+std::string formatDollars(uint64_t amount)
+{
+    /* We want to format our number with comma separators so it's easier to
+       use. Now, we could use the nice print_money() function to do this.
+       However, whilst this initially looks pretty handy, if we have a locale
+       such as ja_JP.utf8, 1 TRTL will actually be formatted as 100 TRTL, which
+       is terrible, and could really screw over users.
+
+       So, easy solution right? Just use en_US.utf8! Sure, it's not very
+       international, but it'll work! Unfortunately, no. The user has to have
+       the locale installed, and if they don't, we get a nasty error at
+       runtime.
+
+       Annoyingly, there's no easy way to comma separate numbers outside of
+       using the locale method, without writing a pretty long boiler plate
+       function. So, instead, we define our own locale, which just returns
+       the values we want.
+       
+       It's less internationally friendly than we would potentially like
+       but that would require a ton of scrutinization which if not done could
+       land us with quite a few issues and rightfully angry users.
+       Furthermore, we'd still have to hack around cases like JP locale
+       formatting things incorrectly, and it makes reading in inputs harder
+       too. */
+
+    /* Thanks to https://stackoverflow.com/a/7277333/8737306 for this neat
+       workaround */
+    class comma_numpunct : public std::numpunct<char>
     {
-        s.insert(0, numDecimalPlaces + 1 - s.size(), '0');
-    }
+      protected:
+        virtual char do_thousands_sep() const
+        {
+            return ',';
+        }
 
-    s.insert(s.size() - numDecimalPlaces, ".");
+        virtual std::string do_grouping() const
+        {
+            return "\03";
+        }
+    };
 
-    s += " TRTL";
+    std::locale comma_locale(std::locale(), new comma_numpunct());
+    std::stringstream stream;
+    stream.imbue(comma_locale);
+    stream << amount;
+    return stream.str();
+}
 
-    return s;
+/* Pad to two spaces, e.g. 5 becomes 05, 50 remains 50 */
+std::string formatCents(uint64_t amount)
+{
+    std::stringstream stream;
+    stream << std::setfill('0') << std::setw(2) << amount;
+    return stream.str();
 }
 
 bool confirm(std::string msg)

--- a/src/SimpleWallet/Tools.h
+++ b/src/SimpleWallet/Tools.h
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <fstream>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 
 #include <Common/ConsoleTools.h>
 #include <SimpleWallet/PasswordContainer.h>
@@ -28,6 +29,8 @@ void confirmPassword(std::string walletPass);
 bool confirm(std::string msg);
 
 std::string formatAmount(uint64_t amount);
+std::string formatDollars(uint64_t amount);
+std::string formatCents(uint64_t amount);
 
 class ColouredMsg
 {

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -20,6 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 bool parseAmount(std::string strAmount, uint64_t &amount)
 {
     boost::algorithm::trim(strAmount);
+    /* If the user entered thousand separators, remove them */
+    boost::erase_all(strAmount, ",");
 
     size_t pointIndex = strAmount.find_first_of('.');
     size_t fractionSize;


### PR DESCRIPTION
Makes large balances a bit easier to read.

Before: `Available balance: 3139485.50 TRTL`
After: `Available balance: 3,139,485.50 TRTL`

Unfortunately this doesn't have locale support. Read my long essay in Tools.cpp I wrote for justification on that.

Commas are removed when people are inputting, so you can have a transfer input of `123,456.78` and it will parse fine, for example if the user copy pastes their balance.