### PR TITLE
Daemon RPC Enhancements

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -50,10 +50,12 @@ struct COMMAND_RPC_GET_HEIGHT {
 
   struct response {
     uint64_t height;
+    uint32_t network_height;
     std::string status;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(height)
+      KV_MEMBER(network_height)
       KV_MEMBER(status)
     }
   };
@@ -276,6 +278,8 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t grey_peerlist_size;
     uint32_t last_known_block_index;
     uint32_t network_height;
+    uint32_t hashrate;
+    bool synced;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
@@ -290,6 +294,8 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(grey_peerlist_size)
       KV_MEMBER(last_known_block_index)
       KV_MEMBER(network_height)
+      KV_MEMBER(hashrate)
+      KV_MEMBER(synced)
     }
   };
 };

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -19,6 +19,7 @@
 
 #include <future>
 #include <unordered_map>
+#include "math.h"
 
 // CryptoNote
 #include "Common/StringTools.h"
@@ -26,6 +27,7 @@
 #include "CryptoNoteCore/Core.h"
 #include "CryptoNoteCore/Miner.h"
 #include "CryptoNoteCore/TransactionExtra.h"
+#include "CryptoNoteConfig.h"
 
 #include "CryptoNoteProtocol/CryptoNoteProtocolHandlerCommon.h"
 
@@ -451,12 +453,15 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
   res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocol.getObservedHeight()) - 1;
   res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
+  res.hashrate = (uint32_t)round(res.difficulty / CryptoNote::parameters::DIFFICULTY_TARGET);
+  res.synced = ((uint32_t)res.height == (uint32_t)res.network_height);
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }
 
 bool RpcServer::on_get_height(const COMMAND_RPC_GET_HEIGHT::request& req, COMMAND_RPC_GET_HEIGHT::response& res) {
   res.height = m_core.getTopBlockIndex() + 1;
+  res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }


### PR DESCRIPTION
## Changelog

* Added the following /getinfo response properties
  * synced
  * hashrate
* Added /getheight response property
  * network_height

## /getinfo response

### Example of daemon that is not in sync

```javascript
{
  "alt_blocks_count": 0,
  "difficulty": 206404553,
  "grey_peerlist_size": 1588,
  "hashrate": 6880151,
  "height": 355175,
  "incoming_connections_count": 0,
  "last_known_block_index": 355690,
  "network_height": 355692,
  "outgoing_connections_count": 8,
  "status": "OK",
  "synced": false,
  "tx_count": 319734,
  "tx_pool_size": 0,
  "white_peerlist_size": 40
}
```

### Example of daemon that is in sync

```javascript
{
  "alt_blocks_count": 0,
  "difficulty": 161661413,
  "grey_peerlist_size": 1594,
  "hashrate": 5388713,
  "height": 355694,
  "incoming_connections_count": 0,
  "last_known_block_index": 355691,
  "network_height": 355694,
  "outgoing_connections_count": 8,
  "status": "OK",
  "synced": true,
  "tx_count": 320147,
  "tx_pool_size": 1,
  "white_peerlist_size": 41
}
```

## /getheight response

```javascript
{
  "height": 355706,
  "network_height": 355706,
  "status": "OK"
}
```