### PR TITLE
Add fork readyness info to status command

### DIFF
--- a/src/Common/FormatTools.cpp
+++ b/src/Common/FormatTools.cpp
@@ -138,58 +138,6 @@ std::string get_update_status(ForkStatus forkStatus, uint64_t height, std::vecto
 }
 
 //--------------------------------------------------------------------------------
-std::string get_upgrade_time(uint64_t height, std::vector<uint64_t> upgrade_heights, uint64_t supported_height) {
-  std::string supported = "(Your version of the software is ready for this fork)";
-  std::string ret;
-
-  uint64_t next_fork = 0;
-
-  for (auto upgrade : upgrade_heights)
-  {
-      /* We have hit an upgrade already that the user cannot support */
-      if (height >= upgrade && supported_height < upgrade)
-      {
-          return " (The network forked at height " + std::to_string(upgrade) + ", please update your software: https://turtlecoin.lol/)";
-      }
-
-      /* Get the next fork height */
-      if (upgrade > height)
-      {
-          next_fork = upgrade;
-          break;
-      }
-  }
-
-  /* Software doesn't support the next fork yet, and fork is < 25k blocks away */
-  if (supported_height < next_fork && supported_height + 25000 > next_fork)
-  {
-      supported = " (Your software will need to be upgraded to support this fork)";
-  }
-
-  /* No more hardforks on the list, don't print anything */
-  if (height > next_fork)
-  {
-      return ret;
-  }
-
-  float days = (next_fork - height) / CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;
-
-  if (height == next_fork)
-  {
-      ret = " (forking now) ";
-  }
-  else if (days < 1)
-  {
-      ret = (boost::format(" (next fork in %.1f hours) ") % (days * 24)).str();
-  }
-  else
-  {
-      ret = (boost::format(" (next fork in %.1f days) ") % days).str();
-  }
-
-  return ret + supported;
-}
-
 std::string get_upgrade_info(uint64_t supported_height, std::vector<uint64_t> upgrade_heights)
 {
     for (auto upgrade : upgrade_heights)

--- a/src/Common/FormatTools.cpp
+++ b/src/Common/FormatTools.cpp
@@ -149,7 +149,7 @@ std::string get_upgrade_info(uint64_t supported_height, std::vector<uint64_t> up
     }
 
     /* This shouldnt happen */
-    return "";
+    return std::string();
 }
 
 //--------------------------------------------------------------------------------

--- a/src/Common/FormatTools.cpp
+++ b/src/Common/FormatTools.cpp
@@ -36,14 +36,37 @@ std::string get_sync_percentage(uint64_t height, uint64_t target_height) {
 }
 
 //--------------------------------------------------------------------------------
-std::string get_upgrade_time(uint64_t height, uint64_t upgrade_height) {
+std::string get_upgrade_time(uint64_t height, uint64_t upgrade_height, uint64_t supported_height) {
   float days = (upgrade_height - height) / CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;
+  std::string supported = "(Your version of the software is ready for this fork)";
+  std::string ret;
 
-  if (height > upgrade_height) return std::string();
-  if (height == upgrade_height) return std::string(" (forking now)");
-  if (days < 1) return (boost::format(" (next fork in %.1f hours)") % (days * 24)).str();
-  
-  return (boost::format(" (next fork in %.1f days)") % days).str();
+  if (supported_height < upgrade_height)
+  {
+      supported = "(Your software will need to be upgraded to support this fork)";
+  }
+
+  std::cout << supported_height << ", " << upgrade_height << std::endl;
+
+  if (height > upgrade_height)
+  {
+      return ret;
+  }
+
+  if (height == upgrade_height)
+  {
+      ret = " (forking now) ";
+  }
+  else if (days < 1)
+  {
+      ret = (boost::format(" (next fork in %.1f hours) ") % (days * 24)).str();
+  }
+  else
+  {
+      ret = (boost::format(" (next fork in %.1f days) ") % days).str();
+  }
+
+  return ret + supported;
 }
 
 //--------------------------------------------------------------------------------
@@ -53,7 +76,7 @@ std::string get_status_string(CryptoNote::COMMAND_RPC_GET_INFO::response iresp) 
 
   ss << "Height: " << iresp.height << "/" << iresp.network_height << " (" << get_sync_percentage(iresp.height, iresp.network_height) << "%) "
      << "on " << (iresp.testnet ? "testnet, " : "mainnet, ") << (iresp.synced ? "synced, " : "syncing, ") 
-     << "net hash " << get_mining_speed(iresp.hashrate) << ", " << "v" << +iresp.major_version << get_upgrade_time(iresp.network_height, iresp.upgrade_height) << ", "
+     << "net hash " << get_mining_speed(iresp.hashrate) << ", " << "v" << +iresp.major_version << get_upgrade_time(iresp.network_height, iresp.upgrade_height, iresp.supported_height) << ", "
      << iresp.outgoing_connections_count << "(out)+" << iresp.incoming_connections_count << "(in) connections, "
      << "uptime " << (unsigned int)floor(uptime / 60.0 / 60.0 / 24.0) << "d " << (unsigned int)floor(fmod((uptime / 60.0 / 60.0), 24.0)) << "h "
      << (unsigned int)floor(fmod((uptime / 60.0), 60.0)) << "m " << (unsigned int)fmod(uptime, 60.0) << "s";

--- a/src/Common/FormatTools.cpp
+++ b/src/Common/FormatTools.cpp
@@ -35,6 +35,108 @@ std::string get_sync_percentage(uint64_t height, uint64_t target_height) {
   return (boost::format("%.2f") % pc).str();
 }
 
+enum ForkStatus { UpToDate, ForkLater, ForkSoonReady, ForkSoonNotReady, OutOfDate };
+
+ForkStatus get_fork_status(uint64_t height, std::vector<uint64_t> upgrade_heights, uint64_t supported_height)
+{
+    uint64_t next_fork = 0;
+
+    for (auto upgrade : upgrade_heights)
+    {
+      /* We have hit an upgrade already that the user cannot support */
+      if (height >= upgrade && supported_height < upgrade)
+      {
+          return OutOfDate;
+      }
+
+      /* Get the next fork height */
+      if (upgrade > height)
+      {
+          next_fork = upgrade;
+          break;
+      }
+    }
+
+    /* Next fork in < 25k blocks away */
+    if (height + 25000 > next_fork)
+    {
+        /* Software doesn't support the next fork yet */
+        if (supported_height < next_fork)
+        {
+            return ForkSoonNotReady;
+        }
+        else
+        {
+            return ForkSoonReady;
+        }
+    }
+
+    if (height > next_fork)
+    {
+        return UpToDate;
+    }
+
+    return ForkLater;
+}
+
+std::string get_fork_time(uint64_t height, std::vector<uint64_t> upgrade_heights)
+{
+    uint64_t next_fork = 0;
+
+    for (auto upgrade : upgrade_heights)
+    {
+        /* Get the next fork height */
+        if (upgrade > height)
+        {
+            next_fork = upgrade;
+            break;
+        }
+    }
+
+    float days = (next_fork - height) / CryptoNote::parameters::EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;
+
+    if (height == next_fork)
+    {
+        return " (forking now),";
+    }
+    else if (days < 1)
+    {
+        return (boost::format(" (next fork in %.1f hours),") % (days * 24)).str();
+    }
+    else
+    {
+        return (boost::format(" (next fork in %.1f days),") % days).str();
+    }
+}
+
+std::string get_update_status(ForkStatus forkStatus, uint64_t height, std::vector<uint64_t> upgrade_heights)
+{
+    switch(forkStatus)
+    {
+        case UpToDate:
+        case ForkLater:
+        {
+            return " up to date";
+        }
+        case ForkSoonReady:
+        {
+            return get_fork_time(height, upgrade_heights) + " up to date";
+        }
+        case ForkSoonNotReady:
+        {
+            return get_fork_time(height, upgrade_heights) + " update needed";
+        }
+        case OutOfDate:
+        {
+            return " out of date, likely forked";
+        }
+        default:
+        {
+            throw std::runtime_error("Unexpected case unhandled");
+        }
+    }
+}
+
 //--------------------------------------------------------------------------------
 std::string get_upgrade_time(uint64_t height, std::vector<uint64_t> upgrade_heights, uint64_t supported_height) {
   std::string supported = "(Your version of the software is ready for this fork)";
@@ -58,8 +160,8 @@ std::string get_upgrade_time(uint64_t height, std::vector<uint64_t> upgrade_heig
       }
   }
 
-  /* Software doesn't support the next fork yet */
-  if (supported_height < next_fork)
+  /* Software doesn't support the next fork yet, and fork is < 25k blocks away */
+  if (supported_height < next_fork && supported_height + 25000 > next_fork)
   {
       supported = " (Your software will need to be upgraded to support this fork)";
   }
@@ -88,23 +190,43 @@ std::string get_upgrade_time(uint64_t height, std::vector<uint64_t> upgrade_heig
   return ret + supported;
 }
 
+std::string get_upgrade_info(uint64_t supported_height, std::vector<uint64_t> upgrade_heights)
+{
+    for (auto upgrade : upgrade_heights)
+    {
+        if (upgrade > supported_height)
+        {
+            return "The network forked at height " + std::to_string(upgrade) + ", please update your software: https://turtlecoin.lol";
+        }
+    }
+
+    /* This shouldnt happen */
+    return "";
+}
+
 //--------------------------------------------------------------------------------
 std::string get_status_string(CryptoNote::COMMAND_RPC_GET_INFO::response iresp) {
   std::stringstream ss;
   std::time_t uptime = std::time(nullptr) - iresp.start_time;
+  auto forkStatus = get_fork_status(iresp.network_height, iresp.upgrade_heights, iresp.supported_height);
 
   ss << "Height: " << iresp.height << "/" << iresp.network_height
      << " (" << get_sync_percentage(iresp.height, iresp.network_height) << "%) "
      << "on " << (iresp.testnet ? "testnet, " : "mainnet, ")
      << (iresp.synced ? "synced, " : "syncing, ") 
      << "net hash " << get_mining_speed(iresp.hashrate) << ", "
-     << "v" << +iresp.major_version
-     << get_upgrade_time(iresp.network_height, iresp.upgrade_heights, iresp.supported_height)
+     << "v" << +iresp.major_version << ","
+     << get_update_status(forkStatus, iresp.network_height, iresp.upgrade_heights)
      << ", " << iresp.outgoing_connections_count << "(out)+" << iresp.incoming_connections_count << "(in) connections, "
      << "uptime " << (unsigned int)floor(uptime / 60.0 / 60.0 / 24.0)
      << "d " << (unsigned int)floor(fmod((uptime / 60.0 / 60.0), 24.0))
      << "h " << (unsigned int)floor(fmod((uptime / 60.0), 60.0))
      << "m " << (unsigned int)fmod(uptime, 60.0) << "s";
+
+  if (forkStatus == OutOfDate)
+  {
+      ss << std::endl << get_upgrade_info(iresp.supported_height, iresp.upgrade_heights);
+  }
 
   return ss.str();
 }

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -96,6 +96,26 @@ const uint32_t UPGRADE_WINDOW                                = EXPECTED_NUMBER_O
 static_assert(0 < UPGRADE_VOTING_THRESHOLD && UPGRADE_VOTING_THRESHOLD <= 100, "Bad UPGRADE_VOTING_THRESHOLD");
 static_assert(UPGRADE_VOTING_WINDOW > 1, "Bad UPGRADE_VOTING_WINDOW");
 
+/* The index in the FORK_HEIGHTS array that this version of the software will
+   support. For example, if CURRENT_FORK_INDEX is 3, this version of the
+   software will support the fork at 600,000 blocks. */
+const uint8_t CURRENT_FORK_INDEX = 3;
+
+/* Block heights we are going to have hard forks at */
+const uint64_t FORK_HEIGHTS[] = {
+    187000,
+    350000,
+    440000,
+    600000,
+    700000,
+    800000,
+    900000,
+    1000000
+};
+
+/* Make sure CURRENT_FORK_INDEX is a valid index */
+static_assert(CURRENT_FORK_INDEX < (sizeof(FORK_HEIGHTS)/sizeof(*FORK_HEIGHTS)));
+
 const char     CRYPTONOTE_BLOCKS_FILENAME[]                  = "blocks.bin";
 const char     CRYPTONOTE_BLOCKINDEXES_FILENAME[]            = "blockindexes.bin";
 const char     CRYPTONOTE_POOLDATA_FILENAME[]                = "poolstate.bin";
@@ -148,4 +168,3 @@ const char* const SEED_NODES[] = {
   "165.227.252.132:11897" //iburnmycd
 };
 } // CryptoNote
-

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -107,10 +107,10 @@ const uint64_t FORK_HEIGHTS[] = {
     350000,
     440000,
     600000,
-    700000,
     800000,
-    900000,
-    1000000
+    1000000,
+    1200000,
+    1400000
 };
 
 /* Make sure CURRENT_FORK_INDEX is a valid index */

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -96,6 +96,26 @@ const uint32_t UPGRADE_WINDOW                                = EXPECTED_NUMBER_O
 static_assert(0 < UPGRADE_VOTING_THRESHOLD && UPGRADE_VOTING_THRESHOLD <= 100, "Bad UPGRADE_VOTING_THRESHOLD");
 static_assert(UPGRADE_VOTING_WINDOW > 1, "Bad UPGRADE_VOTING_WINDOW");
 
+/* The index in the FORK_HEIGHTS array that this version of the software will
+   support. For example, if CURRENT_FORK_INDEX is 0, this version of the
+   software will support the fork at 600,000 blocks. */
+const uint8_t CURRENT_FORK_INDEX = 3;
+
+/* Block heights we are going to have hard forks at */
+const uint64_t FORK_HEIGHTS[] = {
+    187000,
+    350000,
+    440000,
+    600000,
+    700000,
+    800000,
+    900000,
+    1000000
+};
+
+/* Make sure CURRENT_FORK_INDEX is a valid index */
+static_assert(CURRENT_FORK_INDEX < (sizeof(FORK_HEIGHTS)/sizeof(*FORK_HEIGHTS)));
+
 const char     CRYPTONOTE_BLOCKS_FILENAME[]                  = "blocks.bin";
 const char     CRYPTONOTE_BLOCKINDEXES_FILENAME[]            = "blockindexes.bin";
 const char     CRYPTONOTE_POOLDATA_FILENAME[]                = "poolstate.bin";

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -267,6 +267,7 @@ struct COMMAND_RPC_GET_INFO {
     uint32_t last_known_block_index;
     uint32_t network_height;
     uint64_t upgrade_height;
+    uint64_t supported_height;
     uint32_t hashrate;
     uint8_t major_version;
     uint8_t minor_version;
@@ -289,6 +290,7 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(last_known_block_index)
       KV_MEMBER(network_height)
       KV_MEMBER(upgrade_height)
+      KV_MEMBER(supported_height)
       KV_MEMBER(hashrate)
       KV_MEMBER(major_version)
       KV_MEMBER(minor_version)

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -266,7 +266,7 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t grey_peerlist_size;
     uint32_t last_known_block_index;
     uint32_t network_height;
-    uint64_t upgrade_height;
+    std::vector<uint64_t> upgrade_heights;
     uint64_t supported_height;
     uint32_t hashrate;
     uint8_t major_version;
@@ -289,7 +289,7 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(grey_peerlist_size)
       KV_MEMBER(last_known_block_index)
       KV_MEMBER(network_height)
-      KV_MEMBER(upgrade_height)
+      KV_MEMBER(upgrade_heights)
       KV_MEMBER(supported_height)
       KV_MEMBER(hashrate)
       KV_MEMBER(major_version)

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -492,7 +492,18 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
   res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocol.getObservedHeight()) - 1;
   res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
-  res.upgrade_height = CryptoNote::parameters::UPGRADE_HEIGHT_CURRENT;
+
+  res.upgrade_height = std::numeric_limits<uint64_t>::max();
+
+  for (auto height : CryptoNote::parameters::FORK_HEIGHTS) {
+      if (res.network_height < height) {
+          res.upgrade_height = height;
+          break;
+      }
+  }
+
+  res.supported_height = CryptoNote::parameters::FORK_HEIGHTS[CryptoNote::parameters::CURRENT_FORK_INDEX];
+
   res.hashrate = (uint32_t)round(res.difficulty / CryptoNote::parameters::DIFFICULTY_TARGET);
   res.synced = ((uint64_t)res.height == (uint64_t)res.network_height);
   res.testnet = m_core.getCurrency().isTestnet();

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -493,14 +493,8 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocol.getObservedHeight()) - 1;
   res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
 
-  res.upgrade_height = std::numeric_limits<uint64_t>::max();
-
-  for (auto height : CryptoNote::parameters::FORK_HEIGHTS) {
-      if (res.network_height < height) {
-          res.upgrade_height = height;
-          break;
-      }
-  }
+  res.upgrade_heights = std::vector<uint64_t>(std::begin(CryptoNote::parameters::FORK_HEIGHTS),
+                                              std::end(CryptoNote::parameters::FORK_HEIGHTS));
 
   res.supported_height = CryptoNote::parameters::FORK_HEIGHTS[CryptoNote::parameters::CURRENT_FORK_INDEX];
 


### PR DESCRIPTION
* Tells the user if they need to upgrade for the fork or not
* Tells the user if the fork has already happened, and to upgrade if it has and they are not ready.
* Adds an easy mechanism to add new forks and indicate the current softwares fork support: Add a value to FORK_HEIGHTS, and increase the value of CURRENT_FORK_INDEX by one.

E.g: 
```
Height: 516685/516696 (99.99%) on mainnet, syncing, net hash 4.57 MH/s, v4 (next fork in 28.0 days) (Your version of the software is ready for this fork), 2(out)+0(in) connections, uptime 0d 0h 0m 4s
```

or
```
Height: 516685/516696 (99.99%) on mainnet, syncing, net hash 4.57 MH/s, v4 (next fork in 28.0 days) (Your software will need to be upgraded to support this fork), 2(out)+0(in) connections, uptime 0d 0h 0m 4s
```
or

```
Height: 516685/516696 (99.99%) on mainnet, syncing, net hash 4.57 MH/s, v4 (The network forked at height 350000, please update your software: https://turtlecoin.lol), 2(out)+0(in) connections, uptime 0d 0h 0m 4s
```

The git commits are a bit ugly on this because I had to revert the reverting of the PR :stuck_out_tongue: 