### PR TITLE
Fix non deterministic tx size

### DIFF
--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -33,6 +33,13 @@
 
 namespace CryptoNote {
 
+struct PreparedTransaction {
+    std::shared_ptr<ITransaction> transaction;
+    std::vector<WalletTransfer> destinations;
+    uint64_t neededMoney;
+    uint64_t changeAmount;
+};
+
 class WalletGreen : public IWallet,
                     ITransfersObserver,
                     IBlockchainSynchronizerObserver,
@@ -81,14 +88,17 @@ public:
   virtual std::vector<WalletTransactionWithTransfers> getUnconfirmedTransactions() const override;
   virtual std::vector<size_t> getDelayedTransactionIds() const override;
 
-  virtual size_t transfer(const TransactionParameters& sendingTransaction) override;
+  virtual size_t transfer(const TransactionParameters& transactionParameters) override;
 
   virtual size_t makeTransaction(const TransactionParameters& sendingTransaction) override;
   virtual void commitTransaction(size_t) override;
   virtual void rollbackUncommitedTransaction(size_t) override;
-  bool txIsTooLarge(const TransactionParameters& sendingTransaction);
-  size_t getTxSize(const TransactionParameters &sendingTransaction);
+
+  size_t transfer(const PreparedTransaction& preparedTransaction);
+  bool txIsTooLarge(const PreparedTransaction &p);
+  size_t getTxSize(const PreparedTransaction &p);
   size_t getMaxTxSize();
+  PreparedTransaction formTransaction(const TransactionParameters &sendingTransaction);
   void updateInternalCache();
   void clearCaches(bool clearTransactions, bool clearCachedData);
   void clearCacheAndShutdown();
@@ -221,13 +231,7 @@ protected:
   void pushEvent(const WalletEvent& event);
   bool isFusionTransaction(const WalletTransaction& walletTx) const;
 
-  struct PreparedTransaction {
-    std::unique_ptr<ITransaction> transaction;
-    std::vector<WalletTransfer> destinations;
-    uint64_t neededMoney;
-    uint64_t changeAmount;
-  };
-
+  
   void prepareTransaction(std::vector<WalletOuts>&& wallets,
     const std::vector<WalletOrder>& orders,
     uint64_t fee,

--- a/src/zedwallet/Fusion.cpp
+++ b/src/zedwallet/Fusion.cpp
@@ -207,10 +207,10 @@ bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold)
             }
             
             std::cout << std::endl
-                      << SuccessMsg("Will try again in 5 seconds...")
+                      << SuccessMsg("Will try again in 15 seconds...")
                       << std::endl;
 
-            std::this_thread::sleep_for(std::chrono::seconds(5));
+            std::this_thread::sleep_for(std::chrono::seconds(15));
 
             wallet.updateInternalCache();
         }

--- a/src/zedwallet/Transfer.h
+++ b/src/zedwallet/Transfer.h
@@ -21,12 +21,12 @@ void doTransfer(std::string address, uint64_t amount, uint64_t fee,
                 uint32_t height, bool integratedAddress,
                 uint64_t mixin = WalletConfig::defaultMixin);
 
-void sendMultipleTransactions(CryptoNote::WalletGreen &wallet,
-                              std::vector<CryptoNote::TransactionParameters>
-                              transfers);
+void splitTX(CryptoNote::WalletGreen &wallet,
+             const CryptoNote::TransactionParameters p);
 
-void splitTx(CryptoNote::WalletGreen &wallet,
-             CryptoNote::TransactionParameters p);
+void sendTX(std::shared_ptr<WalletInfo> walletInfo, 
+            CryptoNote::TransactionParameters p, uint32_t height,
+            bool retried = false);
 
 bool confirmTransaction(CryptoNote::TransactionParameters t,
                         std::shared_ptr<WalletInfo> walletInfo,
@@ -39,6 +39,9 @@ bool parseStandardAddress(std::string address, bool printErrors = false);
 bool parseIntegratedAddress(std::string address);
 
 bool parseFee(std::string feeString);
+
+bool handleTransferError(const std::system_error &e, bool retried,
+                         uint32_t height);
 
 AddressType parseAddress(std::string address);
 


### PR DESCRIPTION
So I only discovered this after the fork, I assume because dust makes things a lot large whilst not effecting the amount much -

You can create a transaction with it's parameters, then check the size of it, and it's good to send, then you go and send it, and it's too big. This is because when you just pass the transaction parameters to check the size, it's creating a new transaction each time. Because the mixin output picking is random, we pick different outputs each time, so what was a fine size the first time, might not be when we go to send it.

To fix this, we can instead 'prepare' our transaction, which does the mixin selection, and then go ahead and send this prepared transaction and the mixins will stay the same.

The issue with this is when we are splitting multiple transactions up, if we prepare each one to make sure they can all fit in before sending them, then they can possible use the same key image more than once.

So, there's no easy way to send multiple transactions with each transaction being the same uniform size (e.g., 10 transactions of 1000 TRTL). Instead, we use a dynamic approach where we prepare transactions as we go and send them, which means we can't get these nice uniform amounts, but it can actually be more efficient, e.g. we could do 1 transaction of 1k TRTL and 2 of 500 TRTL instead of 4 of 500 TRTL.

The math is a little harder in this form, from my tests it appears to function as expected, but there's quite a few edge cases which i'm not 100% confident on, for example running out of balance because you use a large fee, non divisible amounts, and so on.