### PR TITLE
Versions? We don't need no stinking versions!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /
 ADD https://github.com/just-containers/socklog-overlay/releases/download/v2.1.0-0/socklog-overlay-amd64.tar.gz /tmp/
 RUN tar xzf /tmp/socklog-overlay-amd64.tar.gz -C /
 
-ARG TURTLECOIN_VERSION=v0.6.0
-ENV TURTLECOIN_VERSION=${TURTLECOIN_VERSION}
+ARG TURTLECOIN_BRANCH=master
+ENV TURTLECOIN_BRANCH=${TURTLECOIN_BRANCH}
 
 # install build dependencies
 # checkout the latest tag
@@ -28,7 +28,7 @@ RUN apt-get update && \
       librocksdb-dev && \
     git clone https://github.com/turtlecoin/turtlecoin.git /src/turtlecoin && \
     cd /src/turtlecoin && \
-    git checkout $TURTLECOIN_VERSION && \
+    git checkout $TURTLECOIN_BRANCH && \
     mkdir build && \
     cd build && \
     cmake -DCMAKE_CXX_FLAGS="-g0 -Os -fPIC -std=gnu++11" .. && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -22,8 +22,8 @@ ADD https://raw.githubusercontent.com/turtlecoin/checkpoints/master/checkpoints.
 # In a multi-node testnet, we'll want to have the slave nodes "wait" for the master node to wake up, so let's get ready
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /tmp/
 
-ARG TURTLECOIN_VERSION=v0.6.0
-ENV TURTLECOIN_VERSION=${TURTLECOIN_VERSION}
+ARG TURTLECOIN_BRANCH=master
+ENV TURTLECOIN_BRANCH=${TURTLECOIN_BRANCH}
 
 # install build dependencies
 # checkout the latest tag
@@ -39,7 +39,7 @@ RUN apt-get update && \
       librocksdb-dev && \
     git clone https://github.com/turtlecoin/turtlecoin.git /src/turtlecoin && \
     cd /src/turtlecoin && \
-    git checkout $TURTLECOIN_VERSION && \
+    git checkout $TURTLECOIN_BRANCH && \
     sed -i '/std::vector<uint64_t> timestamps_o(timestamps);/i \\/*\n   Lower difficulty to static 500 for testnet\n   The rest of this function is ignored\n*\/\nreturn 500;\n\n' src/CryptoNoteCore/Currency.cpp && \
     sed -i -e 's/"104.236.227.176:11897",/"172.16.76.11:11897",/g' src/CryptoNoteConfig.h && \
     sed -i -e 's/"46.101.132.184:11897",/"172.16.76.12:11897",/g' src/CryptoNoteConfig.h && \


### PR DESCRIPTION
...at least not for docker. This replaces the tagged version with the branch for the docker build, so we won't need to worry about updating the version in the Dockerfile anymore. This also allows us to create a docker image using the development branch by passing a build argument when building (e.g. ```docker build --build-arg TURTLECOIN_BRANCH=development -t turtlecoin .```). The default is set to build the master branch.