### PR TITLE
Cap mixin to reasonable levels

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -53,7 +53,12 @@ const size_t   CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE        = 600;
 const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 2;
 const uint64_t MINIMUM_FEE                                   = UINT64_C(10);
 const uint16_t DEFAULT_MIXIN                                 = 5;
-const uint16_t MINIMUM_MIXIN                                 = 3;
+/* minimum_mixin = enforced for deamon
+   minimum_mixin_no_dust = enforced for simplewallet, when dust is not present
+   if dust is present, 0 mixin allowed. Possibly later disabled, or relegated to sweep_unmixable */
+const uint16_t MINIMUM_MIXIN_NO_DUST                         = 3;
+const uint16_t MINIMUM_MIXIN                                 = 0;
+const uint16_t MAXIMUM_MIXIN                                 = 100;
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(10);
 
 const uint64_t DIFFICULTY_TARGET                             = 30; // seconds

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -933,21 +933,13 @@ bool Core::addTransactionToPool(const BinaryArray& transactionBinaryArray) {
 }
 
 bool Core::addTransactionToPool(CachedTransaction&& cachedTransaction) {
-  auto transactionHash = cachedTransaction.getTransactionHash();
-
-  /* 2000 mixin transaction hash crashes daemons... */
-  if (Common::podToHex(transactionHash) == "f0e956833c62e6d5047c25998a34b75938af035b8011a5ffb39c55924833ca2a")
-  {
-      logger(Logging::DEBUGGING) << "Ignoring bad transaction hash";
-      return false;
-  }
-
   TransactionValidatorState validatorState;
 
   if (!isTransactionValidForPool(cachedTransaction, validatorState)) {
     return false;
   }
 
+  auto transactionHash = cachedTransaction.getTransactionHash();
 
   if (!transactionPool->pushTransaction(std::move(cachedTransaction), std::move(validatorState))) {
     logger(Logging::DEBUGGING) << "Failed to push transaction " << transactionHash << " to pool, already exists";
@@ -959,6 +951,44 @@ bool Core::addTransactionToPool(CachedTransaction&& cachedTransaction) {
 }
 
 bool Core::isTransactionValidForPool(const CachedTransaction& cachedTransaction, TransactionValidatorState& validatorState) {
+  uint64_t mixin = 0;
+
+  auto tx = createTransaction(cachedTransaction.getTransaction());
+
+  for (size_t i = 0; i < tx->getInputCount(); ++i) {
+    if (tx->getInputType(i) != TransactionTypes::InputType::Key) {
+      continue;
+    }
+
+    KeyInput input;
+    tx->getInput(i, input);
+    uint64_t currentMixin = input.outputIndexes.size();
+    if (currentMixin > mixin) {
+        mixin = currentMixin;
+    }
+  }
+
+  /* Note that the mixin calculated here is one more than the mixin you input
+     in your transaction. This is checking the number of outputs, for example,
+     5, where yours is one of them. Mixin 4 = mix my output with 4 others,
+     so 5 outputs. So, we add one here. */
+  uint64_t minMixin = CryptoNote::parameters::MINIMUM_MIXIN + 1;
+  uint64_t maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN + 1;
+
+  if (mixin > maxMixin) {
+    logger(Logging::DEBUGGING) << "Transaction " << cachedTransaction.getTransactionHash()
+      << " is not valid. Reason: transaction mixin is too large (" << mixin
+      << "). Maximum mixin allowed is " << maxMixin;
+
+    return false;
+  } else if (mixin < minMixin) {
+    logger(Logging::DEBUGGING) << "Transaction " << cachedTransaction.getTransactionHash()
+      << " is not valid. Reason: transaction mixin is too small (" << mixin
+      << "). Minimum mixin allowed is " << minMixin;
+
+    return false;
+  }
+
   uint64_t fee;
 
   if (auto validationResult = validateTransaction(cachedTransaction, validatorState, chainsLeaves[0], fee, getTopBlockIndex())) {

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -282,6 +282,18 @@ void validateAddresses(const std::vector<std::string>& addresses, const CryptoNo
   }
 }
 
+void validateMixin(const uint32_t mixin, Logging::LoggerRef logger) {
+  if (mixin < CryptoNote::parameters::MINIMUM_MIXIN) {
+    logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Mixin " << mixin
+      << " under minimum threshold " << CryptoNote::parameters::MINIMUM_MIXIN;
+    throw std::system_error(make_error_code(CryptoNote::error::MIXIN_BELOW_THRESHOLD));
+  } else if (mixin > CryptoNote::parameters::MAXIMUM_MIXIN) {
+    logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Mixin " << mixin
+      << " above maximum threshold " << CryptoNote::parameters::MAXIMUM_MIXIN;
+    throw std::system_error(make_error_code(CryptoNote::error::MIXIN_ABOVE_THRESHOLD));
+  }
+}
+
 std::string getValidatedTransactionExtraString(const std::string& extraString) {
   std::vector<uint8_t> binary;
   if (!Common::fromHex(extraString, binary)) {
@@ -916,6 +928,8 @@ std::error_code WalletService::sendTransaction(const SendTransaction::Request& r
     if (!request.changeAddress.empty()) {
       validateAddresses({ request.changeAddress }, currency, logger);
     }
+
+    validateMixin(request.anonymity, logger);
 
     CryptoNote::TransactionParameters sendParams;
     if (!request.paymentId.empty()) {

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -1176,13 +1176,28 @@ bool parseMixin(std::string mixinString)
            to parse as it's a uint16_t? */
         uint16_t mixin = std::stoi(mixinString);
 
-        uint16_t minMixin = CryptoNote::parameters::MINIMUM_MIXIN;
+        /* Force them to use a set mixin, if we detect dust later, then we
+           will allow them to use 0 mixin. */
+        uint16_t minMixin = std::max(CryptoNote::parameters
+                                               ::MINIMUM_MIXIN_NO_DUST,
+                                     CryptoNote::parameters::MINIMUM_MIXIN);
+
+        uint16_t maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN;
 
         if (mixin < minMixin)
         {
             std::cout << WarningMsg("Mixin count is too small! "
                                     "Minimum allowed is " + 
-                                    std::to_string(minMixin)) << "." 
+                                    std::to_string(minMixin) + ".")
+                                    << std::endl;
+
+            return false;
+        }
+        else if (mixin > maxMixin)
+        {
+            std::cout << WarningMsg("Mixin count is too large! "
+                                    "Maximum allowed is " +
+                                    std::to_string(maxMixin) + ".")
                                     << std::endl;
 
             return false;

--- a/src/Wallet/WalletErrors.h
+++ b/src/Wallet/WalletErrors.h
@@ -54,7 +54,9 @@ enum WalletErrorCodes {
   DESTINATION_ADDRESS_REQUIRED,
   DESTINATION_ADDRESS_NOT_FOUND,
   BAD_PAYMENT_ID,
-  BAD_TRANSACTION_EXTRA
+  BAD_TRANSACTION_EXTRA,
+  MIXIN_BELOW_THRESHOLD,
+  MIXIN_ABOVE_THRESHOLD
 };
 
 // custom category:
@@ -101,6 +103,8 @@ public:
     case DESTINATION_ADDRESS_NOT_FOUND: return "Destination address not found";
     case BAD_PAYMENT_ID:                return "Wrong payment id format";
     case BAD_TRANSACTION_EXTRA:         return "Wrong transaction extra format";
+    case MIXIN_BELOW_THRESHOLD:         return "Mixin below minimum allowed threshold";
+    case MIXIN_ABOVE_THRESHOLD:         return "Mixin above maximum allowed threshold";
     default:                            return "Unknown error";
     }
   }


### PR DESCRIPTION
Current limits are 0 - 100. Of course we want to ban 0 mixin later on, but it's not feasible to do without a grace period. This makes transactions out of those limits not get added to the transaction pool. Simplewallet will prevent you from making a transaction outside of those limits, and as will walletd.

Walletd will return a json response like so:

`{'code': -32700, 'data': {'application_code': 32}, 'message': 'Mixin above maximum allowed threshold'}`