### PR TITLE
Cleanup the version commands for poolwallet, walletd, and miner.

### DIFF
--- a/src/Miner/MiningConfig.cpp
+++ b/src/Miner/MiningConfig.cpp
@@ -65,7 +65,8 @@ void parseDaemonAddress(const std::string& daemonAddress, std::string& daemonHos
 
 MiningConfig::MiningConfig(): help(false) {
   cmdOptions.add_options()
-      ("help,h", "produce this help message and exit")
+      ("help,h", "Produce this help message and exit")
+      ("version", "Print the version number and exit")
       ("address", po::value<std::string>(), "Valid cryptonote miner's address")
       ("daemon-host", po::value<std::string>()->default_value(DEFAULT_DAEMON_HOST), "Daemon host")
       ("daemon-rpc-port", po::value<uint16_t>()->default_value(static_cast<uint16_t>(RPC_DEFAULT_PORT)), "Daemon's RPC port")
@@ -86,6 +87,11 @@ void MiningConfig::parse(int argc, char** argv) {
 
   if (options.count("help") != 0) {
     help = true;
+    return;
+  }
+
+  if (options.count("version") != 0) {
+    version = true;
     return;
   }
 
@@ -133,6 +139,10 @@ void MiningConfig::parse(int argc, char** argv) {
 
 void MiningConfig::printHelp() {
   std::cout << cmdOptions << std::endl;
+}
+
+void MiningConfig::printVersion() {
+  std::cout << "TurtleCoin v" << PROJECT_VERSION << " Miner" << std::endl;
 }
 
 }

--- a/src/Miner/MiningConfig.h
+++ b/src/Miner/MiningConfig.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "version.h"
+
 #include <cstdint>
 #include <string>
 
@@ -27,6 +29,7 @@ struct MiningConfig {
 
   void parse(int argc, char** argv);
   void printHelp();
+  void printVersion();
 
   std::string miningAddress;
   std::string daemonHost;
@@ -38,6 +41,7 @@ struct MiningConfig {
   uint64_t firstBlockTimestamp;
   int64_t blockTimestampInterval;
   bool help;
+  bool version;
 };
 
 } //namespace CryptoNote

--- a/src/Miner/main.cpp
+++ b/src/Miner/main.cpp
@@ -35,6 +35,11 @@ int main(int argc, char** argv) {
       return 0;
     }
 
+    if (config.version) {
+      config.printVersion();
+      return 0;
+    }
+
     Logging::LoggerGroup loggerGroup;
     Logging::ConsoleLogger consoleLogger(static_cast<Logging::Level>(config.logLevel));
     loggerGroup.addLogger(consoleLogger);

--- a/src/PaymentGateService/ConfigurationManager.cpp
+++ b/src/PaymentGateService/ConfigurationManager.cpp
@@ -76,7 +76,7 @@ bool ConfigurationManager::init(int argc, char** argv) {
   }
 
   if (cmdOptions.count("version") > 0) {
-    std::cout << "walletd v" << PROJECT_VERSION_LONG;
+    std::cout << "walletd v" << PROJECT_VERSION_LONG << std::endl;
     return false;
   }
 

--- a/src/PoolWallet/PoolWallet.cpp
+++ b/src/PoolWallet/PoolWallet.cpp
@@ -1592,7 +1592,7 @@ int main(int argc, char* argv[]) {
       std::cout << desc_all << '\n' << tmp_wallet.get_commands_str();
       return false;
     } else if (command_line::get_arg(vm, command_line::arg_version))  {
-      std::cout << CRYPTONOTE_NAME << " wallet v" << PROJECT_VERSION_LONG;
+      std::cout << CRYPTONOTE_NAME << " wallet v" << PROJECT_VERSION_LONG << std::endl;
       return false;
     }
 


### PR DESCRIPTION
After testing different versions of the binaries, wanted to clean up some low hanging fruit...

* Added a new line to the end of the version for walletd and poolwallet.
* Added a command line option to miner to print the version.