### PR TITLE
BUG FIX: RPC Death on Socket Error

### DIFF
--- a/src/Rpc/HttpServer.cpp
+++ b/src/Rpc/HttpServer.cpp
@@ -62,11 +62,11 @@ void HttpServer::acceptLoop() {
     BOOST_SCOPE_EXIT_ALL(this, &connection) { 
       m_connections.erase(&connection); };
 
+    workingContextGroup.spawn(std::bind(&HttpServer::acceptLoop, this));
+
     auto addr = connection.getPeerAddressAndPort();
 
     logger(DEBUGGING) << "Incoming connection from " << addr.first.toDottedDecimal() << ":" << addr.second;
-
-    workingContextGroup.spawn(std::bind(&HttpServer::acceptLoop, this));
 
     System::TcpStreambuf streambuf(connection);
     std::iostream stream(&streambuf);


### PR DESCRIPTION
The long story short here is the the underlying socket encountered a condition where it would throw an exception and the recursive loop would not fire. Thus, when the socket threw the error, the RPC service would stop accepting connections. The NetNode would still be running and sync would be maintained; however, with the RPC server completely unresponsive the daemon appears dead.

This fix, if you will, calls the recursive loop binding before the possibility of the socket throwing the exception thereby allowing the RPC server to continue to accept new connections despite a socket throwing an error.

Pass some love to @yamiM0NSTER as the original way I was attacking this was far more convoluted and his suggestion of moving the bind statement before the socket call is a quick fix.