### PR TITLE
Mention both wallet names when failing to find wallet

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -639,8 +639,11 @@ std::string getExistingWalletFileName(Config &config)
         }
         else
         {
-            std::cout << WarningMsg("A wallet with the filename " 
-                                  + walletFileName + " doesn't exist!")
+            std::cout << WarningMsg("A wallet with the filename ")
+                      << InformationMsg(walletName)
+                      << WarningMsg(" or ")
+                      << InformationMsg(walletFileName)
+                      << WarningMsg(" doesn't exist!")
                       << std::endl
                       << "Ensure you entered your wallet name correctly."
                       << std::endl;


### PR DESCRIPTION
If you're trying to open a wallet file `foobar`, and the wallet file doesn't exist, it would throw a message
"A wallet with the filename foobar.wallet doesn't exist!". This should instead mention both `foobar.wallet` and `foobar`, to avoid confusion.