### PR TITLE
Adds a send_all command to zedwallet

### DIFF
--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1322,6 +1322,25 @@ size_t WalletGreen::transfer(const TransactionParameters& transactionParameters)
   return id;
 }
 
+uint64_t WalletGreen::getBalanceMinusDust(const std::vector<std::string>& addresses)
+{
+    std::vector<WalletOuts> wallets = pickWallets(addresses);
+    std::vector<OutputToTransfer> unused;
+
+    /* We want to get the full balance, so don't stop getting outputs early */
+    uint64_t needed = std::numeric_limits<uint64_t>::max();
+
+    return selectTransfers
+    (
+        needed,
+        /* Don't include dust outputs */
+        false,
+        m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()),
+        std::move(wallets),
+        unused
+    );
+}
+
 void WalletGreen::prepareTransaction(std::vector<WalletOuts>&& wallets,
   const std::vector<WalletOrder>& orders,
   uint64_t fee,

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -95,6 +95,7 @@ public:
   void createViewWallet(const std::string &path, const std::string &password,
                         const std::string address, 
                         const Crypto::SecretKey &viewSecretKey);
+  uint64_t getBalanceMinusDust(const std::vector<std::string>& addresses);
 
   virtual void start() override;
   virtual void stop() override;

--- a/src/zedwallet/Commands.cpp
+++ b/src/zedwallet/Commands.cpp
@@ -158,6 +158,10 @@ bool dispatchCommand(std::shared_ptr<WalletInfo> &walletInfo,
     {
         createIntegratedAddress();
     }
+    else if (command == "send_all")
+    {
+        transfer(walletInfo, node.getLastKnownBlockHeight(), true);
+    }
     /* This should never happen */
     else
     {
@@ -265,7 +269,8 @@ std::vector<Command> allCommands()
         {"outgoing_transfers", "Show outgoing transfers", false, true},
         {"reset", "Recheck the chain from zero for transactions", true, true},
         {"save", "Save your wallet state", true, true},
-        {"save_csv", "Save all wallet transactions to a CSV file", false, true},
+        {"save_csv", "Save all wallet transactions to a CSV file", true, true},
+        {"send_all", "Send all your balance to someone", false, true},
         {"status", "Show the daemon status", true, true}
     };
 

--- a/src/zedwallet/Transfer.h
+++ b/src/zedwallet/Transfer.h
@@ -7,14 +7,19 @@
 #include <memory>
 
 #include <zedwallet/Types.h>
+#include <zedwallet/WalletConfig.h>
 
 enum AddressType {NotAnAddress, IntegratedAddress, StandardAddress};
 
-void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height);
+enum BalanceInfo {NotEnoughBalance, EnoughBalance, SetMixinToZero};
+
+void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height,
+              bool sendAll = false);
 
 void doTransfer(std::string address, uint64_t amount, uint64_t fee,
                 std::string extra, std::shared_ptr<WalletInfo> walletInfo,
-                uint32_t height, bool integratedAddress);
+                uint32_t height, bool integratedAddress,
+                uint64_t mixin = WalletConfig::defaultMixin);
 
 void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
                               std::vector<CryptoNote::TransactionParameters>
@@ -51,3 +56,7 @@ Maybe<uint64_t> getTransferAmount();
 
 Maybe<std::pair<std::string, std::string>> extractIntegratedAddress(
     std::string integratedAddress);
+
+BalanceInfo doWeHaveEnoughBalance(uint64_t amount, uint64_t fee,
+                                  std::shared_ptr<WalletInfo> walletInfo,
+                                  uint64_t height);


### PR DESCRIPTION
I still need to do a few more sanity checks to check all the edge cases behave as expected, but I think it's good.

I did add a method to walletgreen which lets you get the balance minus dust, which could potentially be helpful for walletd so GUI wallets can implement their send all or better error messages, though with the fork at 620k this probably isn't needed. Let me know if anyone wants it and i'll expose it, could actually add it to getBalance() as another field.