### PR TITLE
Additional tests can be skipped on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ set(CMAKE_SUPPRESS_REGENERATION ON)
 SET(DO_TESTS ON CACHE STRING "Spend time making tests? Defaults to ON")
 
 if(DO_TESTS)
+  message(STATUS "BUILD TESTS: enabled")
   enable_testing()
+else()
+  message(STATUS "BUILD TESTS: disabled")
 endif()
 
 # copy CTestCustom.cmake to build dir to disable long running tests in 'make test'

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,14 +3,17 @@ set(UPNPC_BUILD_SHARED OFF CACHE BOOL "Build shared library")
 set(UPNPC_BUILD_TESTS OFF CACHE BOOL "Build test executables")
 
 add_subdirectory(miniupnpc)
-add_subdirectory(gtest)
+
+if (DO_TESTS)
+  add_subdirectory(gtest)
+endif()
 
 if(MSVC)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR} ../version)
     add_subdirectory(rocksDB EXCLUDE_FROM_ALL)
-    set_property(TARGET upnpc-static gtest gtest_main rocksdblib PROPERTY FOLDER "external")
+    set_property(TARGET upnpc-static rocksdblib PROPERTY FOLDER "external")
 elseif(NOT MSVC)
-    set_property(TARGET upnpc-static gtest gtest_main PROPERTY FOLDER "external")
+    set_property(TARGET upnpc-static PROPERTY FOLDER "external")
     add_custom_target(
        rocksdb
        COMMAND make static_lib
@@ -19,6 +22,10 @@ elseif(NOT MSVC)
     add_library(rocksdblib STATIC IMPORTED GLOBAL)
     set_target_properties(rocksdblib PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/librocksdb.a)
     add_dependencies(rocksdblib rocksdb)
+endif()
+
+if(DO_TESTS)
+  set_property(TARGET gtest gtest_main PROPERTY FOLDER "external")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
This supplements #136 by @SoreGums as we don't need to build gtests either in the event DO_TESTS is set to off.