### PR TITLE
Make messages fit better in windows terminal

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -751,8 +751,10 @@ void printPrivateKeys(CryptoNote::WalletGreen &wallet, bool viewWallet)
 
     if (viewWallet)
     {
-        std::cout << SuccessMsg("Private view key: " 
-                              + Common::podToHex(privateViewKey)) << std::endl;
+        std::cout << SuccessMsg("Private view key:")
+                  << std::endl
+                  << SuccessMsg(Common::podToHex(privateViewKey))
+                  << std::endl;
         return;
     }
 
@@ -765,10 +767,15 @@ void printPrivateKeys(CryptoNote::WalletGreen &wallet, bool viewWallet)
 
     bool deterministicPrivateKeys = derivedPrivateViewKey == privateViewKey;
 
-    std::cout << SuccessMsg("Private spend key: " 
-                          + Common::podToHex(privateSpendKey)) << std::endl
-              << SuccessMsg("Private view key: " 
-                          + Common::podToHex(privateViewKey)) << std::endl;
+    std::cout << SuccessMsg("Private spend key:")
+              << std::endl
+              << SuccessMsg(Common::podToHex(privateSpendKey))
+              << std::endl
+              << std::endl
+              << SuccessMsg("Private view key:")
+              << std::endl
+              << SuccessMsg(Common::podToHex(privateViewKey))
+              << std::endl;
 
     if (deterministicPrivateKeys)
     {
@@ -778,17 +785,25 @@ void printPrivateKeys(CryptoNote::WalletGreen &wallet, bool viewWallet)
                                               mnemonicSeed,
                                               "English");
 
-        std::cout << SuccessMsg("Mnemonic seed: " + mnemonicSeed) << std::endl;
+        std::cout << std::endl
+                  << SuccessMsg("Mnemonic seed:")
+                  << std::endl
+                  << SuccessMsg(mnemonicSeed)
+                  << std::endl;
     }
 }
 
 void welcomeMsg()
 {
-    std::cout << "Use the " << SuggestionMsg("help") 
-              << " command to see the list "
-              << "of available commands." << std::endl << "Use "
-              << SuggestionMsg("exit") << " when closing to ensure your wallet "
-              << "file doesn't get corrupted." << std::endl << std::endl;
+    std::cout << "Use the "
+              << SuggestionMsg("help") 
+              << " command to see the list of available commands."
+              << std::endl
+              << "Use "
+              << SuggestionMsg("exit")
+              << " when closing to ensure your wallet file doesn't get "
+              << "corrupted."
+              << std::endl << std::endl;
 }
 
 std::string getInputAndDoWorkWhileIdle(std::shared_ptr<WalletInfo> &walletInfo)
@@ -1192,20 +1207,24 @@ void printOutgoingTransfer(CryptoNote::WalletTransaction t,
 {
     std::string blockTime = getBlockTime(getBlock(t.blockHeight, node));
 
-    std::cout << WarningMsg("Outgoing transfer: " + Common::podToHex(t.hash))
+    std::cout << WarningMsg("Outgoing transfer:")
+              << std::endl
+              << WarningMsg("Hash: " + Common::podToHex(t.hash))
               << std::endl
               << WarningMsg("Spent: " + formatAmount(-t.totalAmount - t.fee))
               << std::endl
               << WarningMsg("Fee: " + formatAmount(t.fee))
               << std::endl
               << WarningMsg("Total Spent: " + formatAmount(-t.totalAmount))
-              << std::endl << std::endl;
+              << std::endl;
 
     /* Couldn't get timestamp, maybe old node or turtlecoind closed */
     if (blockTime != "")
     {
         std::cout << WarningMsg("Timestamp: " + blockTime) << std::endl;
     }
+
+    std::cout << std::endl;
 }
 
 void printIncomingTransfer(CryptoNote::WalletTransaction t,
@@ -1213,16 +1232,20 @@ void printIncomingTransfer(CryptoNote::WalletTransaction t,
 {
     std::string blockTime = getBlockTime(getBlock(t.blockHeight, node));
 
-    std::cout << SuccessMsg("Incoming transfer: " + Common::podToHex(t.hash))
+    std::cout << SuccessMsg("Incoming transfer:")
+              << std::endl
+              << SuccessMsg("Hash: " + Common::podToHex(t.hash))
               << std::endl
               << SuccessMsg("Amount: " + formatAmount(t.totalAmount))
-              << std::endl << std::endl;
+              << std::endl;
 
     /* Couldn't get timestamp, maybe old node or turtlecoind closed */
     if (blockTime != "")
     {
         std::cout << SuccessMsg("Timestamp: " + blockTime) << std::endl;
     }
+
+    std::cout << std::endl;
 }
 
 void listTransfers(bool incoming, bool outgoing, 
@@ -1282,8 +1305,9 @@ void checkForNewTransactions(std::shared_ptr<WalletInfo> &walletInfo)
                 std::cout << std::endl
                           << InformationMsg("New transaction found!")
                           << std::endl
-                          << SuccessMsg("Incoming transfer: " 
-                                      + Common::podToHex(t.hash))
+                          << SuccessMsg("Incoming transfer:")
+                          << std::endl
+                          << SuccessMsg("Hash: " + Common::podToHex(t.hash))
                           << std::endl
                           << SuccessMsg("Amount: "
                                       + formatAmount(t.totalAmount))
@@ -1350,17 +1374,19 @@ void findNewTransactions(CryptoNote::INode &node,
     if (walletHeight == 1)
     {
         std::cout << "Scanning through the blockchain to find transactions "
-                     "that belong to you." << std::endl
-                     << "Please wait, this will take some time."
-                     << std::endl << std::endl;
+                  << "that belong to you." << std::endl
+                  << "Please wait, this will take some time."
+                  << std::endl << std::endl;
     }
     else
     {
         std::cout << "Scanning through the blockchain to find any new "
-                     "transactions you received whilst your wallet wasn't "
-                     "open." << std::endl
-                     << "Please wait, this may take some time."
-                     << std::endl << std::endl;
+                  << "transactions you received"
+                  << std::endl
+                  << "whilst your wallet wasn't open."
+                  << std::endl
+                  << "Please wait, this may take some time."
+                  << std::endl << std::endl;
     }
 
     while (walletHeight < localHeight)

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1354,7 +1354,9 @@ void findNewTransactions(CryptoNote::INode &node,
     {
         std::cout << "Your TurtleCoind isn't fully synced yet!" << std::endl
                   << "Until you are fully synced, you won't be able to send "
-                  << "transactions, and your balance may be missing or "
+                  << "transactions,"
+                  << std::endl
+                  << "and your balance may be missing or "
                   << "incorrect!" << std::endl << std::endl;
     }
 
@@ -1481,7 +1483,8 @@ void findNewTransactions(CryptoNote::INode &node,
         std::this_thread::sleep_for(std::chrono::seconds(waitSeconds));
     }
 
-    std::cout << SuccessMsg("Finished scanning blockchain!") << std::endl
+    std::cout << std::endl
+              << SuccessMsg("Finished scanning blockchain!") << std::endl
               << std::endl;
 
     /* In case the user force closes, we don't want them to have to rescan

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -105,9 +105,9 @@ bool confirmTransaction(CryptoNote::TransactionParameters t,
     }
     
     std::cout << std::endl << std::endl
-              << "FROM: " << InformationMsg(walletInfo->walletFileName)
+              << "FROM: " << SuccessMsg(walletInfo->walletFileName)
               << std::endl
-              << "TO: " << InformationMsg(t.destinations[0].address)
+              << "TO: " << SuccessMsg(t.destinations[0].address)
               << std::endl << std::endl;
 
     if (confirm("Is this correct?"))
@@ -154,8 +154,10 @@ void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
                 CryptoNote::WalletTransaction sentTx 
                     = wallet.getTransaction(id);
 
-                std::cout << SuccessMsg("Transaction has been sent! ID:\n" + 
-                                        Common::podToHex(sentTx.hash))
+                std::cout << SuccessMsg("Transaction has been sent!")
+                          << std::endl
+                          << SuccessMsg("Hash: " 
+                                      + Common::podToHex(sentTx.hash))
                           << std::endl << std::endl;
 
                 break;
@@ -343,7 +345,7 @@ void quickOptimize(CryptoNote::WalletGreen &wallet)
 
 void fullOptimize(CryptoNote::WalletGreen &wallet)
 {
-    std::cout << "Attempting to fully optimize your wallet to allow you to "
+    std::cout << "Attempting to optimize your wallet to allow you to "
               << "send large amounts at once. " << std::endl
               << WarningMsg("This may take a very long time!") << std::endl;
 
@@ -414,14 +416,14 @@ bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold)
     if (fusionTransactionHashes.size() == 1)
     {
         std::cout << SuccessMsg("1 fusion transaction has been sent, waiting "
-                                "for balance to return and unlock...")
+                                "for balance to return and unlock")
                   << std::endl << std::endl;
     }
     else
     {
         std::cout << SuccessMsg(std::to_string(fusionTransactionHashes.size()) +
                                 " fusion transactions have been sent, waiting "
-                                "for balance to return and unlock...")
+                                "for balance to return and unlock")
               << std::endl << std::endl;
     }
 
@@ -563,8 +565,9 @@ void fusionTX(CryptoNote::WalletGreen &wallet,
             size_t id = wallet.transfer(p);
             CryptoNote::WalletTransaction tx = wallet.getTransaction(id);
 
-            std::cout << SuccessMsg("Transaction has been sent! ID:\n" 
-                                + Common::podToHex(tx.hash))
+            std::cout << SuccessMsg("Transaction has been sent!")
+                      << std::endl
+                      << SuccessMsg("Hash:" + Common::podToHex(tx.hash))
                       << std::endl;
         }
     }
@@ -750,7 +753,7 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo)
     if (balance < amount + fee)
     {
         std::cout << WarningMsg("You don't have enough funds to cover this "
-                            "transaction!") << std::endl
+                                "transaction!") << std::endl
                   << InformationMsg("Funds needed: " 
                                   + formatAmount(amount + fee))
                   << std::endl
@@ -843,8 +846,10 @@ void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                 CryptoNote::WalletTransaction tx 
                     = walletInfo->wallet.getTransaction(id);
 
-                std::cout << SuccessMsg("Transaction has been sent! ID:\n" 
-                                      + Common::podToHex(tx.hash)) << std::endl;
+                std::cout << SuccessMsg("Transaction has been sent!")
+                          << SuccessMsg("Hash: " + 
+                                        Common::podToHex(tx.hash))
+                          << std::endl;
             }
         }
         catch (const std::system_error &e)
@@ -951,8 +956,9 @@ Maybe<std::string> getPaymentID()
                   << std::endl 
                   << "These are usually used for sending to exchanges."
                   << std::endl
-                  << WarningMsg("Warning: if you were given a payment ID, you "
-                                "MUST use it, or your funds may be lost!")
+                  << WarningMsg("Warning: if you were given a payment ID,")
+                  << std::endl
+                  << WarningMsg("you MUST use it, or your funds may be lost!")
                   << std::endl
                   << "Hit enter for the default of no payment ID: ";
 
@@ -1113,7 +1119,11 @@ bool parseFee(std::string feeString)
     if (!parseAmount(feeString, fee))
     {
         std::cout << WarningMsg("Failed to parse fee! Ensure you entered the "
-                                "value correctly.") << std::endl;
+                                "value correctly.")
+                  << std::endl
+                  << "Please note, you can only use 2 decimal places."
+                  << std::endl;
+
         return false;
     }
     else if (fee < CryptoNote::parameters::MINIMUM_FEE)
@@ -1156,7 +1166,7 @@ bool parseAddress(std::string address)
         std::cout << WarningMsg("Address is wrong length!") << std::endl
                   << "It should be " << expectedLen
                   << " characters long, but it is " << address.length()
-                  << " characters long!" << std::endl;
+                  << " characters long!" << std::endl << std::endl;
 
         return false;
     }
@@ -1165,7 +1175,7 @@ bool parseAddress(std::string address)
     else if (prefix != expectedPrefix)
     {
         std::cout << WarningMsg("Invalid address! It should start with "
-                                "\"TRTL\"!") << std::endl;
+                                "\"TRTL\"!") << std::endl << std::endl;
 
         return false;
     }
@@ -1212,7 +1222,8 @@ bool parseAmount(std::string amountString)
         std::cout << WarningMsg("Failed to parse amount! Ensure you entered "
                                 "the value correctly.")
                   << std::endl
-                  << "Please note, the minimum you can send is 0.01 TRTL, "
+                  << "Please note, the minimum you can send is 0.01 TRTL,"
+                  << std::endl
                   << "and you can only use 2 decimal places."
                   << std::endl;
 


### PR DESCRIPTION
When devving I was using a bigger terminal and didn't realise some of the messages got truncated and looked a bit ugly in a standard windows command prompt.