### PR TITLE
Fix not connecting to remote node initially when all args specified

### DIFF
--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -160,6 +160,8 @@ void NodeRpcProxy::workerThread(const INode::Callback& initialized_callback) {
       m_cv_initialized.notify_all();
     }
 
+    updateNodeStatus();
+
     initialized_callback(std::error_code());
 
     contextGroup.spawn([this]() {

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -102,11 +102,11 @@ void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
         }
     });
 
-    /* If all the arguments are specified, and we're using a remote node, it
-       seems like we don't have time to get a response from the node instantly,
-       and so about 50% of the time it will report that turtlecoind is not
-       open. We can simply add a small sleep to mitigate this */
-    if (config.host != "127.0.0.1" && config.walletGiven && config.passGiven)
+    /* When we're using a remote node, it seems like we don't have time to 
+       get a response from the node instantly, and so about 50% of the 
+       time it will report that turtlecoind is not open. We can simply add
+       a small sleep to mitigate this */
+    if (config.host != "127.0.0.1")
     {
         std::this_thread::sleep_for(std::chrono::seconds(2));
     }

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -102,15 +102,6 @@ void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
         }
     });
 
-    /* When we're using a remote node, it seems like we don't have time to 
-       get a response from the node instantly, and so about 50% of the 
-       time it will report that turtlecoind is not open. We can simply add
-       a small sleep to mitigate this */
-    if (config.host != "127.0.0.1")
-    {
-        std::this_thread::sleep_for(std::chrono::seconds(2));
-    }
-
     while (node.getLastKnownBlockHeight() == 0)
     {
         std::cout << WarningMsg("It looks like TurtleCoind isn't open!")


### PR DESCRIPTION
It seems if you specified all args needed on the command line, 50% of the time the wallet wouldn't connect to turtlecoind quickly enough, and so would report it is closed. We run the update function in init() once before returning so it is fully inited when it returns.

Also save periodically when scanning chain initially so progress isn't lost if a user exits before it's complete.