### PR TITLE
Add integrated addresses to zedwallet

### DIFF
--- a/src/zedwallet/CommandImplementations.cpp
+++ b/src/zedwallet/CommandImplementations.cpp
@@ -11,6 +11,7 @@
 #include <Common/StringTools.h>
 
 #include <CryptoNoteCore/Account.h>
+#include <CryptoNoteCore/TransactionExtra.h>
 
 #ifndef MSVC
 #include <fstream>
@@ -439,4 +440,55 @@ void save(CryptoNote::WalletGreen &wallet)
     std::cout << InformationMsg("Saving.") << std::endl;
     wallet.save();
     std::cout << InformationMsg("Saved.") << std::endl;
+}
+
+void createIntegratedAddress()
+{
+    std::cout << InformationMsg("Creating an integrated address from an ")
+              << InformationMsg("address and payment ID pair...")
+              << std::endl << std::endl;
+
+    std::string address;
+    std::string paymentID;
+
+    while (true)
+    {
+        std::cout << InformationMsg("Address: ");
+
+        std::getline(std::cin, address);
+        boost::algorithm::trim(address);
+
+        std::cout << std::endl;
+
+        if (parseStandardAddress(address, true))
+        {
+            break;
+        }
+    }
+
+    while (true)
+    {
+        std::cout << InformationMsg("Payment ID: ");
+
+        std::getline(std::cin, paymentID);
+        boost::algorithm::trim(paymentID);
+
+        std::vector<uint8_t> extra;
+
+        std::cout << std::endl;
+
+        if (!CryptoNote::createTxExtraWithPaymentId(paymentID, extra))
+        {
+            std::cout << WarningMsg("Failed to parse! Payment ID's are 64 "
+                                    "character hexadecimal strings.")
+                      << std::endl << std::endl;
+
+            continue;
+        }
+
+        break;
+    }
+
+    std::cout << InformationMsg(createIntegratedAddress(address, paymentID))
+              << std::endl;
 }

--- a/src/zedwallet/CommandImplementations.h
+++ b/src/zedwallet/CommandImplementations.h
@@ -35,3 +35,5 @@ void printOutgoingTransfer(CryptoNote::WalletTransaction t,
 
 void printIncomingTransfer(CryptoNote::WalletTransaction t,
                            CryptoNote::INode &node);
+
+void createIntegratedAddress();

--- a/src/zedwallet/Commands.cpp
+++ b/src/zedwallet/Commands.cpp
@@ -154,6 +154,10 @@ bool dispatchCommand(std::shared_ptr<WalletInfo> &walletInfo,
     {
         changePassword(walletInfo);
     }
+    else if (command == "make_integrated_address")
+    {
+        createIntegratedAddress();
+    }
     /* This should never happen */
     else
     {
@@ -168,8 +172,8 @@ bool dispatchCommand(std::shared_ptr<WalletInfo> &walletInfo,
 }
 
 const Maybe<Command> resolveCommand(std::string command,
-                              std::vector<Command> &allCommands,
-                              std::vector<Command> &available)
+                                    std::vector<Command> &allCommands,
+                                    std::vector<Command> &available)
 {
     int index;
 
@@ -251,6 +255,10 @@ std::vector<Command> allCommands()
 
         {"bc_height", "Show the blockchain height", true, true},
         {"change_password", "Change your wallet password", true, true},
+
+        {"make_integrated_address", "Make an integrated address from an "
+                                    "address + payment ID", true, true},
+
         {"incoming_transfers", "Show incoming transfers", true, true},
         {"list_transfers", "Show all transfers", false, true},
         {"optimize", "Optimize your wallet to send large amounts", false, true},

--- a/src/zedwallet/Open.cpp
+++ b/src/zedwallet/Open.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<WalletInfo> createViewWallet(CryptoNote::WalletGreen &wallet)
         std::getline(std::cin, address);
         boost::algorithm::trim(address);
 
-        if (parseAddress(address))
+        if (parseStandardAddress(address, true))
         {
             break;
         }

--- a/src/zedwallet/Tools.cpp
+++ b/src/zedwallet/Tools.cpp
@@ -8,6 +8,7 @@
 
 #include <cmath>
 
+#include <Common/Base58.h>
 #include <Common/StringTools.h>
 
 #include <CryptoNoteCore/TransactionExtra.h>
@@ -221,4 +222,13 @@ std::string unixTimeToDate(uint64_t timestamp)
     char buffer[100];
     std::strftime(buffer, sizeof(buffer), "%F %R", std::localtime(&time));
     return std::string(buffer);
+}
+
+std::string createIntegratedAddress(std::string address, std::string paymentID)
+{
+    return Tools::Base58::encode_addr
+    (
+        CryptoNote::parameters::CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX,
+        paymentID + address
+    );
 }

--- a/src/zedwallet/Tools.h
+++ b/src/zedwallet/Tools.h
@@ -24,4 +24,6 @@ std::string getPrompt(std::shared_ptr<WalletInfo> &walletInfo);
 
 std::string unixTimeToDate(uint64_t timestamp);
 
+std::string createIntegratedAddress(std::string address, std::string paymentID);
+
 uint64_t getDivisor();

--- a/src/zedwallet/Transfer.h
+++ b/src/zedwallet/Transfer.h
@@ -8,11 +8,13 @@
 
 #include <zedwallet/Types.h>
 
+enum AddressType {NotAnAddress, IntegratedAddress, StandardAddress};
+
 void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height);
 
 void doTransfer(std::string address, uint64_t amount, uint64_t fee,
                 std::string extra, std::shared_ptr<WalletInfo> walletInfo,
-                uint32_t height);
+                uint32_t height, bool integratedAddress);
 
 void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
                               std::vector<CryptoNote::TransactionParameters>
@@ -22,13 +24,18 @@ void splitTx(CryptoNote::WalletGreen &wallet,
              CryptoNote::TransactionParameters p);
 
 bool confirmTransaction(CryptoNote::TransactionParameters t,
-                        std::shared_ptr<WalletInfo> walletInfo);
+                        std::shared_ptr<WalletInfo> walletInfo,
+                        bool integratedAddress);
 
 bool parseAmount(std::string amountString);
 
-bool parseAddress(std::string address);
+bool parseStandardAddress(std::string address, bool printErrors = false);
+
+bool parseIntegratedAddress(std::string address);
 
 bool parseFee(std::string feeString);
+
+AddressType parseAddress(std::string address);
 
 std::string getExtraFromPaymentID(std::string paymentID);
 
@@ -36,8 +43,11 @@ Maybe<std::string> getPaymentID(std::string msg);
 
 Maybe<std::string> getExtra();
 
-Maybe<std::string> getDestinationAddress();
+Maybe<std::pair<AddressType, std::string>> getAddress(std::string msg);
 
 Maybe<uint64_t> getFee();
 
 Maybe<uint64_t> getTransferAmount();
+
+Maybe<std::pair<std::string, std::string>> extractIntegratedAddress(
+    std::string integratedAddress);

--- a/src/zedwallet/Types.h
+++ b/src/zedwallet/Types.h
@@ -125,22 +125,31 @@ struct AddressBookEntry
     AddressBookEntry(std::string friendlyName) : friendlyName(friendlyName) {}
 
     AddressBookEntry(std::string friendlyName, std::string address,
-                std::string paymentID) : friendlyName(friendlyName),
-                                         address(address),
-                                         paymentID(paymentID) {}
+                     std::string paymentID, bool integratedAddress) :
+                     friendlyName(friendlyName), address(address),
+                     paymentID(paymentID), integratedAddress(integratedAddress)
+                     {}
 
     /* Friendly name for this address book entry */
     std::string friendlyName;
+
     /* The wallet address of this entry */
     std::string address;
+
     /* The payment ID associated with this address */
     std::string paymentID;
+
+    /* Did the user enter this as an integrated address? (We need this to
+       display back the address as either an integrated address, or an
+       address + payment ID pair */
+    bool integratedAddress;
 
     void serialize(CryptoNote::ISerializer &s)
     {
         KV_MEMBER(friendlyName)
         KV_MEMBER(address)
         KV_MEMBER(paymentID)
+        KV_MEMBER(integratedAddress)
     }
 
     /* Only compare via name as we don't really care about the contents */

--- a/src/zedwallet/WalletConfig.h
+++ b/src/zedwallet/WalletConfig.h
@@ -44,7 +44,10 @@ namespace WalletConfig
 
 
     /* The length of a standard address for your coin */
-    const long unsigned int addressLength = 99;
+    const long unsigned int standardAddressLength = 99;
+
+    /* The length of an integrated address for your coin */
+    const long unsigned int integratedAddressLength = 236;
 
 
     /* The mixin value to use with transactions */


### PR DESCRIPTION
You can now transfer to an integrated address, add them to your address book (and send from your address book), and create them via `make_integrated_address`.

They're a massive 236 characters long!

A new field was added to the address book JSON - so it might wipe your existing address books :thinking: 

Next up - walletd.