### PR TITLE
Create get_diff_info.sh

### DIFF
--- a/scripts/get_diff_info.sh
+++ b/scripts/get_diff_info.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+ 
+# The host your rpc is running on
+host=127.0.0.1
+ 
+# The port your rpc is running on
+port=31898
+ 
+# If you only triggered the diff algo at a certain point
+startHeight=100
+ 
+# Get the current block height
+height=$(curl --silent -X POST -H "Accept:application/json" -d '{"jsonrpc":"2.0", "id":"test", "method":"getblockcount", "params":{}}' $host:$port/json_rpc | jq ".result.count")
+ 
+# Loop from start height to current height
+for i in $(seq $startHeight $height);
+do
+    # Get height, timestamp, and diff for given block height
+    result=$(curl --silent -X POST -H "Accept:application/json" -d '{"jsonrpc":"2.0", "id":"test", "method":"getblockheaderbyheight", "params":{"height" : '"$i"'}}' $host:$port/json_rpc | jq ".result.block_header | .height, .timestamp, .difficulty")
+    # Tab separate and print to stdout
+    echo $result | awk -v OFS="\t" '$1=$1'
+done


### PR DESCRIPTION
Dunno if this is helpful or not, it's just a quick script to get the height, timestamp, and diff of a block in a tab separated format, as zawy needs to verify any difficulty algorithms in testing.