### PR TITLE
Fix appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,8 @@
 os: Visual Studio 2015
 
 environment:
-    BOOST_ROOT: C:\Libraries\boost_1_59_0
-    BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14
+    BOOST_ROOT: C:\Libraries\boost_1_67_0
+    BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14
 
 build_script:
     - md build


### PR DESCRIPTION
Appveyor removed support for boost 1.59 recently causing the automated builds to fail.

https://www.appveyor.com/docs/build-environment/#boost

Bump the boost version to the latest supported to prevent this happening for a while.