### PR TITLE
Fix wallets losing sync progress

### DIFF
--- a/src/CryptoNoteCore/CryptoNoteSerialization.cpp
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.cpp
@@ -425,7 +425,7 @@ void serialize(TransactionExtraMergeMiningTag& tag, ISerializer& serializer) {
     serializer(field, "");
   } else {
     std::string field;
-    serializer(field, "");
+    serializer(field, "mm_tag");
     MemoryInputStream stream(field.data(), field.size());
     BinaryInputStreamSerializer input(stream);
     doSerialize(tag, input);

--- a/src/Serialization/BinaryInputStreamSerializer.cpp
+++ b/src/Serialization/BinaryInputStreamSerializer.cpp
@@ -100,8 +100,8 @@ bool BinaryInputStreamSerializer::operator()(std::string& value, Common::StringV
   uint64_t size;
   readVarint(stream, size);
 
-  /* This should probably match block size... */
-  if (size > CryptoNote::parameters::MAX_EXTRA_SIZE)
+  /* Can't take up more than a block size */
+  if (size > CryptoNote::parameters::MAX_EXTRA_SIZE && std::string(name.getData()) == "mm_tag")
   {
     std::vector<char> temp;
     temp.resize(1);


### PR DESCRIPTION
It's only the mm_tag which can possibly overflow of the 4 tags in the tx_extra, so lets only cap our size if we meet that tag. Occasionally we appeared to need quite large reads to successfully open a wallet.