### PR TITLE
Adds the current blockchain height back to the log messages in the daemon and into the getinfo RPC call

### DIFF
--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
@@ -67,6 +67,7 @@ namespace CryptoNote
     int handleCommand(bool is_notify, int command, const BinaryArray& in_buff, BinaryArray& buff_out, CryptoNoteConnectionContext& context, bool& handled);
     virtual size_t getPeerCount() const override;
     virtual uint32_t getObservedHeight() const override;
+    virtual uint32_t getBlockchainHeight() const override;
     void requestMissingPoolTransactions(const CryptoNoteConnectionContext& context);
 
   private:
@@ -105,6 +106,9 @@ namespace CryptoNote
 
     mutable std::mutex m_observedHeightMutex;
     uint32_t m_observedHeight;
+    
+    mutable std::mutex m_blockchainHeightMutex;
+    uint32_t m_blockchainHeight;
 
     std::atomic<size_t> m_peersCount;
     Tools::ObserverManager<ICryptoNoteProtocolObserver> m_observerManager;

--- a/src/CryptoNoteProtocol/ICryptoNoteProtocolQuery.h
+++ b/src/CryptoNoteProtocol/ICryptoNoteProtocolQuery.h
@@ -29,6 +29,7 @@ public:
   virtual bool removeObserver(ICryptoNoteProtocolObserver* observer) = 0;
 
   virtual uint32_t getObservedHeight() const = 0;
+  virtual uint32_t getBlockchainHeight() const = 0;
   virtual size_t getPeerCount() const = 0;
   virtual bool isSynchronized() const = 0;
 };

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -275,6 +275,7 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t white_peerlist_size;
     uint64_t grey_peerlist_size;
     uint32_t last_known_block_index;
+    uint32_t network_height;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
@@ -288,6 +289,7 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(white_peerlist_size)
       KV_MEMBER(grey_peerlist_size)
       KV_MEMBER(last_known_block_index)
+      KV_MEMBER(network_height)
     }
   };
 };

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -450,6 +450,7 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.white_peerlist_size = m_p2p.getPeerlistManager().get_white_peers_count();
   res.grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
   res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocol.getObservedHeight()) - 1;
+  res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }

--- a/tests/UnitTests/ICryptoNoteProtocolQueryStub.cpp
+++ b/tests/UnitTests/ICryptoNoteProtocolQueryStub.cpp
@@ -29,6 +29,10 @@ uint32_t ICryptoNoteProtocolQueryStub::getObservedHeight() const {
   return observedHeight;
 }
 
+uint32_t ICryptoNoteProtocolQueryStub::getBlockchainHeight() const {
+  return blockchainHeight;
+}
+
 size_t ICryptoNoteProtocolQueryStub::getPeerCount() const {
   return peers;
 }

--- a/tests/UnitTests/ICryptoNoteProtocolQueryStub.h
+++ b/tests/UnitTests/ICryptoNoteProtocolQueryStub.h
@@ -31,6 +31,7 @@ public:
   virtual bool addObserver(CryptoNote::ICryptoNoteProtocolObserver* observer) override;
   virtual bool removeObserver(CryptoNote::ICryptoNoteProtocolObserver* observer) override;
   virtual uint32_t getObservedHeight() const override;
+  virtual uint32_t getBlockchainHeight() const override;
   virtual size_t getPeerCount() const override;
   virtual bool isSynchronized() const override;
 
@@ -45,6 +46,7 @@ public:
 private:
   size_t peers;
   uint32_t observedHeight;
+  uint32_t blockchainHeight;
 
   bool synchronized;
 };


### PR DESCRIPTION
2018-Apr-04 00:45:45.926279 INFO    TurtleCoin is now syncing to the network height of 325127
