### PR TITLE
Detect support for AVX/AVX2 in rocksdb

### DIFF
--- a/external/rocksdb/CMakeLists.txt
+++ b/external/rocksdb/CMakeLists.txt
@@ -1017,3 +1017,61 @@ option(WITH_TOOLS "build with tools" ON)
 if(WITH_TOOLS)
   add_subdirectory(tools)
 endif()
+
+
+if(MSVC)
+# Check for the presence of AVX and figure out the flags to use for it.
+	string (REPLACE "/arch:AVX2" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+	string (REPLACE "/arch:AVX" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+    include(CheckCXXSourceRuns)
+    
+    # Check AVX
+    check_cxx_source_runs("
+        #include <immintrin.h>
+        int main()
+        {
+          __m256 a, b, c;
+          const float src[8] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+          float dst[8];
+          a = _mm256_loadu_ps( src );
+          b = _mm256_loadu_ps( src );
+          c = _mm256_add_ps( a, b );
+          _mm256_storeu_ps( dst, c );
+          for( int i = 0; i < 8; i++ ){
+            if( ( src[i] + src[i] ) != dst[i] ){
+              return -1;
+            }
+          }
+          return 0;
+        }"
+        HAVE_AVX_EXTENSIONS)
+
+    # Check AVX2
+    check_cxx_source_runs("
+        #include <immintrin.h>
+        int main()
+        {
+          __m256i a, b, c;
+          const int src[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+          int dst[8];
+          a =  _mm256_loadu_si256( (__m256i*)src );
+          b =  _mm256_loadu_si256( (__m256i*)src );
+          c = _mm256_add_epi32( a, b );
+          _mm256_storeu_si256( (__m256i*)dst, c );
+          for( int i = 0; i < 8; i++ ){
+            if( ( src[i] + src[i] ) != dst[i] ){
+              return -1;
+            }
+          }
+          return 0;
+        }"
+        HAVE_AVX2_EXTENSIONS)
+
+    # Set Flags
+	if(HAVE_AVX2_EXTENSIONS AND NOT MSVC_VERSION LESS 1800)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+	elseif(HAVE_AVX_EXTENSIONS  AND NOT MSVC_VERSION LESS 1600)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX")
+	endif()
+endif()

--- a/external/rocksdb/CMakeLists.txt
+++ b/external/rocksdb/CMakeLists.txt
@@ -1021,57 +1021,57 @@ endif()
 
 if(MSVC)
 # Check for the presence of AVX and figure out the flags to use for it.
-	string (REPLACE "/arch:AVX2" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-	string (REPLACE "/arch:AVX" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  string (REPLACE "/arch:AVX2" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  string (REPLACE "/arch:AVX" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
-    include(CheckCXXSourceRuns)
+  include(CheckCXXSourceRuns)
     
-    # Check AVX
-    check_cxx_source_runs("
-        #include <immintrin.h>
-        int main()
-        {
-          __m256 a, b, c;
-          const float src[8] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
-          float dst[8];
-          a = _mm256_loadu_ps( src );
-          b = _mm256_loadu_ps( src );
-          c = _mm256_add_ps( a, b );
-          _mm256_storeu_ps( dst, c );
-          for( int i = 0; i < 8; i++ ){
-            if( ( src[i] + src[i] ) != dst[i] ){
-              return -1;
-            }
-          }
-          return 0;
-        }"
-        HAVE_AVX_EXTENSIONS)
+  # Check AVX
+  check_cxx_source_runs("
+    #include <immintrin.h>
+    int main()
+    {
+      __m256 a, b, c;
+      const float src[8] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+      float dst[8];
+      a = _mm256_loadu_ps( src );
+      b = _mm256_loadu_ps( src );
+      c = _mm256_add_ps( a, b );
+      _mm256_storeu_ps( dst, c );
+      for( int i = 0; i < 8; i++ ){
+        if( ( src[i] + src[i] ) != dst[i] ){
+          return -1;
+        }
+      }
+      return 0;
+    }"
+    HAVE_AVX_EXTENSIONS)
 
-    # Check AVX2
-    check_cxx_source_runs("
-        #include <immintrin.h>
-        int main()
-        {
-          __m256i a, b, c;
-          const int src[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
-          int dst[8];
-          a =  _mm256_loadu_si256( (__m256i*)src );
-          b =  _mm256_loadu_si256( (__m256i*)src );
-          c = _mm256_add_epi32( a, b );
-          _mm256_storeu_si256( (__m256i*)dst, c );
-          for( int i = 0; i < 8; i++ ){
-            if( ( src[i] + src[i] ) != dst[i] ){
-              return -1;
-            }
-          }
-          return 0;
-        }"
-        HAVE_AVX2_EXTENSIONS)
+  # Check AVX2
+  check_cxx_source_runs("
+    #include <immintrin.h>
+    int main()
+    {
+      __m256i a, b, c;
+      const int src[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+      int dst[8];
+      a =  _mm256_loadu_si256( (__m256i*)src );
+      b =  _mm256_loadu_si256( (__m256i*)src );
+      c = _mm256_add_epi32( a, b );
+      _mm256_storeu_si256( (__m256i*)dst, c );
+      for( int i = 0; i < 8; i++ ){
+        if( ( src[i] + src[i] ) != dst[i] ){
+          return -1;
+        }
+      }
+      return 0;
+    }"
+    HAVE_AVX2_EXTENSIONS)
 
-    # Set Flags
-	if(HAVE_AVX2_EXTENSIONS AND NOT MSVC_VERSION LESS 1800)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
-	elseif(HAVE_AVX_EXTENSIONS  AND NOT MSVC_VERSION LESS 1600)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX")
-	endif()
+  # Set Flags
+  if(HAVE_AVX2_EXTENSIONS AND NOT MSVC_VERSION LESS 1800)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+  elseif(HAVE_AVX_EXTENSIONS  AND NOT MSVC_VERSION LESS 1600)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX")
+  endif()
 endif()


### PR DESCRIPTION
Solves  #171. People with old hardware (pre-Haswell and old AMD CPU's) will have to compile source themselves or download special binaries for older architecture.