### PR TITLE
Add --wallet-file and --password cli arguments

### DIFF
--- a/src/SimpleWallet/ParseArguments.cpp
+++ b/src/SimpleWallet/ParseArguments.cpp
@@ -37,23 +37,70 @@ bool cmdOptionExists(char** begin, char** end, const std::string& option)
 Config parseArguments(int argc, char **argv)
 {
     Config config;
+
     config.exit = false;
+    config.walletGiven = false;
+    config.passGiven = false;
+
     config.host = "127.0.0.1";
     config.port = CryptoNote::RPC_DEFAULT_PORT;
+
+    config.walletFile = "";
+    config.walletPass = "";
 
     if (cmdOptionExists(argv, argv+argc, "-h")
      || cmdOptionExists(argv, argv+argc, "--help"))
     {
         helpMessage();
         config.exit = true;
+        return config;
     }
-    else if (cmdOptionExists(argv, argv+argc, "-v")
-          || cmdOptionExists(argv, argv+argc, "--version"))
+
+    if (cmdOptionExists(argv, argv+argc, "-v")
+     || cmdOptionExists(argv, argv+argc, "--version"))
     {
         versionMessage();
         config.exit = true;
+        return config;
     }
-    else if (cmdOptionExists(argv, argv+argc, "--remote-daemon"))
+
+    if (cmdOptionExists(argv, argv+argc, "--wallet-file"))
+    {
+        char *wallet = getCmdOption(argv, argv+argc, "--wallet-file");
+
+        if (!wallet)
+        {
+            std::cout << "--wallet-file was specified, but no wallet file "
+                      << "was given!" << std::endl;
+
+            helpMessage();
+            config.exit = true;
+            return config;
+        }
+
+        config.walletFile = std::string(wallet);
+        config.walletGiven = true;
+    }
+
+    if (cmdOptionExists(argv, argv+argc, "--password"))
+    {
+        char *password = getCmdOption(argv, argv+argc, "--password");
+
+        if (!password)
+        {
+            std::cout << "--password was specified, but no password was "
+                      << "given!" << std::endl;
+
+            helpMessage();
+            config.exit = true;
+            return config;
+        }
+
+        config.walletPass = std::string(password);
+        config.passGiven = true;
+    }
+
+    if (cmdOptionExists(argv, argv+argc, "--remote-daemon"))
     {
         char *url = getCmdOption(argv, argv + argc, "--remote-daemon");
 
@@ -107,7 +154,9 @@ void helpMessage()
     versionMessage();
 
     std::cout << std::endl << "simplewallet [--version] [--help] "
-              << "[--remote-daemon <url>]" << std::endl << std::endl
+              << "[--remote-daemon <url>] [--wallet-file <file>] "
+              << "[--password <pass>]"
+              << std::endl << std::endl
               << "Commands:" << std::endl << "  -h, " << std::left
               << std::setw(25) << "--help"
               << "Display this help message and exit"
@@ -115,5 +164,10 @@ void helpMessage()
               << "--version" << "Display the version information and exit"
               << std::endl << "      " << std::left << std::setw(25)
               << "--remote-daemon <url>" << "Connect to the remote daemon at "
-              << "<url> instead of the default: 127.0.0.1:11898" << std::endl;
+              << "<url>"
+              << std::endl << "      " << std::left << std::setw(25)
+              << "--wallet-file <file>" << "Open the wallet <file>"
+              << std::endl << "      " << std::left << std::setw(25)
+              << "--password <pass>" << "Use the password <pass> to open the "
+              << "wallet" << std::endl;
 }

--- a/src/SimpleWallet/ParseArguments.cpp
+++ b/src/SimpleWallet/ParseArguments.cpp
@@ -121,21 +121,31 @@ Config parseArguments(int argc, char **argv)
             /* Get the index of the ":" */
             size_t splitter = urlString.find_first_of(":");
 
-            /* Host is everything before ":" */
-            config.host = urlString.substr(0, splitter);
-
-            /* Port is everything after ":" */
-            std::string port = urlString.substr(splitter + 1,   
-                                                std::string::npos);
-
-            try
+            /* No ":" present */
+            if (splitter == std::string::npos)
             {
-                config.port = std::stoi(port);
+                config.host = urlString;
+                std::cout << "No port given, using default of "
+                          << CryptoNote::RPC_DEFAULT_PORT << std::endl;
             }
-            catch (const std::invalid_argument)
+            else
             {
-                std::cout << "Failed to parse daemon port!" << std::endl;
-                config.exit = true;
+                /* Host is everything before ":" */
+                config.host = urlString.substr(0, splitter);
+
+                /* Port is everything after ":" */
+                std::string port = urlString.substr(splitter + 1,   
+                                                    std::string::npos);
+
+                try
+                {
+                    config.port = std::stoi(port);
+                }
+                catch (const std::invalid_argument)
+                {
+                    std::cout << "Failed to parse daemon port!" << std::endl;
+                    config.exit = true;
+                }
             }
         }
     }

--- a/src/SimpleWallet/ParseArguments.h
+++ b/src/SimpleWallet/ParseArguments.h
@@ -25,8 +25,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 struct Config {
     bool exit;
+
+    bool walletGiven;
+    bool passGiven;
+
     std::string host;
     int port;
+
+    std::string walletFile;
+    std::string walletPass;
 };
 
 char* getCmdOption(char ** begin, char ** end, const std::string & option);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -119,10 +119,45 @@ void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
                                 "communicate with the network.")
                   << std::endl << std::endl;
 
-        if (!confirm("Try again?"))
+        bool proceed = false;
+
+        while (true)
         {
-            shutdown(walletInfo->wallet, node, alreadyShuttingDown);
-            return;
+            std::cout << "[" << InformationMsg("T") << "]ry again, "
+                      << "[" << InformationMsg("E") << "]xit, or "
+                      << "[" << InformationMsg("C") << "]ontinue anyway?: ";
+
+            std::string answer;
+            std::getline(std::cin, answer);
+
+            char c = std::tolower(answer[0]);
+
+            /* Lets people spam enter in the transaction screen */
+            if (c == 't' || c == '\0')
+            {
+                break;
+            }
+            else if (c == 'e' || c == std::ifstream::traits_type::eof())
+            {
+                shutdown(walletInfo->wallet, node, alreadyShuttingDown);
+                return;
+            }
+            else if (c == 'c')
+            {
+                proceed = true;
+                break;
+            }
+            else
+            {
+                std::cout << WarningMsg("Bad input: ") << InformationMsg(answer)
+                          << WarningMsg(" - please enter either T, E, or C.")
+                          << std::endl;
+            }
+        }
+
+        if (proceed)
+        {
+            break;
         }
 
         std::cout << std::endl;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -796,6 +796,12 @@ void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node)
         {
             return;
         }
+        else if (command == "save")
+        {
+            std::cout << InformationMsg("Saving.") << std::endl;
+            walletInfo->wallet.save();
+            std::cout << InformationMsg("Saved.") << std::endl;
+        }
         else if (command == "bc_height")
         {
             blockchainHeight(node, walletInfo->wallet);
@@ -870,6 +876,8 @@ void help(bool viewWallet)
               << "Displays your payment address" << std::endl
               << SuccessMsg("exit", 25)
               << "Exit and save your wallet" << std::endl
+              << SuccessMsg("save", 25)
+              << "Save your wallet state" << std::endl
               << SuccessMsg("incoming_transfers", 25)
               << "Show incoming transfers" << std::endl;
                   

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -54,7 +54,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 enum Action {Open, Generate, Import, SeedImport, ViewWallet};
 
-Action getAction();
+Action getAction(Config &config);
 
 void logIncorrectMnemonicWords(std::vector<std::string> words);
 
@@ -73,7 +73,8 @@ void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node)
 
 void exportKeys(std::shared_ptr<WalletInfo> &walletInfo);
 
-void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node);
+void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
+         Config &config);
 
 void blockchainHeight(CryptoNote::INode &node, CryptoNote::WalletGreen &wallet);
 
@@ -107,7 +108,7 @@ std::string getInputAndDoWorkWhileIdle(std::shared_ptr<WalletInfo> &walletInfo);
 
 std::string getNewWalletFileName();
 
-std::string getExistingWalletFileName();
+std::string getExistingWalletFileName(Config &config);
 
 std::string getWalletPassword(bool verifyPwd);
 
@@ -115,7 +116,8 @@ std::shared_ptr<WalletInfo> importFromKeys(CryptoNote::WalletGreen &wallet,
                                            Crypto::SecretKey privateSpendKey,
                                            Crypto::SecretKey privateViewKey);
 
-std::shared_ptr<WalletInfo> openWallet(CryptoNote::WalletGreen &wallet);
+std::shared_ptr<WalletInfo> openWallet(CryptoNote::WalletGreen &wallet,
+                                       Config &config);
 
 std::shared_ptr<WalletInfo> importWallet(CryptoNote::WalletGreen &wallet);
 
@@ -127,7 +129,7 @@ std::shared_ptr<WalletInfo> mnemonicImportWallet(CryptoNote::WalletGreen
 std::shared_ptr<WalletInfo> generateWallet(CryptoNote::WalletGreen &wallet);
 
 std::shared_ptr<WalletInfo> handleAction(CryptoNote::WalletGreen &wallet,
-                                         Action action);
+                                         Action action, Config &config);
 
 Crypto::SecretKey getPrivateKey(std::string outputMsg);
 

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -363,6 +363,18 @@ bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold)
             CryptoNote::WalletTransaction w
                 = wallet.getTransaction(tmpFusionTxID);
             fusionTransactionHashes.push_back(w.hash);
+
+            if (fusionTransactionHashes.size() == 1)
+            {
+                std::cout << SuccessMsg("Created 1 fusion transaction!")
+                          << std::endl;
+            }
+            else
+            {
+                std::cout << SuccessMsg("Created " 
+                            + std::to_string(fusionTransactionHashes.size())
+                                    + " fusion transactions!") << std::endl;
+            }
         }
     }
 


### PR DESCRIPTION
Usage: `./simplewallet --wallet-file somefile.wallet --password somesecretpassword`

Also:
* Better output when fusions are being created
* Allow retry when no connection to daemon, or continue regardless, e.g. to export keys
* Use default port when none given with --remote-daemon, e.g. `./simplewallet --remote-daemon public.turtlenode.io`

Be careful about what password you use, as it will be left around in .bash_history