### PR TITLE
Add timestamps to simplewallet list_transfers

### DIFF
--- a/include/INode.h
+++ b/include/INode.h
@@ -114,6 +114,7 @@ public:
 
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<BlockDetails>>& blocks, const Callback& callback) = 0;
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) = 0;
+  virtual void getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) = 0;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) = 0;
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) = 0;
 };

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1589,6 +1589,20 @@ IBlockchainCache* Core::findSegmentContainingBlock(const Crypto::Hash& blockHash
   return findAlternativeSegmentContainingBlock(blockHash);
 }
 
+IBlockchainCache* Core::findSegmentContainingBlock(uint32_t blockHeight) const {
+  assert(chainsLeaves.size() > 0);
+
+  // first search in main chain
+  auto blockSegment = findMainChainSegmentContainingBlock(blockHeight);
+  if (blockSegment != nullptr) {
+    return blockSegment;
+  }
+
+  // than search in alternative chains
+  return findAlternativeSegmentContainingBlock(blockHeight);
+}
+
+
 IBlockchainCache* Core::findAlternativeSegmentContainingBlock(const Crypto::Hash& blockHash) const {
   IBlockchainCache* cache = nullptr;
   std::find_if(++chainsLeaves.begin(), chainsLeaves.end(),
@@ -1928,6 +1942,17 @@ void Core::mergeSegments(IBlockchainCache* acceptingSegment, IBlockchainCache* s
     acceptingSegment->pushBlock(CachedBlock(block), transactions, info.validatorState, info.blockSize,
                                 info.generatedCoins, info.blockDifficulty, std::move(info.rawBlock));
   }
+}
+
+BlockDetails Core::getBlockDetails(const uint32_t blockHeight) const {
+  throwIfNotInitialized();
+
+  IBlockchainCache* segment = findSegmentContainingBlock(blockHeight);
+  if (segment == nullptr) {
+    throw std::runtime_error("Requested block height wasn't found in blockchain.");
+  }
+
+  return getBlockDetails(segment->getBlockHash(blockHeight));
 }
 
 BlockDetails Core::getBlockDetails(const Crypto::Hash& blockHash) const {

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -112,6 +112,7 @@ public:
   virtual void load() override;
 
   virtual BlockDetails getBlockDetails(const Crypto::Hash& blockHash) const override;
+  BlockDetails getBlockDetails(const uint32_t blockHeight) const;
   virtual TransactionDetails getTransactionDetails(const Crypto::Hash& transactionHash) const override;
   virtual std::vector<Crypto::Hash> getAlternativeBlockHashesByIndex(uint32_t blockIndex) const override;
   virtual std::vector<Crypto::Hash> getBlockHashesByTimestamps(uint64_t timestampBegin, size_t secondsCount) const override;
@@ -155,6 +156,7 @@ private:
   uint64_t getAdjustedTime() const;
   void updateMainChainSet();
   IBlockchainCache* findSegmentContainingBlock(const Crypto::Hash& blockHash) const;
+  IBlockchainCache* findSegmentContainingBlock(uint32_t blockHeight) const;
   IBlockchainCache* findMainChainSegmentContainingBlock(const Crypto::Hash& blockHash) const;
   IBlockchainCache* findAlternativeSegmentContainingBlock(const Crypto::Hash& blockHash) const;
 

--- a/src/InProcessNode/InProcessNode.h
+++ b/src/InProcessNode/InProcessNode.h
@@ -84,6 +84,7 @@ public:
 
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<BlockDetails>>& blocks, const Callback& callback) override;
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) override;
+  virtual void getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) override;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
 

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -79,6 +79,7 @@ public:
           std::vector<std::unique_ptr<ITransactionReader>>& newTxs, std::vector<Crypto::Hash>& deletedTxIds, const Callback& callback) override;
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<BlockDetails>>& blocks, const Callback& callback) override;
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) override;
+  virtual void getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) override;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
 
@@ -110,6 +111,7 @@ private:
   std::error_code doGetPoolSymmetricDifference(std::vector<Crypto::Hash>&& knownPoolTxIds, Crypto::Hash knownBlockId, bool& isBcActual,
           std::vector<std::unique_ptr<ITransactionReader>>& newTxs, std::vector<Crypto::Hash>& deletedTxIds);
   std::error_code doGetBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks);
+  std::error_code doGetBlock(const uint32_t blockHeight, BlockDetails& block);
   std::error_code doGetTransactionHashesByPaymentId(const Crypto::Hash& paymentId, std::vector<Crypto::Hash>& transactionHashes);
   std::error_code doGetTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions);
 

--- a/src/PaymentGate/NodeFactory.cpp
+++ b/src/PaymentGate/NodeFactory.cpp
@@ -77,6 +77,9 @@ public:
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<CryptoNote::BlockDetails>& blocks,
     const Callback& callback) override { }
 
+  virtual void getBlock(const uint32_t blockHeight, CryptoNote::BlockDetails &block,
+    const Callback& callback) override { }
+
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<CryptoNote::TransactionDetails>& transactions,
     const Callback& callback) override { }
 

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -729,6 +729,26 @@ struct COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HASHES {
   };
 };
 
+struct COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT {
+  struct request {
+    uint32_t blockHeight;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(blockHeight)
+    }
+  };
+
+  struct response {
+    BlockDetails block;
+    std::string status;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(status)
+      KV_MEMBER(block)
+    }
+  };
+};
+
 struct COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS {
   struct request {
     uint64_t timestampBegin;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -118,6 +118,7 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   { "/getrandom_outs.bin", { binMethod<COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS>(&RpcServer::on_get_random_outs), false } },
   { "/get_pool_changes.bin", { binMethod<COMMAND_RPC_GET_POOL_CHANGES>(&RpcServer::onGetPoolChanges), false } },
   { "/get_pool_changes_lite.bin", { binMethod<COMMAND_RPC_GET_POOL_CHANGES_LITE>(&RpcServer::onGetPoolChangesLite), false } },
+  { "/get_block_details_by_height.bin", { binMethod<COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT>(&RpcServer::onGetBlockDetailsByHeight), false } },
   { "/get_blocks_details_by_hashes.bin", { binMethod<COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HASHES>(&RpcServer::onGetBlocksDetailsByHashes), false } },
   { "/get_blocks_hashes_by_timestamps.bin", { binMethod<COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS>(&RpcServer::onGetBlocksHashesByTimestamps), false } },
   { "/get_transaction_details_by_hashes.bin", { binMethod<COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASHES>(&RpcServer::onGetTransactionDetailsByHashes), false } },
@@ -369,6 +370,22 @@ bool RpcServer::onGetBlocksDetailsByHashes(const COMMAND_RPC_GET_BLOCKS_DETAILS_
     }
 
     rsp.blocks = std::move(blockDetails);
+  } catch (std::system_error& e) {
+    rsp.status = e.what();
+    return false;
+  } catch (std::exception& e) {
+    rsp.status = "Error: " + std::string(e.what());
+    return false;
+  }
+
+  rsp.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::onGetBlockDetailsByHeight(const COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT::response& rsp) {
+  try {
+    BlockDetails blockDetails = m_core.getBlockDetails(req.blockHeight);
+    rsp.block = blockDetails;
   } catch (std::system_error& e) {
     rsp.status = e.what();
     return false;

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -67,6 +67,7 @@ private:
   bool onGetPoolChanges(const COMMAND_RPC_GET_POOL_CHANGES::request& req, COMMAND_RPC_GET_POOL_CHANGES::response& rsp);
   bool onGetPoolChangesLite(const COMMAND_RPC_GET_POOL_CHANGES_LITE::request& req, COMMAND_RPC_GET_POOL_CHANGES_LITE::response& rsp);
   bool onGetBlocksDetailsByHashes(const COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HASHES::request& req, COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HASHES::response& rsp);
+  bool onGetBlockDetailsByHeight(const COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT::response& rsp);
   bool onGetBlocksHashesByTimestamps(const COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS::request& req, COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS::response& rsp);
   bool onGetTransactionDetailsByHashes(const COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASHES::request& req, COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASHES::response& rsp);
   bool onGetTransactionHashesByPaymentId(const COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response& rsp);

--- a/src/Serialization/BlockchainExplorerDataSerialization.cpp
+++ b/src/Serialization/BlockchainExplorerDataSerialization.cpp
@@ -180,7 +180,10 @@ void serialize(BlockDetails& block, ISerializer& serializer) {
   serializer(block.alreadyGeneratedCoins, "alreadyGeneratedCoins");
   serializer(block.alreadyGeneratedTransactions, "alreadyGeneratedTransactions");
   serializer(block.sizeMedian, "sizeMedian");
+  /* Some serializers don't support doubles, which causes this to fail and
+     not serialize the whole object
   serializer(block.penalty, "penalty");
+  */
   serializer(block.totalFeeAmount, "totalFeeAmount");
   serializer(block.transactions, "transactions");
 }

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1100,8 +1100,15 @@ CryptoNote::BlockDetails getBlock(uint32_t blockHeight,
 {
     CryptoNote::BlockDetails block;
 
+    /* No connection to turtlecoind */
+    if (node.getLastKnownBlockHeight() == 0)
+    {
+        return block;
+    }
+
     std::promise<std::error_code> errorPromise;
-    auto f_error = errorPromise.get_future();
+
+    auto e = errorPromise.get_future();
 
     auto callback = [&errorPromise](std::error_code e)
     {
@@ -1110,12 +1117,10 @@ CryptoNote::BlockDetails getBlock(uint32_t blockHeight,
 
     node.getBlock(blockHeight, block, callback);
 
-    auto error = f_error.get();
-
-    if (error)
+    if (e.get())
     {
-        std::cout << "Failed to retrieve block from node, is TurtleCoind open?"
-                  << std::endl;
+        std::cout << "Failed to retrieve block from node, is TurtleCoind "
+                  << "open?" << std::endl;
     }
 
     return block;

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -79,16 +79,18 @@ void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
 void blockchainHeight(CryptoNote::INode &node, CryptoNote::WalletGreen &wallet);
 
 void listTransfers(bool incoming, bool outgoing, 
-                   CryptoNote::WalletGreen &wallet);
+                   CryptoNote::WalletGreen &wallet, CryptoNote::INode &node);
 
 void findNewTransactions(CryptoNote::INode &node, 
                          std::shared_ptr<WalletInfo> &walletInfo);
 
 void reset(CryptoNote::INode &node, std::shared_ptr<WalletInfo> &walletInfo);
 
-void printOutgoingTransfer(CryptoNote::WalletTransaction t);
+void printOutgoingTransfer(CryptoNote::WalletTransaction t,
+                           CryptoNote::INode &node);
 
-void printIncomingTransfer(CryptoNote::WalletTransaction t);
+void printIncomingTransfer(CryptoNote::WalletTransaction t,
+                           CryptoNote::INode &node);
 
 void checkForNewTransactions(std::shared_ptr<WalletInfo> &walletInfo);
 
@@ -112,6 +114,8 @@ std::string getExistingWalletFileName(Config &config);
 
 std::string getWalletPassword(bool verifyPwd);
 
+std::string getBlockTime(CryptoNote::BlockDetails b);
+
 std::shared_ptr<WalletInfo> importFromKeys(CryptoNote::WalletGreen &wallet, 
                                            Crypto::SecretKey privateSpendKey,
                                            Crypto::SecretKey privateViewKey);
@@ -134,3 +138,6 @@ std::shared_ptr<WalletInfo> handleAction(CryptoNote::WalletGreen &wallet,
 Crypto::SecretKey getPrivateKey(std::string outputMsg);
 
 ColouredMsg getPrompt(std::shared_ptr<WalletInfo> &walletInfo);
+
+CryptoNote::BlockDetails getBlock(uint32_t blockHeight,
+                                  CryptoNote::INode &node);

--- a/tests/UnitTests/INodeStubs.cpp
+++ b/tests/UnitTests/INodeStubs.cpp
@@ -442,6 +442,40 @@ void INodeTrivialRefreshStub::doGetBlocks(const std::vector<uint32_t>& blockHeig
   callback(std::error_code());
 }
 
+void INodeTrivialRefreshStub::getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) {
+  m_asyncCounter.addAsyncContext();
+
+  std::thread task([=, &blocks]() mutable { doGetBlock(blockHeight, block, callback); });
+  task.detach();
+}
+
+void INodeTrivialRefreshStub::doGetBlock(const uint32_t blockHeight, BlockDetails& block, const Callback& callback) {
+  ContextCounterHolder counterHolder(m_asyncCounter);
+  std::unique_lock<std::mutex> lock(m_walletLock);
+
+  if (m_blockchainGenerator.getBlockchain().size() <= blockHeight) {
+    lock.unlock();
+    callback(std::error_code(EDOM, std::generic_category()));
+    return;
+  }
+  BlockDetails b = BlockDetails();
+  b.index = blockHeight;
+  b.isAlternative = false;
+  auto cached = CachedBlock(m_blockchainGenerator.getBlockchain()[height]);
+  b.hash = cached.getBlockHash();
+  b.timestamp = cached.getBlock().timestamp;
+  b.alreadyGeneratedTransactions = m_blockchainGenerator.getGeneratedTransactionsNumber(height);
+
+  std::transform(cached.getBlock().transactionHashes.begin(), cached.getBlock().transactionHashes.end(),
+                 std::back_inserter(b.transactions), [&](const Crypto::Hash& hash) {
+                   return toDetails(m_blockchainGenerator.getTransactionByHash(hash), b.hash, b.index);
+                 });
+  block = b;
+
+  lock.unlock();
+  callback(std::error_code());
+}
+
 void INodeTrivialRefreshStub::getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) {
   m_asyncCounter.addAsyncContext();
 

--- a/tests/UnitTests/INodeStubs.cpp
+++ b/tests/UnitTests/INodeStubs.cpp
@@ -445,7 +445,7 @@ void INodeTrivialRefreshStub::doGetBlocks(const std::vector<uint32_t>& blockHeig
 void INodeTrivialRefreshStub::getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) {
   m_asyncCounter.addAsyncContext();
 
-  std::thread task([=, &blocks]() mutable { doGetBlock(blockHeight, block, callback); });
+  std::thread task([=, &block]() mutable { doGetBlock(blockHeight, block, callback); });
   task.detach();
 }
 
@@ -461,10 +461,10 @@ void INodeTrivialRefreshStub::doGetBlock(const uint32_t blockHeight, BlockDetail
   BlockDetails b = BlockDetails();
   b.index = blockHeight;
   b.isAlternative = false;
-  auto cached = CachedBlock(m_blockchainGenerator.getBlockchain()[height]);
+  auto cached = CachedBlock(m_blockchainGenerator.getBlockchain()[blockHeight]);
   b.hash = cached.getBlockHash();
   b.timestamp = cached.getBlock().timestamp;
-  b.alreadyGeneratedTransactions = m_blockchainGenerator.getGeneratedTransactionsNumber(height);
+  b.alreadyGeneratedTransactions = m_blockchainGenerator.getGeneratedTransactionsNumber(blockHeight);
 
   std::transform(cached.getBlock().transactionHashes.begin(), cached.getBlock().transactionHashes.end(),
                  std::back_inserter(b.transactions), [&](const Crypto::Hash& hash) {

--- a/tests/UnitTests/INodeStubs.h
+++ b/tests/UnitTests/INodeStubs.h
@@ -59,6 +59,7 @@ public:
 
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<CryptoNote::BlockDetails>>& blocks, const Callback& callback) override { callback(std::error_code()); };
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<CryptoNote::BlockDetails>& blocks, const Callback& callback) override { callback(std::error_code()); };
+  virtual void getBlock(const uint32_t blockHeight, CryptoNote::BlockDetails& blocks, const Callback& callback) override { callback(std::error_code()); };
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<CryptoNote::TransactionDetails>& transactions, const Callback& callback) override { callback(std::error_code()); };
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override { callback(std::error_code()); };
 
@@ -101,6 +102,7 @@ public:
 
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<CryptoNote::BlockDetails>>& blocks, const Callback& callback) override;
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<CryptoNote::BlockDetails>& blocks, const Callback& callback) override;
+  virtual void getBlock(const uint32_t blockHeight, CryptoNote::BlockDetails& block, const Callback& callback) override;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<CryptoNote::TransactionDetails>& transactions, const Callback& callback) override;
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
 
@@ -135,6 +137,7 @@ protected:
 
   void doGetBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<CryptoNote::BlockDetails>>& blocks, const Callback& callback);
   void doGetBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<CryptoNote::BlockDetails>& blocks, const Callback& callback);
+  void doGetBlock(const uint32_t blockHeight, CryptoNote::BlockDetails& blocks, const Callback& callback);
   void doGetBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<CryptoNote::BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback);
   void doGetTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<CryptoNote::TransactionDetails>& transactions, const Callback& callback);
   void doGetPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<CryptoNote::TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps, const Callback& callback);


### PR DESCRIPTION
Caveats:
* It's slower to list all transactions because it has to scour the blockchain
* I had to comment out the serialization of block.penalty due to binary serialization not supporting doubles.

Screenshot:
![selection_001](https://user-images.githubusercontent.com/22151537/38577488-fb42bb82-3cf8-11e8-9f9b-4211de5a4aec.png)

It should use the users' timezone. It appears to work on GMT, but I haven't tested other time zones.
Both linux and windows work fine - though if TurtleCoind is being slow to respond it will hold up the process quite a bit.
