### PR TITLE
Simplewallet - Return to selection on error, small fixes

### DIFF
--- a/src/SimpleWallet/PasswordContainer.h
+++ b/src/SimpleWallet/PasswordContainer.h
@@ -34,7 +34,8 @@ namespace Tools
     void clear();
     bool empty() const { return m_empty; }
     const std::string& password() const { return m_password; }
-    void password(std::string&& val) { m_password = std::move(val); m_empty = false; }
+    void password(std::string&& val) { m_password = std::move(val); 
+                                       m_empty = false; }
     bool read_and_validate();
     bool read_password();
     bool read_password(bool verify);

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -69,7 +69,8 @@ void welcomeMsg();
 
 void help(bool viewWallet);
 
-void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node);
+void inputLoop(std::shared_ptr<WalletInfo> &walletInfo,
+               CryptoNote::INode &node);
 
 void exportKeys(std::shared_ptr<WalletInfo> &walletInfo);
 
@@ -120,8 +121,8 @@ std::shared_ptr<WalletInfo> importFromKeys(CryptoNote::WalletGreen &wallet,
                                            Crypto::SecretKey privateSpendKey,
                                            Crypto::SecretKey privateViewKey);
 
-std::shared_ptr<WalletInfo> openWallet(CryptoNote::WalletGreen &wallet,
-                                       Config &config);
+Maybe<std::shared_ptr<WalletInfo>> openWallet(CryptoNote::WalletGreen &wallet,
+                                              Config &config);
 
 std::shared_ptr<WalletInfo> importWallet(CryptoNote::WalletGreen &wallet);
 
@@ -132,8 +133,8 @@ std::shared_ptr<WalletInfo> mnemonicImportWallet(CryptoNote::WalletGreen
 
 std::shared_ptr<WalletInfo> generateWallet(CryptoNote::WalletGreen &wallet);
 
-std::shared_ptr<WalletInfo> handleAction(CryptoNote::WalletGreen &wallet,
-                                         Action action, Config &config);
+Maybe<std::shared_ptr<WalletInfo>> handleAction(CryptoNote::WalletGreen &wallet,
+                                                Action action, Config &config);
 
 Crypto::SecretKey getPrivateKey(std::string outputMsg);
 

--- a/src/SimpleWallet/Tools.cpp
+++ b/src/SimpleWallet/Tools.cpp
@@ -122,7 +122,8 @@ bool confirm(std::string msg)
         else
         {
             std::cout << WarningMsg("Bad input: ") << InformationMsg(answer)
-                      << WarningMsg(" - please enter either Y or N.") << std::endl;
+                      << WarningMsg(" - please enter either Y or N.")
+                      << std::endl;
         }
     }
 }

--- a/src/SimpleWallet/Tools.h
+++ b/src/SimpleWallet/Tools.h
@@ -121,3 +121,77 @@ class WarningMsg : public ColouredMsg
                : ColouredMsg(msg, padding, 
                              Common::Console::Color::BrightRed) {}
 };
+
+/* This borrows from haskell, and is a nicer boost::optional class. We either
+   have Just a value, or Nothing.
+
+   Example usage follows.
+   The below code will print:
+
+   ```
+   100
+   Nothing
+   ```
+
+   Maybe<int> parseAmount(std::string input)
+   {
+        if (input.length() == 0)
+        {
+            return Nothing<int>();
+        }
+
+        try
+        {
+            return Just<int>(std::stoi(input)
+        }
+        catch (const std::invalid_argument)
+        {
+            return Nothing<int>();
+        }
+   }
+
+   int main()
+   {
+       auto foo = parseAmount("100");
+
+       if (foo.isJust)
+       {
+           std::cout << foo.x << std::endl;
+       }
+       else
+       {
+           std::cout << "Nothing" << std::endl;
+       }
+
+       auto bar = parseAmount("garbage");
+
+       if (bar.isJust)
+       {
+           std::cout << bar.x << std::endl;
+       }
+       else
+       {
+           std::cout << "Nothing" << std::endl;
+       }
+   }
+
+*/
+
+template <class X> struct Maybe
+{
+    X x;
+    bool isJust;
+
+    Maybe(const X &x) : x (x), isJust(true) {}
+    Maybe() : isJust(false) {}
+};
+
+template <class X> Maybe<X> Just(const X&x)
+{
+    return Maybe<X>(x);
+}
+
+template <class X> Maybe<X> Nothing()
+{
+    return Maybe<X>();
+}

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -68,7 +68,7 @@ bool parseAmount(std::string strAmount, uint64_t &amount)
 }
 
 bool confirmTransaction(CryptoNote::TransactionParameters t,
-						            std::shared_ptr<WalletInfo> walletInfo)
+                        std::shared_ptr<WalletInfo> walletInfo)
 {
     std::cout << std::endl
               << InformationMsg("Confirm Transaction?") << std::endl;

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -68,35 +68,46 @@ bool parseAmount(std::string strAmount, uint64_t &amount)
 }
 
 bool confirmTransaction(CryptoNote::TransactionParameters t,
-						std::shared_ptr<WalletInfo> walletInfo)
+						            std::shared_ptr<WalletInfo> walletInfo)
 {
-	std::cout << std::endl
-			  << InformationMsg("Confirm Transaction?") << std::endl;
+    std::cout << std::endl
+              << InformationMsg("Confirm Transaction?") << std::endl;
 
-	std::string paymentId = "";
+    std::string paymentId = "";
 
-	if (t.extra.length() > 0)
-	{
-		std::vector<uint8_t> vecExtra;
+    if (t.extra.length() > 0)
+    {
+        std::vector<uint8_t> vecExtra;
 
-		for (auto it : t.extra)
-			vecExtra.push_back(static_cast<uint8_t>(it));
+        for (auto it : t.extra)
+        {
+            vecExtra.push_back(static_cast<uint8_t>(it));
+        }
 
-		Crypto::Hash paymentIdHash;
-		CryptoNote::getPaymentIdFromTxExtra(vecExtra, paymentIdHash);
-		paymentId = Common::podToHex(paymentIdHash);
-	}
+        Crypto::Hash paymentIdHash;
+        CryptoNote::getPaymentIdFromTxExtra(vecExtra, paymentIdHash);
+        paymentId = Common::podToHex(paymentIdHash);
+    }
 
-	std::cout << "You are sending "
-			  << SuccessMsg(formatAmount(t.destinations[0].amount))
-		  	  << ", with a fee of " << SuccessMsg(formatAmount(t.fee))
-			  << std::endl
-			  << "FROM: " << InformationMsg(walletInfo->walletFileName)
-			  << std::endl
-			  << "TO: " << std::endl
-			  << InformationMsg(t.destinations[0].address) << std::endl
-			  << "Payment ID: " << InformationMsg(paymentId) << std::endl
-			  << "MixIn: " << (unsigned)t.mixIn
+    std::cout << "You are sending "
+              << SuccessMsg(formatAmount(t.destinations[0].amount))
+              << ", with a fee of " << SuccessMsg(formatAmount(t.fee))
+              << ", " << std::endl;
+
+    if (paymentId != "")
+    {
+        std::cout << "A mixin of " << SuccessMsg(std::to_string(t.mixIn))
+                  << " and a Payment ID of " << SuccessMsg(paymentId);
+    }
+    else
+    {
+        std::cout << "And a mixin of " << SuccessMsg(std::to_string(t.mixIn));
+    }
+    
+    std::cout << std::endl << std::endl
+              << "FROM: " << InformationMsg(walletInfo->walletFileName)
+              << std::endl
+              << "TO: " << InformationMsg(t.destinations[0].address)
               << std::endl << std::endl;
 
     if (confirm("Is this correct?"))
@@ -1127,11 +1138,13 @@ bool parseAmount(std::string amountString)
 
     if (!parseAmount(amountString, amount))
     {
-        std::cout << WarningMsg("Failed to parse amount! Ensure you entered the "
-                                "value correctly.") << std::endl
+        std::cout << WarningMsg("Failed to parse amount! Ensure you entered "
+                                "the value correctly.")
+                  << std::endl
                   << "Please note, the minimum you can send is 0.01 TRTL, "
                   << "and you can only use 2 decimal places."
                   << std::endl;
+
         return false;
     }
 


### PR DESCRIPTION
If we hit an error, go back to the selection screen rather than closing. Gives the user more control, as they can easily exit anyway, with ctrl+c or just closing the window.

Instead of printing out "Could not get timestamp" - just don't print the timestamp.

Small transfer confirmation alteration to sate my ~~autism~~ peculiarities. 