### PR TITLE
Use LWMA difficulty algorithm [DON'T MERGE]

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -44,7 +44,7 @@ const size_t ZAWY_DIFFICULTY_V2                              = 0;
 const uint8_t ZAWY_DIFFICULTY_DIFFICULTY_BLOCK_VERSION       = 3;
 
 const uint64_t LWMA_DIFFICULTY_BLOCK_INDEX                   = 500000;
-const uint64_t DIFFICULTY_WINDOW_V3                          = 60;
+const uint64_t DIFFICULTY_WINDOW_V3                          = 80;
 const uint64_t DIFFICULTY_BLOCKS_COUNT_V3                    = DIFFICULTY_WINDOW_V3 + 1;
 
 const unsigned EMISSION_SPEED_FACTOR                         = 25;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -31,14 +31,22 @@ const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
 const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 3914525;
 const uint32_t CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 40;
 const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT            = 60 * 60 * 2;
+const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V3         = 400;
 
 const size_t   BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW             = 60;
+const size_t   BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3          = 11;
 
 // MONEY_SUPPLY - total number coins to be generated
 const uint64_t MONEY_SUPPLY                                  = UINT64_C(100000000000000);
+
 const uint32_t ZAWY_DIFFICULTY_BLOCK_INDEX                   = 187000;
 const size_t ZAWY_DIFFICULTY_V2                              = 0;
 const uint8_t ZAWY_DIFFICULTY_DIFFICULTY_BLOCK_VERSION       = 3;
+
+const uint64_t LWMA_DIFFICULTY_BLOCK_INDEX                   = 500000;
+const uint64_t DIFFICULTY_WINDOW_V3                          = 60;
+const uint64_t DIFFICULTY_BLOCKS_COUNT_V3                    = DIFFICULTY_WINDOW_V3 + 1;
+
 const unsigned EMISSION_SPEED_FACTOR                         = 25;
 const uint64_t GENESIS_BLOCK_REWARD                          = UINT64_C(0);
 static_assert(EMISSION_SPEED_FACTOR <= 8 * sizeof(uint64_t), "Bad EMISSION_SPEED_FACTOR");

--- a/src/CryptoNoteCore/BlockchainCache.cpp
+++ b/src/CryptoNoteCore/BlockchainCache.cpp
@@ -952,10 +952,10 @@ Difficulty BlockchainCache::getDifficultyForNextBlock() const {
 Difficulty BlockchainCache::getDifficultyForNextBlock(uint32_t blockIndex) const {
   assert(blockIndex <= getTopBlockIndex());
   uint8_t nextBlockMajorVersion = getBlockMajorVersionForHeight(blockIndex+1);
-  auto timestamps = getLastTimestamps(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion), blockIndex, skipGenesisBlock);
+  auto timestamps = getLastTimestamps(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion, blockIndex), blockIndex, skipGenesisBlock);
   auto commulativeDifficulties =
-      getLastCumulativeDifficulties(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion), blockIndex, skipGenesisBlock);
-  return currency.nextDifficulty(nextBlockMajorVersion, blockIndex, std::move(timestamps), std::move(commulativeDifficulties));
+      getLastCumulativeDifficulties(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion, blockIndex), blockIndex, skipGenesisBlock);
+  return currency.getNextDifficulty(nextBlockMajorVersion, blockIndex, std::move(timestamps), std::move(commulativeDifficulties));
 }
 
 Difficulty BlockchainCache::getCurrentCumulativeDifficulty() const {

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -519,12 +519,12 @@ Difficulty Core::getDifficultyForNextBlock() const {
 
   uint8_t nextBlockMajorVersion = getBlockMajorVersionForHeight(topBlockIndex);
 
-  size_t blocksCount = std::min(static_cast<size_t>(topBlockIndex), currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion));
+  size_t blocksCount = std::min(static_cast<size_t>(topBlockIndex), currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion, topBlockIndex));
 
   auto timestamps = mainChain->getLastTimestamps(blocksCount);
   auto difficulties = mainChain->getLastCumulativeDifficulties(blocksCount);
 
-  return currency.nextDifficulty(nextBlockMajorVersion, topBlockIndex, timestamps, difficulties);
+  return currency.getNextDifficulty(nextBlockMajorVersion, topBlockIndex, timestamps, difficulties);
 }
 
 std::vector<Crypto::Hash> Core::findBlockchainSupplement(const std::vector<Crypto::Hash>& remoteBlockIds,
@@ -1128,6 +1128,36 @@ bool Core::getBlockTemplate(BlockTemplate& b, const AccountPublicAddress& adr, c
   b.previousBlockHash = getTopBlockHash();
   b.timestamp = time(nullptr);
 
+  uint64_t blockchain_timestamp_check_window;
+  
+
+  if (height < CryptoNote::parameters::LWMA_DIFFICULTY_BLOCK_INDEX)
+  {
+      blockchain_timestamp_check_window = CryptoNote::parameters::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3;
+  }
+  /* Jagerman MTP Patch */
+  else
+  {
+      blockchain_timestamp_check_window = CryptoNote::parameters::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW;
+  }
+
+  if (height >= blockchain_timestamp_check_window)
+  {
+      std::vector<uint64_t> timestamps;
+
+      for (size_t offset = height - blockchain_timestamp_check_window; offset < height; offset++)
+      {
+          timestamps.push_back(getBlockTimestampByIndex(offset));
+      }
+
+      uint64_t median_ts = Common::medianValue(timestamps);
+
+      if (b.timestamp < median_ts)
+      {
+          b.timestamp = median_ts;
+      }
+  }
+
   size_t medianSize = calculateCumulativeBlocksizeLimit(height) / 2;
 
   assert(!chainsStorage.empty());
@@ -1471,7 +1501,7 @@ std::error_code Core::validateBlock(const CachedBlock& cachedBlock, IBlockchainC
     }
   }
 
-  if (block.timestamp > getAdjustedTime() + currency.blockFutureTimeLimit()) {
+  if (block.timestamp > getAdjustedTime() + currency.blockFutureTimeLimit(previousBlockIndex+1)) {
     return error::BlockValidationError::TIMESTAMP_TOO_FAR_IN_FUTURE;
   }
 

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1133,12 +1133,12 @@ bool Core::getBlockTemplate(BlockTemplate& b, const AccountPublicAddress& adr, c
 
   if (height < CryptoNote::parameters::LWMA_DIFFICULTY_BLOCK_INDEX)
   {
-      blockchain_timestamp_check_window = CryptoNote::parameters::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3;
+      blockchain_timestamp_check_window = CryptoNote::parameters::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW;
   }
   /* Jagerman MTP Patch */
   else
   {
-      blockchain_timestamp_check_window = CryptoNote::parameters::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW;
+      blockchain_timestamp_check_window = CryptoNote::parameters::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3;      
   }
 
   if (height >= blockchain_timestamp_check_window)

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -475,10 +475,6 @@ Difficulty Currency::nextDifficultyV3(std::vector<uint64_t> timestamps, std::vec
         cumulative_difficulties.resize(N+1);
     }
 
-    /* To get an average solvetime to within +/- ~0.1%, use an adjustment factor.
-       adjust=0.998 for N = 60 */
-    const double adjust = 0.998;
-
     /* The divisor k normalizes the LWMA sum to a standard LWMA. */
     const double k = N * (N + 1) / 2;
 
@@ -506,7 +502,7 @@ Difficulty Currency::nextDifficultyV3(std::vector<uint64_t> timestamps, std::vec
         LWMA = static_cast<double>(T / 4);
     }
 
-    nextDifficulty = harmonic_mean_D * T / LWMA * adjust;
+    nextDifficulty = harmonic_mean_D * T / LWMA;
 
     next_difficulty = static_cast<uint64_t>(nextDifficulty);
     return next_difficulty;

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/math/special_functions/round.hpp>
 #include "../Common/Base58.h"
 #include "../Common/int-util.h"
 #include "../Common/StringTools.h"
@@ -148,7 +149,12 @@ size_t Currency::difficultyCutByBlockVersion(uint8_t blockMajorVersion) const {
   }
 }
 
-size_t Currency::difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion) const {
+size_t Currency::difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion, uint32_t height) const {
+  if (height >= CryptoNote::parameters::LWMA_DIFFICULTY_BLOCK_INDEX)
+  {
+      return CryptoNote::parameters::DIFFICULTY_BLOCKS_COUNT_V3;
+  }
+
   return difficultyWindowByBlockVersion(blockMajorVersion) + difficultyLagByBlockVersion(blockMajorVersion);
 }
 
@@ -433,6 +439,77 @@ bool Currency::parseAmount(const std::string& str, uint64_t& amount) const {
   }
 
   return Common::fromString(strAmount, amount);
+}
+
+Difficulty Currency::getNextDifficulty(uint8_t version, uint32_t blockIndex, std::vector<uint64_t> timestamps, std::vector<Difficulty> cumulativeDifficulties) const
+{
+    if (blockIndex < CryptoNote::parameters::LWMA_DIFFICULTY_BLOCK_INDEX)
+    {
+        return nextDifficulty(version, blockIndex, timestamps, cumulativeDifficulties);
+    }
+    else
+    {
+        return nextDifficultyV3(timestamps, cumulativeDifficulties);
+    }
+}
+
+Difficulty Currency::nextDifficultyV3(std::vector<uint64_t> timestamps, std::vector<Difficulty> cumulative_difficulties) const
+{
+    const int64_t T = CryptoNote::parameters::DIFFICULTY_TARGET;
+    size_t N = CryptoNote::parameters::DIFFICULTY_WINDOW_V3;
+    int64_t FTL = CryptoNote::parameters::CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V3;
+
+    /* Return a difficulty of 1 for the first 3 blocks of a new chain */
+    if (timestamps.size() < 4)
+    {
+        return 1;
+    }
+    /* Use a smaller N if the start of the chain is less than N+1 */
+    else if (timestamps.size() < N+1)
+    {
+        N = timestamps.size() - 1;
+    }
+    else
+    {
+        timestamps.resize(N+1);
+        cumulative_difficulties.resize(N+1);
+    }
+
+    /* To get an average solvetime to within +/- ~0.1%, use an adjustment factor.
+       adjust=0.998 for N = 60 */
+    const double adjust = 0.998;
+
+    /* The divisor k normalizes the LWMA sum to a standard LWMA. */
+    const double k = N * (N + 1) / 2;
+
+    double LWMA = 0;
+    double sum_inverse_D = 0;
+    double harmonic_mean_D = 0;
+    double nextDifficulty = 0;
+    int64_t solveTime = 0;
+    uint64_t difficulty = 0;
+    uint64_t next_difficulty = 0;
+
+    for (size_t i = 1; i <= N; i++)
+    {
+        solveTime = static_cast<int64_t>(timestamps[i]) - static_cast<int64_t>(timestamps[i - 1]);
+        difficulty = cumulative_difficulties[i] - cumulative_difficulties[i - 1];
+        LWMA += (int64_t)(solveTime * i) / k;
+        sum_inverse_D += 1 / static_cast<double>(difficulty);
+    }
+
+    harmonic_mean_D = N / sum_inverse_D;
+
+    /* Limit LWMA same as Bitcoin's 1/4 in case something unforseen occurs. */
+    if (static_cast<int64_t>(boost::math::round(LWMA)) < T / 4)
+    {
+        LWMA = static_cast<double>(T / 4);
+    }
+
+    nextDifficulty = harmonic_mean_D * T / LWMA * adjust;
+
+    next_difficulty = static_cast<uint64_t>(nextDifficulty);
+    return next_difficulty;
 }
 
 Difficulty Currency::nextDifficulty(std::vector<uint64_t> timestamps,

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -42,6 +42,16 @@ public:
 
   size_t timestampCheckWindow() const { return m_timestampCheckWindow; }
   uint64_t blockFutureTimeLimit() const { return m_blockFutureTimeLimit; }
+  uint64_t blockFutureTimeLimit(uint32_t blockHeight) const {
+      if (blockHeight >= CryptoNote::parameters::LWMA_DIFFICULTY_BLOCK_INDEX)
+      {
+          return CryptoNote::parameters::CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V3;
+      }
+      else
+      {
+          return m_blockFutureTimeLimit;
+      }
+  }
 
   uint64_t moneySupply() const { return m_moneySupply; }
   unsigned int emissionSpeedFactor() const { return m_emissionSpeedFactor; }
@@ -69,7 +79,7 @@ size_t difficultyLagByBlockVersion(uint8_t blockMajorVersion) const;
   size_t difficultyCut() const { return m_difficultyCut; }
 size_t difficultyCutByBlockVersion(uint8_t blockMajorVersion) const;
   size_t difficultyBlocksCount() const { return m_difficultyWindow + m_difficultyLag; }
-size_t difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion) const;
+  size_t difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion, uint32_t height) const;
 
   size_t maxBlockSizeInitial() const { return m_maxBlockSizeInitial; }
   uint64_t maxBlockSizeGrowthSpeedNumerator() const { return m_maxBlockSizeGrowthSpeedNumerator; }
@@ -125,8 +135,11 @@ size_t difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion) const;
   std::string formatAmount(int64_t amount) const;
   bool parseAmount(const std::string& str, uint64_t& amount) const;
 
+  Difficulty getNextDifficulty(uint8_t version, uint32_t blockIndex, std::vector<uint64_t> timestamps, std::vector<Difficulty> cumulativeDifficulties) const;
+
   Difficulty nextDifficulty(std::vector<uint64_t> timestamps, std::vector<Difficulty> cumulativeDifficulties) const;
 Difficulty nextDifficulty(uint8_t version, uint32_t blockIndex, std::vector<uint64_t> timestamps, std::vector<Difficulty> cumulativeDifficulties) const;
+  Difficulty nextDifficultyV3(std::vector<uint64_t> timestamps, std::vector<Difficulty> cumulative_difficulties) const;
 
   bool checkProofOfWorkV1(Crypto::cn_context& context, const CachedBlock& block, Difficulty currentDifficulty) const;
   bool checkProofOfWorkV2(Crypto::cn_context& context, const CachedBlock& block, Difficulty currentDifficulty) const;

--- a/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
+++ b/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
@@ -1144,10 +1144,10 @@ Difficulty DatabaseBlockchainCache::getDifficultyForNextBlock() const {
 Difficulty DatabaseBlockchainCache::getDifficultyForNextBlock(uint32_t blockIndex) const {
   assert(blockIndex <= getTopBlockIndex());
   uint8_t nextBlockMajorVersion = getBlockMajorVersionForHeight(blockIndex+1);
-  auto timestamps = getLastTimestamps(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion), blockIndex, UseGenesis{false});
+  auto timestamps = getLastTimestamps(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion, blockIndex), blockIndex, UseGenesis{false});
   auto commulativeDifficulties =
-      getLastCumulativeDifficulties(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion), blockIndex, UseGenesis{false});
-  return currency.nextDifficulty(nextBlockMajorVersion, blockIndex, std::move(timestamps), std::move(commulativeDifficulties));
+      getLastCumulativeDifficulties(currency.difficultyBlocksCountByBlockVersion(nextBlockMajorVersion, blockIndex), blockIndex, UseGenesis{false});
+  return currency.getNextDifficulty(nextBlockMajorVersion, blockIndex, std::move(timestamps), std::move(commulativeDifficulties));
 }
 
 Difficulty DatabaseBlockchainCache::getCurrentCumulativeDifficulty() const {


### PR DESCRIPTION
Initial implementation of the LWMA algorithm by zawy: https://github.com/zawy12/difficulty-algorithms/issues/3

Issues:
- [ ] Needs to be tested on testnet

- [x] Waiting for a response from zawy on what N value to use (currently 60, as masari's)

- [ ] Need to send timestamps to zawy for verification

I was using masari as a reference implementation: https://github.com/masari-project/masari/commit/f8b4c4ddd1543a606703ad08b49eed8b3beebe2b but of course they are based on monero, and so there were some significant changes in the plumbing needed to be done to hook everything up, so there may be errors.

I put 500,000 as the upgrade height because it was the first round number I thought of, naturally this can be altered as needed.

There is an altered version based on zawy's latest algorithm here: https://github.com/ZedPea/turtlecoin/tree/lwma-v2
There is an alternate algorithm, EMA, here: https://github.com/ZedPea/turtlecoin/tree/ema

Currently we are testing out lwma-v2.