### PR TITLE
Add integrated addresses to walletd

### DIFF
--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -353,4 +353,18 @@ void EstimateFusion::Response::serialize(CryptoNote::ISerializer& serializer) {
   serializer(totalOutputCount, "totalOutputCount");
 }
 
+void CreateIntegratedAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
+  if (!serializer(address, "address")) {
+    throw RequestSerializationError();
+  }
+
+  if (!serializer(paymentId, "paymentId")) {
+    throw RequestSerializationError();
+  }
+}
+
+void CreateIntegratedAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
+  serializer(integratedAddress, "integratedAddress");
+}
+
 }

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -425,4 +425,19 @@ struct EstimateFusion {
   };
 };
 
+struct CreateIntegratedAddress {
+  struct Request {
+    std::string address;
+    std::string paymentId;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+
+  struct Response {
+    std::string integratedAddress;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+};
+
 } //namespace PaymentService

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -191,7 +191,7 @@ std::error_code PaymentServiceJsonRpcServer::handleGetTransaction(const GetTrans
   return service.getTransaction(request.transactionHash, response.transaction);
 }
 
-std::error_code PaymentServiceJsonRpcServer::handleSendTransaction(const SendTransaction::Request& request, SendTransaction::Response& response) {
+std::error_code PaymentServiceJsonRpcServer::handleSendTransaction(SendTransaction::Request& request, SendTransaction::Response& response) {
   return service.sendTransaction(request, response.transactionHash);
 }
 

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -58,6 +58,7 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
   handlers.emplace("getAddresses", jsonHandler<GetAddresses::Request, GetAddresses::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetAddresses, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("sendFusionTransaction", jsonHandler<SendFusionTransaction::Request, SendFusionTransaction::Response>(std::bind(&PaymentServiceJsonRpcServer::handleSendFusionTransaction, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("estimateFusion", jsonHandler<EstimateFusion::Request, EstimateFusion::Response>(std::bind(&PaymentServiceJsonRpcServer::handleEstimateFusion, this, std::placeholders::_1, std::placeholders::_2)));
+  handlers.emplace("createIntegratedAddress", jsonHandler<CreateIntegratedAddress::Request, CreateIntegratedAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateIntegratedAddress, this, std::placeholders::_1, std::placeholders::_2)));
 }
 
 void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) {
@@ -232,6 +233,10 @@ std::error_code PaymentServiceJsonRpcServer::handleSendFusionTransaction(const S
 
 std::error_code PaymentServiceJsonRpcServer::handleEstimateFusion(const EstimateFusion::Request& request, EstimateFusion::Response& response) {
   return service.estimateFusion(request.threshold, request.addresses, response.fusionReadyCount, response.totalOutputCount);
+}
+
+std::error_code PaymentServiceJsonRpcServer::handleCreateIntegratedAddress(const CreateIntegratedAddress::Request& request, CreateIntegratedAddress::Response& response) {
+  return service.createIntegratedAddress(request.address, request.paymentId, response.integratedAddress);
 }
 
 }

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.h
@@ -84,7 +84,7 @@ private:
   std::error_code handleGetTransactions(const GetTransactions::Request& request, GetTransactions::Response& response);
   std::error_code handleGetUnconfirmedTransactionHashes(const GetUnconfirmedTransactionHashes::Request& request, GetUnconfirmedTransactionHashes::Response& response);
   std::error_code handleGetTransaction(const GetTransaction::Request& request, GetTransaction::Response& response);
-  std::error_code handleSendTransaction(const SendTransaction::Request& request, SendTransaction::Response& response);
+  std::error_code handleSendTransaction(SendTransaction::Request& request, SendTransaction::Response& response);
   std::error_code handleCreateDelayedTransaction(const CreateDelayedTransaction::Request& request, CreateDelayedTransaction::Response& response);
   std::error_code handleGetDelayedTransactionHashes(const GetDelayedTransactionHashes::Request& request, GetDelayedTransactionHashes::Response& response);
   std::error_code handleDeleteDelayedTransaction(const DeleteDelayedTransaction::Request& request, DeleteDelayedTransaction::Response& response);

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.h
@@ -96,6 +96,8 @@ private:
 
   std::error_code handleSendFusionTransaction(const SendFusionTransaction::Request& request, SendFusionTransaction::Response& response);
   std::error_code handleEstimateFusion(const EstimateFusion::Request& request, EstimateFusion::Response& response);
+  std::error_code handleCreateIntegratedAddress(const CreateIntegratedAddress::Request& request, CreateIntegratedAddress::Response& response);
+
 };
 
 }//namespace PaymentService

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -27,6 +27,7 @@
 
 #include <System/Timer.h>
 #include <System/InterruptedException.h>
+#include "Common/Base58.h"
 #include "Common/Util.h"
 
 #include "crypto/crypto.h"
@@ -1193,6 +1194,27 @@ std::error_code WalletService::estimateFusion(uint64_t threshold, const std::vec
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Failed to estimate number of fusion outputs: " << x.what();
     return make_error_code(CryptoNote::error::INTERNAL_WALLET_ERROR);
   }
+
+  return std::error_code();
+}
+
+std::error_code WalletService::createIntegratedAddress(const std::string &address, const std::string &paymentId, std::string& integratedAddress) {
+  try {
+    System::EventLock lk(readyEvent);
+
+    validateAddresses({address}, currency, logger);
+    validatePaymentId(paymentId, logger);
+
+  } catch (std::system_error& x) {
+    logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Error while creating integrated address: " << x.what();
+    return x.code();
+  }
+
+  integratedAddress = Tools::Base58::encode_addr
+  (
+    CryptoNote::parameters::CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX,
+    paymentId + address
+  );
 
   return std::error_code();
 }

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -86,7 +86,7 @@ public:
     uint32_t blockCount, const std::string& paymentId, std::vector<TransactionsInBlockRpcInfo>& transactionHashes);
   std::error_code getTransaction(const std::string& transactionHash, TransactionRpcInfo& transaction);
   std::error_code getAddresses(std::vector<std::string>& addresses);
-  std::error_code sendTransaction(const SendTransaction::Request& request, std::string& transactionHash);
+  std::error_code sendTransaction(SendTransaction::Request& request, std::string& transactionHash);
   std::error_code createDelayedTransaction(const CreateDelayedTransaction::Request& request, std::string& transactionHash);
   std::error_code getDelayedTransactionHashes(std::vector<std::string>& transactionHashes);
   std::error_code deleteDelayedTransaction(const std::string& transactionHash);

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -96,6 +96,7 @@ public:
   std::error_code sendFusionTransaction(uint64_t threshold, uint32_t anonymity, const std::vector<std::string>& addresses,
     const std::string& destinationAddress, std::string& transactionHash);
   std::error_code estimateFusion(uint64_t threshold, const std::vector<std::string>& addresses, uint32_t& fusionReadyCount, uint32_t& totalOutputCount);
+  std::error_code createIntegratedAddress(const std::string& address, const std::string& paymentId, std::string& integratedAddress);
 
 private:
   void refresh();

--- a/src/Wallet/WalletErrors.h
+++ b/src/Wallet/WalletErrors.h
@@ -56,7 +56,8 @@ enum WalletErrorCodes {
   BAD_PAYMENT_ID,
   BAD_TRANSACTION_EXTRA,
   MIXIN_BELOW_THRESHOLD,
-  MIXIN_ABOVE_THRESHOLD
+  MIXIN_ABOVE_THRESHOLD,
+  CONFLICTING_PAYMENT_IDS
 };
 
 // custom category:
@@ -105,6 +106,7 @@ public:
     case BAD_TRANSACTION_EXTRA:         return "Wrong transaction extra format";
     case MIXIN_BELOW_THRESHOLD:         return "Mixin below minimum allowed threshold";
     case MIXIN_ABOVE_THRESHOLD:         return "Mixin above maximum allowed threshold";
+    case CONFLICTING_PAYMENT_IDS:       return "Multiple conflicting payment ID's were specified via the use of integrated addresses";
     default:                            return "Unknown error";
     }
   }


### PR DESCRIPTION
Adds integrated address support to walletd. Adds a new RPC call, createIntegratedAddress(), that takes a parameter `address`, and a parameter `paymentId`, which returns an integrated address created from the two inputs.

This rpc call will need to be added to the relevant RPC libraries and the api-docs updated.

sendTransaction() will now support integrated addresses as arguments, and will correctly convert them to a payment ID and address pair internally.

Suggested usage is sending one transfer, with one integrated address, but if for some reason you want to also specify the payment ID in the json, that will work. If the payment ID in the json and extracted from the integrated address don't match, it will error out. Similarly, if you specify multiple integrated addresses in the transfers array, it will be allowed if all of the integrated addresses contain the same payment ID.

Again, not sure why you'd want this, but hey, support is there.

Exchanges or other services that require payment ID's can instead call createIntegratedAddress() with the desired address+payment ID, and supply this to users. Users need not worry about forgetting the payment ID, and the service can continue decoding their payment ID's on the receiving end as before.