### PR TITLE
Building Tests is now optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,12 @@ set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo Release CACHE TYPE INTERNAL)
 set(CMAKE_SKIP_INSTALL_RULES ON)
 set(CMAKE_SKIP_PACKAGE_ALL_DEPENDENCY ON)
 set(CMAKE_SUPPRESS_REGENERATION ON)
-enable_testing()
+SET(DO_TESTS ON CACHE STRING "Spend time making tests? Defaults to ON")
+
+if(DO_TESTS)
+  enable_testing()
+endif()
+
 # copy CTestCustom.cmake to build dir to disable long running tests in 'make test'
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -153,4 +158,7 @@ endif()
 
 add_subdirectory(external)
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if(DO_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/build-release.sh
+++ b/build-release.sh
@@ -32,7 +32,7 @@ function build_dynamic_linked_version()
     cd $CLONE_DIR
     mkdir -p build/release
     cd build/release
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fassociative-math" -DCMAKE_CXX_FLAGS="-fassociative-math" ../..
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fassociative-math" -DCMAKE_CXX_FLAGS="-fassociative-math" -DDO_TESTS=OFF ../..
     make
     cd ../..
 
@@ -48,7 +48,7 @@ function build_static_linked_version()
     make clean
     mkdir -p build/release
     cd build/release
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fassociative-math" -DCMAKE_CXX_FLAGS="-fassociative-math" -DSTATIC=true ../..
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fassociative-math" -DCMAKE_CXX_FLAGS="-fassociative-math" -DSTATIC=true -DDO_TESTS=OFF ../..
     make
     cd ../..
 
@@ -72,8 +72,7 @@ function generate_tarball()
         miner \
         simplewallet \
         TurtleCoind \
-        walletd \
-        connectivity_tool
+        walletd
 
     generate_checksums $TARBALL
 }


### PR DESCRIPTION
simply add -DDO_TESTS=OFF to cmake.
also updated release script to skip.

cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fassociative-math" -DCMAKE_CXX_FLAGS="-fassociative-math" ../..; time make -j4

real    8m12.852s
user    29m10.744s
sys     2m23.076s

>>>

cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fassociative-math" -DCMAKE_CXX_FLAGS="-fassociative-math" -DDO_TESTS=OFF ../..; time make -j4
real    3m21.756s
user    11m41.880s
sys     1m3.640s

That is a lot faster. Digital Ocean Droplet 4vcpu-8gb.

Also removed connectivity tool from release script