### PR TITLE
Remove connectivitytool references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,10 @@ RUN apt-get update && \
     cp src/walletd /usr/local/bin/walletd && \
     cp src/simplewallet /usr/local/bin/simplewallet && \
     cp src/miner /usr/local/bin/miner && \
-    cp src/connectivity_tool /usr/local/bin/connectivity_tool && \
     strip /usr/local/bin/TurtleCoind && \
     strip /usr/local/bin/walletd && \
     strip /usr/local/bin/simplewallet && \
     strip /usr/local/bin/miner && \
-    strip /usr/local/bin/connectivity_tool && \
     cd / && \
     rm -rf /src/turtlecoin && \
     apt-get remove -y build-essential python-dev gcc-4.9 g++-4.9 git cmake libboost1.58-all-dev librocksdb-dev && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -35,12 +35,10 @@ RUN apt-get update && \
     cp src/walletd /usr/local/bin/walletd && \
     cp src/simplewallet /usr/local/bin/simplewallet && \
     cp src/miner /usr/local/bin/miner && \
-    cp src/connectivity_tool /usr/local/bin/connectivity_tool && \
     strip /usr/local/bin/TurtleCoind && \
     strip /usr/local/bin/walletd && \
     strip /usr/local/bin/simplewallet && \
     strip /usr/local/bin/miner && \
-    strip /usr/local/bin/connectivity_tool && \
     cd / && \
     rm -rf /src/turtlecoin && \
     apt-get remove -y build-essential python-dev gcc-4.9 g++-4.9 git cmake libboost1.58-all-dev librocksdb-dev && \


### PR DESCRIPTION
ConnectivityTool was removed in https://github.com/turtlecoin/turtlecoin/commit/f51b2f0851e6bb7a24dad51cd3132a3e4b5058cb, but is still referenced in the Dockerfile, and so the docker image fails to build.

This PR just removes these references.