### PR TITLE
Verify mixin of block transactions

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -57,8 +57,9 @@ const uint16_t DEFAULT_MIXIN                                 = 5;
    minimum_mixin_no_dust = enforced for simplewallet, when dust is not present
    if dust is present, 0 mixin allowed. Possibly later disabled, or relegated to sweep_unmixable */
 const uint16_t MINIMUM_MIXIN_NO_DUST                         = 3;
-const uint16_t MINIMUM_MIXIN                                 = 0;
-const uint16_t MAXIMUM_MIXIN                                 = 100;
+const uint16_t MINIMUM_MIXIN_V1                              = 0;
+const uint16_t MAXIMUM_MIXIN_V1                              = 100;
+const uint32_t MIXIN_LIMITS_V1_HEIGHT                        = 450000;
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(10);
 
 const uint64_t DIFFICULTY_TARGET                             = 30; // seconds

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -147,6 +147,7 @@ private:
 
   std::error_code validateSemantic(const Transaction& transaction, uint64_t& fee, uint32_t blockIndex);
   std::error_code validateTransaction(const CachedTransaction& transaction, TransactionValidatorState& state, IBlockchainCache* cache, uint64_t& fee, uint32_t blockIndex);
+  bool validateMixin(const CachedTransaction& transaction, uint16_t minMixin, uint16_t maxMixin);
   
   uint32_t findBlockchainSupplement(const std::vector<Crypto::Hash>& remoteBlockIds) const;
   std::vector<Crypto::Hash> getBlockHashes(uint32_t startBlockIndex, uint32_t maxCount) const;

--- a/src/CryptoNoteCore/TransactionValidationErrors.h
+++ b/src/CryptoNoteCore/TransactionValidationErrors.h
@@ -46,7 +46,8 @@ enum class TransactionValidationError {
   OUTPUT_UNKNOWN_TYPE,
   OUTPUTS_AMOUNT_OVERFLOW,
   WRONG_AMOUNT,
-  WRONG_TRANSACTION_UNLOCK_TIME
+  WRONG_TRANSACTION_UNLOCK_TIME,
+  INVALID_MIXIN
 };
 
 // custom category:
@@ -89,6 +90,7 @@ public:
       case TransactionValidationError::OUTPUTS_AMOUNT_OVERFLOW: return "Transaction has outputs amount overflow";
       case TransactionValidationError::WRONG_AMOUNT: return "Transaction wrong amount";
       case TransactionValidationError::WRONG_TRANSACTION_UNLOCK_TIME: return "Transaction has wrong unlock time";
+      case TransactionValidationError::INVALID_MIXIN: return "Mixin too large or too small";
       default: return "Unknown error";
     }
   }

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -283,13 +283,13 @@ void validateAddresses(const std::vector<std::string>& addresses, const CryptoNo
 }
 
 void validateMixin(const uint32_t mixin, Logging::LoggerRef logger) {
-  if (mixin < CryptoNote::parameters::MINIMUM_MIXIN) {
+  if (mixin < CryptoNote::parameters::MINIMUM_MIXIN_V1) {
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Mixin " << mixin
-      << " under minimum threshold " << CryptoNote::parameters::MINIMUM_MIXIN;
+      << " under minimum threshold " << CryptoNote::parameters::MINIMUM_MIXIN_V1;
     throw std::system_error(make_error_code(CryptoNote::error::MIXIN_BELOW_THRESHOLD));
-  } else if (mixin > CryptoNote::parameters::MAXIMUM_MIXIN) {
+  } else if (mixin > CryptoNote::parameters::MAXIMUM_MIXIN_V1) {
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Mixin " << mixin
-      << " above maximum threshold " << CryptoNote::parameters::MAXIMUM_MIXIN;
+      << " above maximum threshold " << CryptoNote::parameters::MAXIMUM_MIXIN_V1;
     throw std::system_error(make_error_code(CryptoNote::error::MIXIN_ABOVE_THRESHOLD));
   }
 }

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -1180,9 +1180,9 @@ bool parseMixin(std::string mixinString)
            will allow them to use 0 mixin. */
         uint16_t minMixin = std::max(CryptoNote::parameters
                                                ::MINIMUM_MIXIN_NO_DUST,
-                                     CryptoNote::parameters::MINIMUM_MIXIN);
+                                     CryptoNote::parameters::MINIMUM_MIXIN_V1);
 
-        uint16_t maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN;
+        uint16_t maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V1;
 
         if (mixin < minMixin)
         {


### PR DESCRIPTION
To follow up from the previous patch, @SoreGums pointed out that that patch only prevented transactions with mixin out of bounds being included in the pool, but an un-updated/malicious daemon could still include the transaction into a block, which would then cause daemons to crash regardless.

This has tentatively been put at an upgrade height of 450,000. We cannot instantly apply this, as it would prevent new users syncing any previous blocks which fell out of the current mixin bounds. However, this is not hard fork required. Provided no-one submits a block with out of bounds mixin nothing will happen, and if one is, if enough pools are updated then they will just ignore that block.

These bounds have been renamed to be versioned, when mixin bounds change in the future, we can check if the height is above the upgrade point, and apply the mixin bounds for when the block was submitted.

If that's a bit confusing, what I mean is if someone submitted a block today with 1 mixin, that would be valid. If we later update the bounds to ban mixin below 3 for example, that block is still valid at the time it was created. So, version our bounds.