### PR TITLE
Fixes one compile failure whilst building on arm64

### DIFF
--- a/src/Platform/Linux/System/Dispatcher.h
+++ b/src/Platform/Linux/System/Dispatcher.h
@@ -84,13 +84,15 @@ public:
   void pushTimer(int timer);
 
 #ifdef __x86_64__
-# if __WORDSIZE == 64
-  static const int SIZEOF_PTHREAD_MUTEX_T = 40;
-# else
-  static const int SIZEOF_PTHREAD_MUTEX_T = 32;
-# endif
+    # if __WORDSIZE == 64
+    static const int SIZEOF_PTHREAD_MUTEX_T = 40;
+    # else
+    static const int SIZEOF_PTHREAD_MUTEX_T = 32;
+    # endif
+#elif __aarch64__
+static const int SIZEOF_PTHREAD_MUTEX_T = 48;
 #else
-  static const int SIZEOF_PTHREAD_MUTEX_T = 24;
+static const int SIZEOF_PTHREAD_MUTEX_T = 24;
 #endif
 
 private:


### PR DESCRIPTION
Crappy's currently trying to get turtlecoin built on arm64, and ran into an error with a static assert, this fixes that error. It will probably get stuck later on, but every bit helps...