### PR TITLE
[WIP] Remove Remaining Binary Handlers From RpcServer

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -55,7 +55,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST {
     std::vector<Crypto::Hash> block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
     
     void serialize(ISerializer &s) {
-      serializeAsBinary(block_ids, "block_ids", s);
+      KV_MEMBER(block_ids);
     }
   };
 
@@ -96,7 +96,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES {
 
     void serialize(ISerializer &s) {
       KV_MEMBER(tailBlockId)
-      serializeAsBinary(knownTxsIds, "knownTxsIds", s);
+      KV_MEMBER(knownTxsIds);
     }
   };
 
@@ -109,7 +109,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES {
     void serialize(ISerializer &s) {
       KV_MEMBER(isTailBlockActual)
       KV_MEMBER(addedTxs)
-      serializeAsBinary(deletedTxsIds, "deletedTxsIds", s);
+      KV_MEMBER(deletedTxsIds);
       KV_MEMBER(status)
     }
   };
@@ -122,7 +122,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES_LITE {
 
     void serialize(ISerializer &s) {
       KV_MEMBER(tailBlockId)
-      serializeAsBinary(knownTxsIds, "knownTxsIds", s);
+      KV_MEMBER(knownTxsIds);
     }
   };
 
@@ -135,7 +135,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES_LITE {
     void serialize(ISerializer &s) {
       KV_MEMBER(isTailBlockActual)
       KV_MEMBER(addedTxs)
-      serializeAsBinary(deletedTxsIds, "deletedTxsIds", s);
+      KV_MEMBER(deletedTxsIds);
       KV_MEMBER(status)
     }
   };
@@ -177,6 +177,11 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_request {
 struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_out_entry {
   uint32_t global_amount_index;
   Crypto::PublicKey out_key;
+  
+  void serialize(ISerializer &s) {
+    KV_MEMBER(global_amount_index)
+    KV_MEMBER(out_key);
+  }
 };
 #pragma pack(pop)
 
@@ -186,7 +191,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_outs_for_amount {
 
   void serialize(ISerializer &s) {
     KV_MEMBER(amount)
-    serializeAsBinary(outs, "outs", s);
+    KV_MEMBER(outs);
   }
 };
 
@@ -667,7 +672,7 @@ struct COMMAND_RPC_QUERY_BLOCKS {
     uint64_t timestamp;
 
     void serialize(ISerializer &s) {
-      serializeAsBinary(block_ids, "block_ids", s);
+      KV_MEMBER(block_ids);
       KV_MEMBER(timestamp)
     }
   };
@@ -695,7 +700,7 @@ struct COMMAND_RPC_QUERY_BLOCKS_LITE {
     uint64_t timestamp;
 
     void serialize(ISerializer &s) {
-      serializeAsBinary(blockIds, "block_ids", s);
+      KV_MEMBER(blockIds);
       KV_MEMBER(timestamp)
     }
   };
@@ -722,7 +727,7 @@ struct COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HEIGHTS {
     std::vector<uint32_t> blockHeights;
 
     void serialize(ISerializer& s) {
-      serializeAsBinary(blockHeights, "blockHeights", s);
+      KV_MEMBER(blockHeights);
     }
   };
 
@@ -742,7 +747,7 @@ struct COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HASHES {
     std::vector<Crypto::Hash> blockHashes;
 
     void serialize(ISerializer& s) {
-      serializeAsBinary(blockHashes, "blockHashes", s);
+      KV_MEMBER(blockHashes);
     }
   };
 
@@ -814,7 +819,7 @@ struct COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID {
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
-      serializeAsBinary(transactionHashes, "transactionHashes", s);
+      KV_MEMBER(transactionHashes);
     }
   };
 };
@@ -824,7 +829,7 @@ struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASHES {
     std::vector<Crypto::Hash> transactionHashes;
 
     void serialize(ISerializer &s) {
-      serializeAsBinary(transactionHashes, "transactionHashes", s);
+      KV_MEMBER(transactionHashes);
     }
   };
 


### PR DESCRIPTION
# Warning

This pull request alters critical data payloads between wallets (walletd/zedwallet/poolwallet) and the node (Turtlecoind). 

Previous versions of the wallets will **NOT** work with TurtleCoind as a result of merging this code.

**Wallets (walletd/zedwallet/poolwallet) will need to be of the same release or later from here on out.**

## Changelog

* Removed inner binary serializtion of data in RpcServer for the daemon.

***Please make sure that all testing procedures are completed on ALL platforms before releasing this to the public.***

@RocksteadyTC I have labeled this as a WIP for the time being to keep it from being merged until enough people have tested and signed off on it.