### PR TITLE
Better tx limits

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -28,7 +28,6 @@ namespace parameters {
 const uint32_t CRYPTONOTE_MAX_BLOCK_NUMBER                   = 500000000;
 const size_t   CRYPTONOTE_MAX_BLOCK_BLOB_SIZE                = 500000000;
 const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
-const size_t   CRYPTONOTE_MAX_SAFE_TX_SIZE                   = 115000;
 const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 3914525;
 const uint32_t CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 40;
 const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT            = 60 * 60 * 2;

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -190,7 +190,7 @@ void splitTx(CryptoNote::WalletGreen &wallet,
 
     CryptoNote::TransactionParameters restoreInitialTx = p;
 
-    uint64_t maxSize = CryptoNote::parameters::CRYPTONOTE_MAX_SAFE_TX_SIZE;
+    uint64_t maxSize = wallet.getMaxTxSize();
     size_t txSize = wallet.getTxSize(p);
     uint64_t minFee = CryptoNote::parameters::MINIMUM_FEE;
 

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -88,6 +88,7 @@ public:
   virtual void rollbackUncommitedTransaction(size_t) override;
   bool txIsTooLarge(const TransactionParameters& sendingTransaction);
   size_t getTxSize(const TransactionParameters &sendingTransaction);
+  size_t getMaxTxSize();
   void updateInternalCache();
   void clearCaches(bool clearTransactions, bool clearCachedData);
   void clearCacheAndShutdown();
@@ -375,7 +376,6 @@ protected:
   uint64_t m_actualBalance;
   uint64_t m_pendingBalance;
 
-  uint64_t m_upperTransactionSizeLimit;
   uint32_t m_transactionSoftLockTime;
 
   BlockHashesContainer m_blockchain;


### PR DESCRIPTION
After consulting the code I found the correct formula for determining block size, and hence the max size of a transaction that can fit in a block. This is well explained in the comment in WalletGreen.cpp.

It was decided to use the lower bound, so any submitted transaction will always fit in a block, rather than using the theoretical maximum, which could potentially result in a few transactions stuck in the pool.