### PR TITLE
Increase mixin limits and disable dust at next fork

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -51,15 +51,21 @@ const size_t   CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_CURRENT = CRYPTONOTE_BL
 const size_t   CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE        = 600;
 const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 2;
 const uint64_t MINIMUM_FEE                                   = UINT64_C(10);
-const uint16_t DEFAULT_MIXIN                                 = 5;
-/* minimum_mixin = enforced for deamon
-   minimum_mixin_no_dust = enforced for simplewallet, when dust is not present
-   if dust is present, 0 mixin allowed. Possibly later disabled, or relegated to sweep_unmixable */
-const uint16_t MINIMUM_MIXIN_NO_DUST                         = 3;
-const uint16_t MINIMUM_MIXIN_V1                              = 0;
-const uint16_t MAXIMUM_MIXIN_V1                              = 100;
+
+const uint64_t MINIMUM_MIXIN_V1                              = 0;
+const uint64_t MAXIMUM_MIXIN_V1                              = 100;
+const uint64_t MINIMUM_MIXIN_V2                              = 7;
+const uint64_t MAXIMUM_MIXIN_V2                              = 100;
+
+const uint64_t DEFAULT_MIXIN                                 = MINIMUM_MIXIN_V2 + 2;
+
 const uint32_t MIXIN_LIMITS_V1_HEIGHT                        = 440000;
+const uint32_t MIXIN_LIMITS_V2_HEIGHT                        = 600000;
+
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(10);
+const uint64_t DEFAULT_DUST_THRESHOLD_V2                     = UINT64_C(0);
+
+const uint32_t DUST_THRESHOLD_V2_HEIGHT                      = MIXIN_LIMITS_V2_HEIGHT;
 
 const uint64_t DIFFICULTY_TARGET                             = 30; // seconds
 const uint64_t EXPECTED_NUMBER_OF_BLOCKS_PER_DAY             = 24 * 60 * 60 / DIFFICULTY_TARGET;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -599,27 +599,12 @@ std::error_code Core::addBlock(const CachedBlock& cachedBlock, RawBlock&& rawBlo
     return error::BlockValidationError::DIFFICULTY_OVERHEAD;
   }
 
-  uint64_t cumulativeFee = 0;
-
-  /* We now limit the mixin allowed in a transaction. However, there have been
-     some transactions outside these limits in the past, so we need to only
-     enforce this on new blocks, otherwise wouldn't be able to sync the chain */
-
-  /* We also need to ensure that the mixin enforced is for the limit that
-     was correct when the block was formed - i.e. if 0 mixin was allowed at
-     block 100, but is no longer allowed - we should still validate block 100 */
-
-  /* In the future, change this to && <= MIXIN_LIMITS_V2_HEIGHT, then add a
-     new section with the new mixin limits */
-  if (blockIndex >= CryptoNote::parameters::MIXIN_LIMITS_V1_HEIGHT) {
-      for (const auto& transaction : transactions) {
-          if (!validateMixin(transaction,
-                             CryptoNote::parameters::MINIMUM_MIXIN_V1,
-                             CryptoNote::parameters::MAXIMUM_MIXIN_V1)) {
-              return error::TransactionValidationError::INVALID_MIXIN;
-          }
-      }
+  if (!validateMixin(transactions, blockIndex))
+  {
+      return error::TransactionValidationError::INVALID_MIXIN;
   }
+
+  uint64_t cumulativeFee = 0;
 
   for (const auto& transaction : transactions) {
     uint64_t fee = 0;
@@ -971,8 +956,41 @@ bool Core::addTransactionToPool(CachedTransaction&& cachedTransaction) {
   return true;
 }
 
+bool Core::validateMixin(const std::vector<CachedTransaction> transactions,
+                         uint32_t height)
+{
+    uint64_t minMixin = 0;
+    uint64_t maxMixin = std::numeric_limits<uint64_t>::max();
+
+    /* We now limit the mixin allowed in a transaction. However, there have been
+     some transactions outside these limits in the past, so we need to only
+     enforce this on new blocks, otherwise wouldn't be able to sync the chain */
+
+    /* We also need to ensure that the mixin enforced is for the limit that
+     was correct when the block was formed - i.e. if 0 mixin was allowed at
+     block 100, but is no longer allowed - we should still validate block 100 */
+    if (height >= CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
+    {
+        minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V2;
+        maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V2;
+    }
+    else if (height >= CryptoNote::parameters::MIXIN_LIMITS_V1_HEIGHT)
+    {
+        minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V1;
+        maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V1;
+    }
+
+    for (const auto& transaction : transactions)
+    {
+        if (!validateMixin(transaction, minMixin, maxMixin))
+        {
+            return false;
+        }
+    }
+}
+
 bool Core::validateMixin(const CachedTransaction& cachedTransaction,
-                         uint16_t minMixin, uint16_t maxMixin) {
+                         uint64_t minMixin, uint64_t maxMixin) {
 
   /* Note that the mixin calculated here is one more than the mixin you input
      in your transaction. This is checking the number of outputs, for example,
@@ -1016,10 +1034,9 @@ bool Core::validateMixin(const CachedTransaction& cachedTransaction,
 }
 
 bool Core::isTransactionValidForPool(const CachedTransaction& cachedTransaction, TransactionValidatorState& validatorState) {
-  if (!validateMixin(cachedTransaction,
-                     CryptoNote::parameters::MINIMUM_MIXIN_V1,
-                     CryptoNote::parameters::MAXIMUM_MIXIN_V1)) {
-    return false;
+  if (!validateMixin({cachedTransaction}, getTopBlockIndex()))
+  {
+      return false;
   }
   
   uint64_t fee;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -987,6 +987,8 @@ bool Core::validateMixin(const std::vector<CachedTransaction> transactions,
             return false;
         }
     }
+	
+    return true;
 }
 
 bool Core::validateMixin(const CachedTransaction& cachedTransaction,

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -152,7 +152,8 @@ private:
 
   std::error_code validateSemantic(const Transaction& transaction, uint64_t& fee, uint32_t blockIndex);
   std::error_code validateTransaction(const CachedTransaction& transaction, TransactionValidatorState& state, IBlockchainCache* cache, uint64_t& fee, uint32_t blockIndex);
-  bool validateMixin(const CachedTransaction& transaction, uint16_t minMixin, uint16_t maxMixin);
+  bool validateMixin(const CachedTransaction& transaction, uint64_t minMixin, uint64_t maxMixin);
+  bool validateMixin(std::vector<CachedTransaction> transactions, uint32_t height);
   
   uint32_t findBlockchainSupplement(const std::vector<Crypto::Hash>& remoteBlockIds) const;
   std::vector<Crypto::Hash> getBlockHashes(uint32_t startBlockIndex, uint32_t maxCount) const;

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -59,7 +59,14 @@ public:
   uint64_t coin() const { return m_coin; }
 
   uint64_t minimumFee() const { return m_mininumFee; }
-  uint64_t defaultDustThreshold() const { return m_defaultDustThreshold; }
+  uint64_t defaultDustThreshold(uint32_t height) const {
+      if (height >= CryptoNote::parameters::DUST_THRESHOLD_V2_HEIGHT)
+      {
+          return CryptoNote::parameters::DEFAULT_DUST_THRESHOLD_V2;
+      }
+
+      return m_defaultDustThreshold;
+  }
 
   uint64_t difficultyTarget() const { return m_difficultyTarget; }
   size_t difficultyWindow() const { return m_difficultyWindow; }
@@ -111,11 +118,11 @@ size_t difficultyBlocksCountByBlockVersion(uint8_t blockMajorVersion) const;
   bool constructMinerTx(uint8_t blockMajorVersion, uint32_t height, size_t medianSize, uint64_t alreadyGeneratedCoins, size_t currentBlockSize,
     uint64_t fee, const AccountPublicAddress& minerAddress, Transaction& tx, const BinaryArray& extraNonce = BinaryArray(), size_t maxOuts = 1) const;
 
-  bool isFusionTransaction(const Transaction& transaction) const;
-  bool isFusionTransaction(const Transaction& transaction, size_t size) const;
-  bool isFusionTransaction(const std::vector<uint64_t>& inputsAmounts, const std::vector<uint64_t>& outputsAmounts, size_t size) const;
-  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold) const;
-  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold, uint8_t& amountPowerOfTen) const;
+  bool isFusionTransaction(const Transaction& transaction, uint32_t height) const;
+  bool isFusionTransaction(const Transaction& transaction, size_t size, uint32_t height) const;
+  bool isFusionTransaction(const std::vector<uint64_t>& inputsAmounts, const std::vector<uint64_t>& outputsAmounts, size_t size, uint32_t height) const;
+  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold, uint32_t height) const;
+  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold, uint8_t& amountPowerOfTen, uint32_t height) const;
 
   std::string accountAddressAsString(const AccountBase& account) const;
   std::string accountAddressAsString(const AccountPublicAddress& accountPublicAddress) const;

--- a/src/SimpleWallet/Commands.cpp
+++ b/src/SimpleWallet/Commands.cpp
@@ -102,7 +102,7 @@ void help(bool viewWallet)
               << SuccessMsg("export_keys", 25)
               << "Export your private keys" << std::endl
               << SuccessMsg("address", 25)
-              << "Displays your payment address" << std::endl
+              << "Display your payment address" << std::endl
               << SuccessMsg("exit", 25)
               << "Exit and save your wallet" << std::endl
               << SuccessMsg("save", 25)
@@ -122,11 +122,8 @@ void help(bool viewWallet)
                   << "Show outgoing transfers" << std::endl
                   << SuccessMsg("list_transfers", 25)
                   << "Show all transfers" << std::endl
-                  << SuccessMsg("quick_optimize", 25)
-                  << "Quickly optimize your wallet to send large amounts"
-                  << std::endl
-                  << SuccessMsg("full_optimize", 25)
-                  << "Fully optimize your wallet to send large amounts"
+                  << SuccessMsg("optimize", 25)
+                  << "Optimize your wallet to send large amounts"
                   << std::endl
                   << SuccessMsg("transfer", 25)
                   << "Send TRTL to someone" << std::endl;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -519,20 +519,20 @@ void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node)
             }
             else if (command == "transfer")
             {
-                transfer(walletInfo);
+                transfer(walletInfo, node.getLastKnownBlockHeight());
             }
             else if (words[0] == "transfer")
             {
                 /* remove the first item from words - this is the "transfer"
                    command, leaving us just the transfer arguments. */
                 words.erase(words.begin());
-                transfer(walletInfo, words);
+                transfer(walletInfo, words, node.getLastKnownBlockHeight());
             }
             else if (command == "quick_optimize")
             {
                 quickOptimize(walletInfo->wallet);
             }
-            else if (command == "full_optimize")
+            else if (command == "full_optimize" || command == "optimize")
             {
                 fullOptimize(walletInfo->wallet);
             }

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -293,7 +293,7 @@ void splitTx(CryptoNote::WalletGreen &wallet,
 }
 
 void transfer(std::shared_ptr<WalletInfo> walletInfo,
-              std::vector<std::string> args)
+              std::vector<std::string> args, uint32_t height)
 {
     uint16_t mixin;
     std::string address;
@@ -386,10 +386,10 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo,
         }
     }
 
-    doTransfer(mixin, address, amount, fee, extra, walletInfo);
+    doTransfer(mixin, address, amount, fee, extra, walletInfo, height);
 }
 
-void transfer(std::shared_ptr<WalletInfo> walletInfo)
+void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height)
 {
     std::cout << InformationMsg("Note: You can type cancel at any time to "
                                 "cancel the transaction")
@@ -471,12 +471,13 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo)
 
     std::string extra = maybeExtra.x;
 
-    doTransfer(mixin, address, amount, fee, extra, walletInfo);
+    doTransfer(mixin, address, amount, fee, extra, walletInfo, height);
 }
 
 void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                 uint64_t fee, std::string extra,
-                std::shared_ptr<WalletInfo> walletInfo)
+                std::shared_ptr<WalletInfo> walletInfo,
+                uint32_t height)
 {
     uint64_t balance = walletInfo->wallet.getActualBalance();
 
@@ -594,25 +595,26 @@ void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                                   << std::endl;
                     }
 
-                    std::cout << "Try lowering the amount you are "
-                              << "sending in one transaction."
-                              << std::endl
-                              << "Alternatively, you can set the mixin "
-                              << "count to 0."
-                              << std::endl;
+                    std::cout << "Try lowering the amount you are sending "
+                              << "in one transaction." << std::endl;
 
-                    if(confirm("Retry transaction with mixin of 0? "
-                               "This will compromise privacy."))
+                    /* Mixin 0 not allowed after MIXIN_LIMITS_V2 */
+                    if (height < CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
                     {
-                        p.mixIn = 0;
-                        retried = true;
-                        continue;
+                        std::cout << "Alternatively, you can sent the mixin "
+                                  << "count to 0.";
+
+                        if(confirm("Retry transaction with mixin of 0? "
+                                   "This will compromise privacy."))
+                        {
+                            p.mixIn = 0;
+                            retried = true;
+                            continue;
+                        }
                     }
-                    else
-                    {
-                        std::cout << WarningMsg("Cancelling transaction.")
-                                  << std::endl;
-                    }
+
+                    std::cout << WarningMsg("Cancelling transaction.")
+                              << std::endl;
 
                     break;
                 }
@@ -917,11 +919,8 @@ bool parseMixin(std::string mixinString)
 
         /* Force them to use a set mixin, if we detect dust later, then we
            will allow them to use 0 mixin. */
-        uint16_t minMixin = std::max(CryptoNote::parameters
-                                               ::MINIMUM_MIXIN_NO_DUST,
-                                     CryptoNote::parameters::MINIMUM_MIXIN_V1);
-
-        uint16_t maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V1;
+        uint16_t minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V2;
+        uint16_t maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V2;
 
         if (mixin < minMixin)
         {

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -602,7 +602,7 @@ void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                     if (height < CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
                     {
                         std::cout << "Alternatively, you can sent the mixin "
-                                  << "count to 0.";
+                                  << "count to 0." << std::endl;
 
                         if(confirm("Retry transaction with mixin of 0? "
                                    "This will compromise privacy."))

--- a/src/SimpleWallet/Transfer.h
+++ b/src/SimpleWallet/Transfer.h
@@ -21,14 +21,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #include <SimpleWallet/Types.h>
 
-void transfer(std::shared_ptr<WalletInfo> walletInfo);
+void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height);
 
 void transfer(std::shared_ptr<WalletInfo> walletInfo,
-              std::vector<std::string> args);
+              std::vector<std::string> args, uint32_t height);
 
 void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                 uint64_t fee, std::string extra,
-                std::shared_ptr<WalletInfo> walletInfo);
+                std::shared_ptr<WalletInfo> walletInfo, uint32_t height);
 
 void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
                               std::vector<CryptoNote::TransactionParameters>

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1336,7 +1336,7 @@ void WalletGreen::prepareTransaction(std::vector<WalletOuts>&& wallets,
   preparedTransaction.neededMoney = countNeededMoney(preparedTransaction.destinations, fee);
 
   std::vector<OutputToTransfer> selectedTransfers;
-  uint64_t foundMoney = selectTransfers(preparedTransaction.neededMoney, mixIn == 0, m_currency.defaultDustThreshold(), std::move(wallets), selectedTransfers);
+  uint64_t foundMoney = selectTransfers(preparedTransaction.neededMoney, mixIn == 0, m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()), std::move(wallets), selectedTransfers);
 
   if (foundMoney < preparedTransaction.neededMoney) {
     m_logger(ERROR, BRIGHT_RED) << "Failed to create transaction: not enough money. Needed " << m_currency.formatAmount(preparedTransaction.neededMoney) <<
@@ -1354,10 +1354,10 @@ void WalletGreen::prepareTransaction(std::vector<WalletOuts>&& wallets,
   std::vector<InputInfo> keysInfo;
   prepareInputs(selectedTransfers, mixinResult, mixIn, keysInfo);
 
-  uint64_t donationAmount = pushDonationTransferIfPossible(donation, foundMoney - preparedTransaction.neededMoney, m_currency.defaultDustThreshold(), preparedTransaction.destinations);
+  uint64_t donationAmount = pushDonationTransferIfPossible(donation, foundMoney - preparedTransaction.neededMoney, m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()), preparedTransaction.destinations);
   preparedTransaction.changeAmount = foundMoney - preparedTransaction.neededMoney - donationAmount;
 
-  std::vector<ReceiverAmounts> decomposedOutputs = splitDestinations(preparedTransaction.destinations, m_currency.defaultDustThreshold(), m_currency);
+  std::vector<ReceiverAmounts> decomposedOutputs = splitDestinations(preparedTransaction.destinations, m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()), m_currency);
   if (preparedTransaction.changeAmount != 0) {
     WalletTransfer changeTransfer;
     changeTransfer.type = WalletTransferType::CHANGE;
@@ -1365,7 +1365,7 @@ void WalletGreen::prepareTransaction(std::vector<WalletOuts>&& wallets,
     changeTransfer.amount = static_cast<int64_t>(preparedTransaction.changeAmount);
     preparedTransaction.destinations.emplace_back(std::move(changeTransfer));
 
-    auto splittedChange = splitAmount(preparedTransaction.changeAmount, changeDestination, m_currency.defaultDustThreshold());
+    auto splittedChange = splitAmount(preparedTransaction.changeAmount, changeDestination, m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()));
     decomposedOutputs.emplace_back(std::move(splittedChange));
   }
 
@@ -3015,10 +3015,12 @@ size_t WalletGreen::createFusionTransaction(uint64_t threshold, uint16_t mixin,
 
   const size_t MAX_FUSION_OUTPUT_COUNT = 4;
 
-  if (threshold <= m_currency.defaultDustThreshold()) {
+  uint32_t height = m_node.getLastKnownBlockHeight();
+
+  if (threshold <= m_currency.defaultDustThreshold(height)) {
     m_logger(ERROR, BRIGHT_RED) << "Fusion transaction threshold is too small. Threshold " << m_currency.formatAmount(threshold) <<
-      ", minimum threshold " << m_currency.formatAmount(m_currency.defaultDustThreshold() + 1);
-    throw std::runtime_error("Threshold must be greater than " + m_currency.formatAmount(m_currency.defaultDustThreshold()));
+      ", minimum threshold " << m_currency.formatAmount(m_currency.defaultDustThreshold(height) + 1);
+    throw std::runtime_error("Threshold must be greater than " + m_currency.formatAmount(m_currency.defaultDustThreshold(height)));
   }
 
   if (m_walletsContainer.get<RandomAccessIndex>().size() == 0) {
@@ -3157,7 +3159,7 @@ bool WalletGreen::isFusionTransaction(const WalletTransaction& walletTx) const {
   if (outputsSum != inputsSum || outputsSum != txInfo.totalAmountOut || inputsSum != txInfo.totalAmountIn) {
     return false;
   } else {
-    return m_currency.isFusionTransaction(inputsAmounts, outputsAmounts, 0); //size = 0 here because can't get real size of tx in wallet.
+    return m_currency.isFusionTransaction(inputsAmounts, outputsAmounts, 0, m_node.getLastKnownBlockHeight()); //size = 0 here because can't get real size of tx in wallet.
   }
 }
 

--- a/tests/UnitTests/TestCurrency.cpp
+++ b/tests/UnitTests/TestCurrency.cpp
@@ -52,21 +52,21 @@ protected:
 
 TEST_F(Currency_isFusionTransactionTest, succeedsOnFusionTransaction) {
   auto tx = FusionTransactionBuilder(m_currency, TEST_AMOUNT).buildTx();
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, succeedsIfFusionTransactionSizeEqMaxSize) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
   auto tx = builder.createFusionTransactionBySize(m_currency.fusionTxMaxSize());
   ASSERT_EQ(m_currency.fusionTxMaxSize(), getObjectBinarySize(tx));
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfFusionTransactionSizeGreaterThanMaxSize) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
   auto tx = builder.createFusionTransactionBySize(m_currency.fusionTxMaxSize() + 1);
   ASSERT_EQ(m_currency.fusionTxMaxSize() + 1, getObjectBinarySize(tx));
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputsCountIsNotEnought) {
@@ -74,15 +74,15 @@ TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputsCountIsNotEnoug
   builder.setInputCount(m_currency.fusionTxMinInputCount() - 1);
   auto tx = builder.buildTx();
   ASSERT_EQ(m_currency.fusionTxMinInputCount() - 1, tx.inputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputOutputCountRatioIsLessThenNecessary) {
-  FusionTransactionBuilder builder(m_currency, 3710 * m_currency.defaultDustThreshold());
+  FusionTransactionBuilder builder(m_currency, 3710 * m_currency.defaultDustThreshold(0));
   auto tx = builder.buildTx();
   ASSERT_EQ(3, tx.outputs.size());
   ASSERT_GT(tx.outputs.size() * m_currency.fusionTxMinInOutCountRatio(), tx.inputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasNotExponentialOutput) {
@@ -90,42 +90,42 @@ TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasNotExponentialOutp
   builder.setFirstOutput(TEST_AMOUNT);
   auto tx = builder.buildTx();
   ASSERT_EQ(1, tx.outputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasOutputsWithTheSameExponent) {
-  FusionTransactionBuilder builder(m_currency, 130 * m_currency.defaultDustThreshold());
-  builder.setFirstOutput(70 * m_currency.defaultDustThreshold());
+  FusionTransactionBuilder builder(m_currency, 130 * m_currency.defaultDustThreshold(0));
+  builder.setFirstOutput(70 * m_currency.defaultDustThreshold(0));
   auto tx = builder.buildTx();
   ASSERT_EQ(2, tx.outputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, succeedsIfTransactionHasDustOutput) {
-  FusionTransactionBuilder builder(m_currency, 11 * m_currency.defaultDustThreshold());
+  FusionTransactionBuilder builder(m_currency, 11 * m_currency.defaultDustThreshold(0));
   auto tx = builder.buildTx();
   ASSERT_EQ(2, tx.outputs.size());
-  ASSERT_EQ(m_currency.defaultDustThreshold(), tx.outputs[0].amount);
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  ASSERT_EQ(m_currency.defaultDustThreshold(0), tx.outputs[0].amount);
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionFeeIsNotZero) {
-  FusionTransactionBuilder builder(m_currency, 370 * m_currency.defaultDustThreshold());
-  builder.setFee(70 * m_currency.defaultDustThreshold());
+  FusionTransactionBuilder builder(m_currency, 370 * m_currency.defaultDustThreshold(0));
+  builder.setFee(70 * m_currency.defaultDustThreshold(0));
   auto tx = builder.buildTx();
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, succedsIfTransactionHasInputEqualsDustThreshold) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
-  builder.setFirstInput(m_currency.defaultDustThreshold());
+  builder.setFirstInput(m_currency.defaultDustThreshold(0));
   auto tx = builder.buildTx();
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, 0));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasInputLessThanDustThreshold) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
-  builder.setFirstInput(m_currency.defaultDustThreshold() - 1);
+  builder.setFirstInput(m_currency.defaultDustThreshold(0) - 1);
   auto tx = builder.buildTx();
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, 0));
 }

--- a/tests/UnitTests/TestWallet.cpp
+++ b/tests/UnitTests/TestWallet.cpp
@@ -145,7 +145,7 @@ public:
     node(generator),
     alice(dispatcher, currency, node, logger),
     FEE(currency.minimumFee()),
-    FUSION_THRESHOLD(currency.defaultDustThreshold() * 10)
+    FUSION_THRESHOLD(currency.defaultDustThreshold(0) * 10)
   {
     CryptoNote::AccountBase randomAccount;
     randomAccount.generate();
@@ -297,7 +297,7 @@ void WalletApi::generateBlockReward(const std::string& address) {
 void WalletApi::generateFusionOutputsAndUnlock(WalletGreen& wallet, INodeTrivialRefreshStub& node,
   const CryptoNote::Currency& walletCurrency, uint64_t threshold, size_t addressIndex) {
 
-  uint64_t digit = walletCurrency.defaultDustThreshold();
+  uint64_t digit = walletCurrency.defaultDustThreshold(0);
   uint64_t mul = 1;
 
   while (digit > 9) {
@@ -2175,7 +2175,7 @@ TEST_F(WalletApi, createFusionTransactionCreatesValidFusionTransactionWithoutMix
 
   ASSERT_NE(WALLET_INVALID_TRANSACTION_ID, wallet.createFusionTransaction(FUSION_THRESHOLD, 0));
   ASSERT_TRUE(catchNode.caught);
-  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction));
+  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction, 0));
 
   wallet.shutdown();
 }
@@ -2190,7 +2190,7 @@ TEST_F(WalletApi, createFusionTransactionCreatesValidFusionTransactionWithMixin)
 
   ASSERT_NE(WALLET_INVALID_TRANSACTION_ID, wallet.createFusionTransaction(FUSION_THRESHOLD, 2));
   ASSERT_TRUE(catchNode.caught);
-  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction));
+  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction, 0));
 
   wallet.shutdown();
 }
@@ -2226,7 +2226,7 @@ TEST_F(WalletApi, createFusionTransactionThrowsIfStopped) {
 }
 
 TEST_F(WalletApi, createFusionTransactionThrowsIfThresholdTooSmall) {
-  ASSERT_ANY_THROW(alice.createFusionTransaction(currency.defaultDustThreshold() - 1, 0));
+  ASSERT_ANY_THROW(alice.createFusionTransaction(currency.defaultDustThreshold(0) - 1, 0));
 }
 
 TEST_F(WalletApi, createFusionTransactionThrowsIfNoAddresses) {
@@ -2569,7 +2569,7 @@ TEST_F(WalletApi, DISABLED_fusionManagerEstimate) {
       maxOutputIndex = i;
     }
 
-    if (currency.isAmountApplicableInFusionTransactionInput(tx.outputs[i].amount, tx.outputs[i].amount + 1)) {
+    if (currency.isAmountApplicableInFusionTransactionInput(tx.outputs[i].amount, tx.outputs[i].amount + 1, 0)) {
       ++expectedResult.fusionReadyCount;
     }
   }

--- a/tests/UnitTests/TransactionApiHelpers.cpp
+++ b/tests/UnitTests/TransactionApiHelpers.cpp
@@ -217,7 +217,7 @@ void FusionTransactionBuilder::setInputCount(size_t val) {
 std::unique_ptr<ITransactionReader> FusionTransactionBuilder::buildReader() const {
   assert(m_inputCount > 0);
   assert(m_firstInput <= m_amount);
-  assert(m_amount > m_currency.defaultDustThreshold());
+  assert(m_amount > m_currency.defaultDustThreshold(0));
 
   TestTransactionBuilder builder;
 
@@ -230,16 +230,16 @@ std::unique_ptr<ITransactionReader> FusionTransactionBuilder::buildReader() cons
   }
 
   if (m_amount > m_firstInput) {
-    builder.addTestInput(m_amount - m_firstInput - (m_inputCount - 1) * m_currency.defaultDustThreshold());
+    builder.addTestInput(m_amount - m_firstInput - (m_inputCount - 1) * m_currency.defaultDustThreshold(0));
     for (size_t i = 0; i < m_inputCount - 1; ++i) {
-      builder.addTestInput(m_currency.defaultDustThreshold());
+      builder.addTestInput(m_currency.defaultDustThreshold(0));
     }
   }
 
   AccountPublicAddress address = generateAddress();
   std::vector<uint64_t> outputAmounts;
   assert(m_amount >= m_firstOutput + m_fee);
-  decomposeAmount(m_amount - m_firstOutput - m_fee, m_currency.defaultDustThreshold(), outputAmounts);
+  decomposeAmount(m_amount - m_firstOutput - m_fee, m_currency.defaultDustThreshold(0), outputAmounts);
   std::sort(outputAmounts.begin(), outputAmounts.end());
 
   if (m_firstOutput != 0) {


### PR DESCRIPTION
Fork height is currently set at 600,000, this probably needs to be changed to something to fit with our desired release schedule. 

This fork will set the minimum mixin to 7, and disable dust outputs. This should mean 0 mixin is no longer needed to send dust. The code has been improved to make it easier to implement new mixin forks.

One thing that needs to be tested is what happens to transactions that are currently in the transaction pool when the fork hits, if they have a valid mixin before the fork, but invalid mixin after the fork. ETN experienced this with their recent fork, so blocks were created with these invalid transactions and then rejected.

I would like to test this out on testnet to make sure it's been implemented correctly.

Edit: Currently being tested out on lwma-2 testnet


Not really worth mentioning section:

Changed simplewallet help message to only mention "optimize" instead of quick/full, in my experience full is generally the same as quick. Regardless, full and quick are still commands, just undocumented.