### PR TITLE
Add optional cors header to walletd

### DIFF
--- a/src/JsonRpcServer/JsonRpcServer.cpp
+++ b/src/JsonRpcServer/JsonRpcServer.cpp
@@ -77,6 +77,10 @@ void JsonRpcServer::processRequest(const CryptoNote::HttpRequest& req, CryptoNot
       std::ostringstream jsonOutputStream;
       jsonOutputStream << jsonRpcResponse;
 
+      if (config.corsHeader != "") {
+        resp.addHeader("Access-Control-Allow-Origin", config.corsHeader);
+      }
+
       resp.setStatus(CryptoNote::HttpResponse::STATUS_200);
       resp.setBody(jsonOutputStream.str());
 

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -45,6 +45,7 @@ Configuration::Configuration() {
   mnemonicSeed = "";
   rpcPassword = "";
   legacySecurity = false;
+  corsHeader = "";
 }
 
 void Configuration::initOptions(boost::program_options::options_description& desc) {
@@ -68,7 +69,8 @@ void Configuration::initOptions(boost::program_options::options_description& des
       ("server-root", po::value<std::string>(), "server root. The service will use it as working directory. Don't set it if don't want to change it")
       ("log-level", po::value<size_t>(), "log level")
       ("SYNC_FROM_ZERO", "sync from timestamp 0")
-      ("address", "print wallet addresses and exit");
+      ("address", "print wallet addresses and exit")
+      ("enable-cors", po::value<std::string>(), "Adds header 'Access-Control-Allow-Origin' to walletd's RPC responses. Uses the value as domain. Use * for all.");
 }
 
 void Configuration::init(const boost::program_options::variables_map& options) {
@@ -187,6 +189,12 @@ void Configuration::init(const boost::program_options::variables_map& options) {
   }
   else {
     rpcPassword = options["rpc-password"].as<std::string>();
+  }
+
+  if (options.count("enable-cors") != 0) {
+    corsHeader = options["enable-cors"].as<std::string>();
+    std::cout << corsHeader << std::endl;
+    std::cout << options["enable-cors"].as<std::string>() << std::endl;
   }
   
 }

--- a/src/PaymentGateService/PaymentServiceConfiguration.h
+++ b/src/PaymentGateService/PaymentServiceConfiguration.h
@@ -47,6 +47,7 @@ struct Configuration {
   std::string mnemonicSeed;
   std::string logFile;
   std::string serverRoot;
+  std::string corsHeader;
 
   bool generateNewContainer;
   bool daemonize;


### PR DESCRIPTION
Has the same syntax as turtlecoind, e.g. --enable-cors "\*"
(Make sure to quote your "*" otherwise your shell expands it!)