### PR TITLE
Remove mixin options

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -44,12 +44,12 @@ const uint64_t MINIMUM_FEE                                   = UINT64_C(10);
 const uint64_t MINIMUM_MIXIN_V1                              = 0;
 const uint64_t MAXIMUM_MIXIN_V1                              = 100;
 const uint64_t MINIMUM_MIXIN_V2                              = 7;
-const uint64_t MAXIMUM_MIXIN_V2                              = 100;
-
-const uint64_t DEFAULT_MIXIN                                 = MINIMUM_MIXIN_V2 + 2;
+const uint64_t MAXIMUM_MIXIN_V2                              = 7;
 
 const uint32_t MIXIN_LIMITS_V1_HEIGHT                        = 440000;
 const uint32_t MIXIN_LIMITS_V2_HEIGHT                        = 600000;
+
+const uint64_t DEFAULT_MIXIN                                 = MINIMUM_MIXIN_V2;
 
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(10);
 const uint64_t DEFAULT_DUST_THRESHOLD_V2                     = UINT64_C(0);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -447,12 +447,6 @@ void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node)
 
         std::string command = getInputAndDoWorkWhileIdle(walletInfo);
 
-        /* Split into args to support legacy transfer command, for example
-           transfer 5 TRTLxyz... 100, sends 100 TRTL to TRTLxyz... with a mixin
-           of 5 */
-        std::vector<std::string> words;
-        words = boost::split(words, command, ::isspace);
-
         if (command == "")
         {
             // no-op
@@ -513,12 +507,14 @@ void inputLoop(std::shared_ptr<WalletInfo> &walletInfo, CryptoNote::INode &node)
             {
                 transfer(walletInfo, node.getLastKnownBlockHeight());
             }
-            else if (words[0] == "transfer")
+            /* String starts with transfer, old transfer syntax */
+            else if (command.find("transfer") == 0)
             {
-                /* remove the first item from words - this is the "transfer"
-                   command, leaving us just the transfer arguments. */
-                words.erase(words.begin());
-                transfer(walletInfo, words, node.getLastKnownBlockHeight());
+                std::cout << "This transfer syntax has been removed."
+                          << std::endl
+                          << "Run just the " << SuggestionMsg("transfer")
+                          << " command for a walk through guide to "
+                          << "transferring." << std::endl;
             }
             else if (command == "quick_optimize")
             {

--- a/src/SimpleWallet/Transfer.h
+++ b/src/SimpleWallet/Transfer.h
@@ -23,12 +23,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height);
 
-void transfer(std::shared_ptr<WalletInfo> walletInfo,
-              std::vector<std::string> args, uint32_t height);
-
-void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
-                uint64_t fee, std::string extra,
-                std::shared_ptr<WalletInfo> walletInfo, uint32_t height);
+void doTransfer(std::string address, uint64_t amount, uint64_t fee,
+                std::string extra, std::shared_ptr<WalletInfo> walletInfo,
+                uint32_t height);
 
 void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
                               std::vector<CryptoNote::TransactionParameters>
@@ -42,8 +39,6 @@ bool confirmTransaction(CryptoNote::TransactionParameters t,
 
 bool parseAmount(std::string amountString);
 
-bool parseMixin(std::string mixinString);
-
 bool parseAddress(std::string address);
 
 bool parseFee(std::string feeString);
@@ -55,5 +50,3 @@ Maybe<std::string> getDestinationAddress();
 Maybe<uint64_t> getFee();
 
 Maybe<uint64_t> getTransferAmount();
-
-Maybe<uint16_t> getMixin();


### PR DESCRIPTION
Sets default mixin to 7, simplewallet users no longer have an option to choose their mixin. (GUI wallet users could, but it would be rejected by the network)