### PR TITLE
Make timestamps optional in simplewallet

### DIFF
--- a/src/SimpleWallet/Sync.cpp
+++ b/src/SimpleWallet/Sync.cpp
@@ -74,9 +74,10 @@ std::string getBlockTimestamp(CryptoNote::BlockDetails b)
 }
 
 void printOutgoingTransfer(CryptoNote::WalletTransaction t,
-                           CryptoNote::INode &node)
+                           CryptoNote::INode &node,
+                           bool fetchTimestamp)
 {
-    std::string blockTime = getBlockTimestamp(getBlock(t.blockHeight, node));
+
 
     std::cout << WarningMsg("Outgoing transfer:")
               << std::endl
@@ -96,20 +97,24 @@ void printOutgoingTransfer(CryptoNote::WalletTransaction t,
         std::cout << WarningMsg("Payment ID: " + paymentID) << std::endl;
     }
 
-    /* Couldn't get timestamp, maybe old node or turtlecoind closed */
-    if (blockTime != "")
+    if (fetchTimestamp)
     {
-        std::cout << WarningMsg("Timestamp: " + blockTime) << std::endl;
+        std::string blockTime = getBlockTimestamp(getBlock(t.blockHeight, node));
+
+        /* Couldn't get timestamp, maybe old node or turtlecoind closed */
+        if (blockTime != "")
+        {
+            std::cout << WarningMsg("Timestamp: " + blockTime) << std::endl;
+        }
     }
 
     std::cout << std::endl;
 }
 
 void printIncomingTransfer(CryptoNote::WalletTransaction t,
-                           CryptoNote::INode &node)
+                           CryptoNote::INode &node,
+                           bool fetchTimestamp)
 {
-    std::string blockTime = getBlockTimestamp(getBlock(t.blockHeight, node));
-
     std::cout << SuccessMsg("Incoming transfer:")
               << std::endl
               << SuccessMsg("Hash: " + Common::podToHex(t.hash))
@@ -124,10 +129,15 @@ void printIncomingTransfer(CryptoNote::WalletTransaction t,
         std::cout << SuccessMsg("Payment ID: " + paymentID) << std::endl;
     }
 
-    /* Couldn't get timestamp, maybe old node or turtlecoind closed */
-    if (blockTime != "")
+    if (fetchTimestamp)
     {
-        std::cout << SuccessMsg("Timestamp: " + blockTime) << std::endl;
+        std::string blockTime = getBlockTimestamp(getBlock(t.blockHeight, node));
+
+        /* Couldn't get timestamp, maybe old node or turtlecoind closed */
+        if (blockTime != "")
+        {
+            std::cout << SuccessMsg("Timestamp: " + blockTime) << std::endl;
+        }
     }
 
     std::cout << std::endl;
@@ -136,6 +146,10 @@ void printIncomingTransfer(CryptoNote::WalletTransaction t,
 void listTransfers(bool incoming, bool outgoing, 
                    CryptoNote::WalletGreen &wallet, CryptoNote::INode &node)
 {
+    bool fetchTimestamp =
+         confirm("Display timestamps? (Takes lots longer to list transactions)",
+                 false);
+
     size_t numTransactions = wallet.getTransactionCount();
     int64_t totalSpent = 0;
     int64_t totalReceived = 0;
@@ -146,12 +160,12 @@ void listTransfers(bool incoming, bool outgoing,
 
         if (t.totalAmount < 0 && outgoing)
         {
-            printOutgoingTransfer(t, node);
+            printOutgoingTransfer(t, node, fetchTimestamp);
             totalSpent += -t.totalAmount;
         }
         else if (t.totalAmount > 0 && incoming)
         {
-            printIncomingTransfer(t, node);
+            printIncomingTransfer(t, node, fetchTimestamp);
             totalReceived += t.totalAmount;
         }
     }
@@ -381,11 +395,11 @@ void syncWallet(CryptoNote::INode &node,
 
                         if (t.totalAmount < 0)
                         {
-                            printOutgoingTransfer(t, node);
+                            printOutgoingTransfer(t, node, false);
                         }
                         else
                         {
-                            printIncomingTransfer(t, node);
+                            printIncomingTransfer(t, node, false);
                         }
                     }
                 }

--- a/src/SimpleWallet/Tools.cpp
+++ b/src/SimpleWallet/Tools.cpp
@@ -111,35 +111,49 @@ std::string formatCents(uint64_t amount)
 
 bool confirm(std::string msg)
 {
+    return confirm(msg, true);
+}
+
+/* defaultReturn = what value we return on hitting enter, i.e. the "expected"
+   workflow */
+bool confirm(std::string msg, bool defaultReturn)
+{
+    /* In unix programs, the upper case letter indicates the default, for
+       example when you hit enter */
+    std::string prompt = " (Y/n): ";
+
+    /* Yes, I know I can do !defaultReturn. It doesn't make as much sense
+       though. If someone deletes this comment to make me look stupid I'll be
+       mad >:( */
+    if (defaultReturn == false)
+    {
+        prompt = " (y/N): ";
+    }
+
     while (true)
     {
-        std::cout << InformationMsg(msg + " (Y/n): ");
+        std::cout << InformationMsg(msg + prompt);
 
         std::string answer;
         std::getline(std::cin, answer);
 
         char c = std::tolower(answer[0]);
 
-        /* Lets people spam enter in the transaction screen */
-        if (c == 'y' || c == '\0')
+        switch(std::tolower(answer[0]))
         {
-            return true;
+            /* Lets people spam enter / choose default value */
+            case '\0':
+                return defaultReturn;
+            case 'y':
+                return true;
+            case 'n':
+                return false;
         }
-        else if (c == 'n')
-        {
-            return false;
-        }
-        /* Don't loop forever on EOF */
-        else if (c == std::ifstream::traits_type::eof())
-        {
-            return false;
-        } 
-        else
-        {
-            std::cout << WarningMsg("Bad input: ") << InformationMsg(answer)
-                      << WarningMsg(" - please enter either Y or N.")
-                      << std::endl;
-        }
+
+        std::cout << WarningMsg("Bad input: ") << InformationMsg(answer)
+                  << WarningMsg(" - please enter either Y or N.")
+                  << std::endl;
+
     }
 }
 

--- a/src/SimpleWallet/Tools.h
+++ b/src/SimpleWallet/Tools.h
@@ -22,6 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 void confirmPassword(std::string walletPass);
 
 bool confirm(std::string msg);
+bool confirm(std::string msg, bool defaultReturn);
 
 std::string formatAmount(uint64_t amount);
 std::string formatDollars(uint64_t amount);


### PR DESCRIPTION
Getting timestamps from the node is very slow, so could possibly slow down syncing, and makes list_transfers et all way slower, so lets just ask the user what they would like. list_transfers is back to taking about a second on my machine now.