### PR TITLE
Default simplewallet mixin, simplewallet bug fixes

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -53,6 +53,7 @@ const size_t   CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE        = 600;
 const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 2;
 const uint64_t MINIMUM_FEE                                   = UINT64_C(10);
 const uint16_t DEFAULT_MIXIN                                 = 5;
+const uint16_t MINIMUM_MIXIN                                 = 3;
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(10);
 
 const uint64_t DIFFICULTY_TARGET                             = 30; // seconds

--- a/src/SimpleWallet/ParseArguments.cpp
+++ b/src/SimpleWallet/ParseArguments.cpp
@@ -38,7 +38,7 @@ Config parseArguments(int argc, char **argv)
 {
     Config config;
     config.exit = false;
-    config.host = "0.0.0.0";
+    config.host = "127.0.0.1";
     config.port = CryptoNote::RPC_DEFAULT_PORT;
 
     if (cmdOptionExists(argv, argv+argc, "-h")

--- a/src/SimpleWallet/ParseArguments.cpp
+++ b/src/SimpleWallet/ParseArguments.cpp
@@ -115,5 +115,5 @@ void helpMessage()
               << "--version" << "Display the version information and exit"
               << std::endl << "      " << std::left << std::setw(25)
               << "--remote-daemon <url>" << "Connect to the remote daemon at "
-              << "<url> instead of the default: 0.0.0.0:11898" << std::endl;
+              << "<url> instead of the default: 127.0.0.1:11898" << std::endl;
 }

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
 
     if (error.get())
     {
-        throw("Failed to initialize node!");
+        throw std::runtime_error("Failed to initialize node!");
     }
 
     /* Create the wallet instance */

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -19,6 +19,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 int main(int argc, char **argv)
 {
+    /* On ctrl+c the program seems to throw "simplewallet.exe has stopped
+       working" when calling exit(0)... I'm not sure why, this is a bit of
+       a hack, it disables that */
+    #ifdef _WIN32
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    #endif
+
     Config config = parseArguments(argc, argv);
 
     /* User requested --help or --version */

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -15,6 +15,12 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef _WIN32
+/* Prevents windows.h redefining min/max which breaks compilation */
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include <cctype>
 #include <future>
 

--- a/src/SimpleWallet/Transfer.h
+++ b/src/SimpleWallet/Transfer.h
@@ -23,6 +23,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <Common/StringTools.h>
 
 #include <CryptoNoteCore/TransactionExtra.h>
+#include <CryptoNoteCore/CryptoNoteBasicImpl.h>
 
 #include <SimpleWallet/Tools.h>
 


### PR DESCRIPTION
Adds a default mixin of 3 to simplewallet. This is waived if the transaction is dust and cannot be sent without lowering it. This can of course be bypassed by compiling without the restrictions but is a good start to introducing a minimum.

Also fixes issues with being unable to send on testnet.

I couldn't find a way to easily go from a prefix to a string to print out the expected string, so for now it just prints out `TRTL`.

Also fixes windows crashing with "simplewallet.exe has stopped working" when you ctrl+c - it's doing this when exit(0) is called, not sure if this is intended behaviour or possibly something being cleared up calling terminate(), for now it is hacked around :disappointed:  

Also fixes being unable to connect to daemon sometimes on windows - was able to reproduce 100% in windows 7 VM but worked fine for soregums on I think windows 10... was just using 0.0.0.0 instead of 127.0.0.1.