### PR TITLE
Adding command line description for RPC arguments

### DIFF
--- a/src/Rpc/RpcServerConfig.cpp
+++ b/src/Rpc/RpcServerConfig.cpp
@@ -26,8 +26,8 @@ namespace CryptoNote {
     const std::string DEFAULT_RPC_IP = "127.0.0.1";
     const uint16_t DEFAULT_RPC_PORT = RPC_DEFAULT_PORT;
 
-    const command_line::arg_descriptor<std::string> arg_rpc_bind_ip = { "rpc-bind-ip", "", DEFAULT_RPC_IP };
-    const command_line::arg_descriptor<uint16_t> arg_rpc_bind_port = { "rpc-bind-port", "", DEFAULT_RPC_PORT };
+    const command_line::arg_descriptor<std::string> arg_rpc_bind_ip = { "rpc-bind-ip", "Interface for RPC service", DEFAULT_RPC_IP };
+    const command_line::arg_descriptor<uint16_t> arg_rpc_bind_port = { "rpc-bind-port", "Port for RPC service", DEFAULT_RPC_PORT };
   }
 
 


### PR DESCRIPTION
Adding a description to the command line arguments. Noticed this while working on something else.