### PR TITLE
[BUGFIX] Resolves Walletd Interaction with node via --local flag

### DIFF
--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -34,6 +34,9 @@
 #include "CryptoNoteCore/RocksDBWrapper.h"
 #include "CryptoNoteProtocol/CryptoNoteProtocolHandler.h"
 #include "P2p/NetNode.h"
+#include "Rpc/RpcServer.h"
+#include "Rpc/RpcServerConfig.h"
+#include "NodeRpcProxy/NodeRpcProxy.h"
 #include <System/Context.h>
 #include "Wallet/WalletGreen.h"
 
@@ -211,7 +214,9 @@ void PaymentGateService::runInProcess(Logging::LoggerRef& log) {
 
   CryptoNote::CryptoNoteProtocolHandler protocol(currency, *dispatcher, core, nullptr, logger);
   CryptoNote::NodeServer p2pNode(*dispatcher, protocol, logger);
-
+  CryptoNote::RpcServerConfig rpcConfig;
+  CryptoNote::RpcServer rpcServer(*dispatcher, logger, core, p2pNode, protocol);
+  
   protocol.set_p2p_endpoint(&p2pNode);
 
   log(Logging::INFO) << "initializing p2pNode";
@@ -219,8 +224,11 @@ void PaymentGateService::runInProcess(Logging::LoggerRef& log) {
     throw std::runtime_error("Failed to init p2pNode");
   }
 
-  std::unique_ptr<CryptoNote::INode> node(new CryptoNote::InProcessNode(core, protocol, *dispatcher));
-
+  log(Logging::INFO) << "Starting node RPC Server address " << rpcConfig.getBindAddress() << " ...";
+  rpcServer.start(rpcConfig.bindIp, rpcConfig.bindPort);
+  
+  log(Logging::INFO) << "Starting local NodeRPCProxy...";
+  std::unique_ptr<CryptoNote::INode> node(new CryptoNote::NodeRpcProxy(rpcConfig.bindIp, rpcConfig.bindPort, logger));
   std::error_code nodeInitStatus;
   node->init([&log, &nodeInitStatus](std::error_code ec) {
     nodeInitStatus = ec;
@@ -232,6 +240,7 @@ void PaymentGateService::runInProcess(Logging::LoggerRef& log) {
   } else {
     log(Logging::INFO) << "node is inited successfully";
   }
+  log(Logging::INFO) << "Local NodeRPCProxy Started...";
 
   log(Logging::INFO) << "Spawning p2p server";
 
@@ -243,13 +252,16 @@ void PaymentGateService::runInProcess(Logging::LoggerRef& log) {
   });
 
   p2pStarted.wait();
-
+  
   runWalletService(currency, *node);
 
+  log(Logging::INFO) << "Stopping node RPC Server...";
+  rpcServer.stop();
   p2pNode.sendStopSignal();
   context.get();
   node->shutdown();
   p2pNode.deinit(); 
+  core.save();
 }
 
 void PaymentGateService::runRpcProxy(Logging::LoggerRef& log) {


### PR DESCRIPTION
Instead of using InProcessNode for walletd to talk to the daemon that it's running, this instead launches the RpcServer the same way that the normal daemon does and then uses the NodeRpcProxy to talk the the daemon that is running in its process. While this isn't the most elegant solution, it does appear to resolve #286 

NodeRpcProxy is also uses with the remote daemon when specified -- or when --local is not supplied. So it's basically doing the same thing in 3 out of 3 cases now where it was doing something special for --local that really wasn't the best idea IMO.


***Please have MULTIPLE people test this before it makes it towards release.***