### PR TITLE
RocksDB Build Speedup by allowing the jobServer to operate

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,7 +17,7 @@ elseif(NOT MSVC)
     set_property(TARGET upnpc-static PROPERTY FOLDER "external")
     add_custom_target(
        rocksdb
-       COMMAND make rocksdb
+       COMMAND $(MAKE) rocksdb
        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/rocksdb
     )
     add_library(rocksdblib STATIC IMPORTED GLOBAL)


### PR DESCRIPTION
## Test Build Commands
```base
cmake .. -DDO_TESTS=OFF
make -j8
```

### Old build time
```text
real    5m44.033s
user    13m14.948s
sys     0m54.488s
```

### New build time
```text
real    1m43.796s
user    8m11.024s
sys     0m31.988s
```

Much better. Now my coffee doesn't get cold during the build process.