### PR TITLE
if wallet sync is stuck, save wallet to cause sync process to attempt…

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1147,75 +1147,76 @@ void findNewTransactions(CryptoNote::INode &node,
         /* This MUST be called on the main thread! */
         walletInfo->wallet.updateInternalCache();
 
-        size_t tmpTransactionCount = walletInfo->wallet.getTransactionCount();
-
-        uint32_t tmpWalletHeight = walletInfo->wallet.getBlockCount();
-
-        if (tmpWalletHeight == walletHeight)
-        {
-            stuckCounter++;
-        }
-        else
-        {
-            stuckCounter = 0;
-        }
-
-        /* Should be around a minute */
-        if (stuckCounter > 20)
-        {
-            std::cout << WarningMsg("It looks like syncing might have got "
-                                    "stuck...") << std::endl
-                      << WarningMsg("This is probably due to TurtleCoind not "
-                                    "responding. Try restarting TurtleCoind "
-                                    "and the wallet.") << std::endl
-                      << WarningMsg("If this error still continues after "
-                                    "restarting the software, you may need to "
-                                    "resync the blockchain.") << std::endl
-                      << WarningMsg("See https://github.com/turtlecoin/"
-                                    "turtlecoin/wiki/Bootstrapping-the-"
-                                    "Blockchain for a quicker sync.")
-                      << std::endl;
-
-        }
-
-        walletHeight = tmpWalletHeight;
-
         localHeight = node.getLastLocalBlockHeight();
         remoteHeight = node.getLastKnownBlockHeight();
-
         std::cout << SuccessMsg(std::to_string(walletHeight))
                   << " of " << InformationMsg(std::to_string(localHeight))
                   << std::endl;
 
-        if (tmpTransactionCount != transactionCount)
+        uint32_t tmpWalletHeight = walletInfo->wallet.getBlockCount();
+
+        int waitSeconds = 1;
+        if (tmpWalletHeight == walletHeight)
         {
-            for (size_t i = transactionCount; i < tmpTransactionCount; i++)
+            stuckCounter++;
+            waitSeconds = 3;
+
+            if (stuckCounter > 20)
             {
-                CryptoNote::WalletTransaction t 
-                    = walletInfo->wallet.getTransaction(i);
+                std::string warning =
+                    "Syncing may be stuck. Try restarting Turtlecoind.\n"
+                    "If this persists, visit "
+                    "https://turtlecoin.lol/#contact for support.";
+                std::cout << WarningMsg(warning) << std::endl;
+            }
+            else if (stuckCounter > 19)
+            {
+                /*
+                   Calling save has the side-effect of starting
+                   and stopping blockchainSynchronizer, which seems
+                   to sometimes force the sync to resume properly.
+                   So we'll try this before warning the user.
+                */
+                std::cout << InformationMsg("Saving wallet.") << std::endl;
+                walletInfo->wallet.save();
+                waitSeconds = 5;
+            }
+        }
+        else
+        {
+            stuckCounter = 0;
+            walletHeight = tmpWalletHeight;
 
-                /* Don't print out fusion transactions */
-                if (t.totalAmount != 0)
+            size_t tmpTransactionCount = walletInfo->wallet.getTransactionCount();
+            if (tmpTransactionCount != transactionCount)
+            {
+                for (size_t i = transactionCount; i < tmpTransactionCount; i++)
                 {
-                    std::cout << std::endl
-                              << InformationMsg("New transaction found!")
-                              << std::endl << std::endl;
+                    CryptoNote::WalletTransaction t
+                        = walletInfo->wallet.getTransaction(i);
 
-                    if (t.totalAmount < 0)
+                    /* Don't print out fusion transactions */
+                    if (t.totalAmount != 0)
                     {
-                        printOutgoingTransfer(t);
-                    }
-                    else
-                    {
-                        printIncomingTransfer(t);
+                        std::cout << std::endl
+                                  << InformationMsg("New transaction found!")
+                                  << std::endl << std::endl;
+
+                        if (t.totalAmount < 0)
+                        {
+                            printOutgoingTransfer(t);
+                        }
+                        else
+                        {
+                            printIncomingTransfer(t);
+                        }
                     }
                 }
+
+                transactionCount = tmpTransactionCount;
             }
-
-            transactionCount = tmpTransactionCount;
         }
-
-        std::this_thread::sleep_for(std::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(waitSeconds));
     }
 
     std::cout << SuccessMsg("Finished scanning blockchain!") << std::endl


### PR DESCRIPTION
… a restart before warning user. Also updated the stuck messaging to be a little more succinct, but we may want to think about that a little more and decide if we want more troubleshooting info in the message or not.

Example output when save happens:
![screen shot 2018-04-03 at 11 37 36 am](https://user-images.githubusercontent.com/36076951/38265152-a7501254-373a-11e8-9e94-fe06fda258f9.png)
