### PR TITLE
Rework integrated addresses to be more compact

### DIFF
--- a/src/zedwallet/CommandImplementations.cpp
+++ b/src/zedwallet/CommandImplementations.cpp
@@ -320,25 +320,15 @@ void saveCSV(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node)
             continue;
         }
 
-        const std::string amount = formatAmountBasic(std::abs(t.totalAmount));
+        const std::string amount = formatAmountBasic(t.totalAmount);
 
         const std::string direction = t.totalAmount > 0 ? "IN" : "OUT";
 
         csv << unixTimeToDate(t.timestamp) << ","       /* Timestamp */
             << t.blockHeight << ","                     /* Block Height */
-            << Common::podToHex(t.hash) << ",";         /* Hash */
-            
-            /* Make outgoing transfers negative for easier spreadsheet math */
-            if (t.totalAmount < 0)
-            {
-                csv << "-" << amount << ",";
-            }
-            else
-            {
-                csv << amount << ",";
-            }
-            
-        csv << direction                                /* In/Out */
+            << Common::podToHex(t.hash) << ","          /* Hash */
+            << amount << ","                            /* Amount */
+            << direction                                /* In/Out */
             << std::endl;
     }
 

--- a/src/zedwallet/Commands.cpp
+++ b/src/zedwallet/Commands.cpp
@@ -154,7 +154,7 @@ bool dispatchCommand(std::shared_ptr<WalletInfo> &walletInfo,
     {
         changePassword(walletInfo);
     }
-    else if (command == "make_integrated_address")
+    else if (command == "create_integrated_address")
     {
         createIntegratedAddress();
     }
@@ -260,8 +260,8 @@ std::vector<Command> allCommands()
         {"bc_height", "Show the blockchain height", true, true},
         {"change_password", "Change your wallet password", true, true},
 
-        {"make_integrated_address", "Make an integrated address from an "
-                                    "address + payment ID", true, true},
+        {"create_integrated_address", "Make an integrated address from an "
+                                      "address + payment ID", true, true},
 
         {"incoming_transfers", "Show incoming transfers", true, true},
         {"list_transfers", "Show all transfers", false, true},

--- a/src/zedwallet/Tools.cpp
+++ b/src/zedwallet/Tools.cpp
@@ -11,6 +11,8 @@
 #include <Common/Base58.h>
 #include <Common/StringTools.h>
 
+#include <CryptoNoteCore/CryptoNoteBasicImpl.h>
+#include <CryptoNoteCore/CryptoNoteTools.h>
 #include <CryptoNoteCore/TransactionExtra.h>
 
 #include <zedwallet/ColouredMsg.h>
@@ -226,9 +228,23 @@ std::string unixTimeToDate(uint64_t timestamp)
 
 std::string createIntegratedAddress(std::string address, std::string paymentID)
 {
+    uint64_t prefix;
+
+    CryptoNote::AccountPublicAddress addr;
+
+    /* Get the private + public key from the address */
+    const bool valid = CryptoNote::parseAccountAddressString(prefix, addr,
+                                                             address);
+
+    /* Pack as a binary array */
+    CryptoNote::BinaryArray ba;
+    CryptoNote::toBinaryArray(addr, ba);
+    std::string keys = Common::asString(ba);
+
+    /* Encode prefix + paymentID + keys as an address */
     return Tools::Base58::encode_addr
     (
         CryptoNote::parameters::CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX,
-        paymentID + address
+        paymentID + keys
     );
 }

--- a/src/zedwallet/WalletConfig.h
+++ b/src/zedwallet/WalletConfig.h
@@ -46,9 +46,13 @@ namespace WalletConfig
     /* The length of a standard address for your coin */
     const long unsigned int standardAddressLength = 99;
 
-    /* The length of an integrated address for your coin */
-    const long unsigned int integratedAddressLength = 236;
-
+    /* The length of an integrated address for your coin - It's the same as
+       a normal address, but there is a paymentID included in there - since
+       payment ID's are 64 chars, and base58 encoding is done by encoding
+       chunks of 8 chars at once into blocks of 11 chars, we can calculate
+       this automatically */
+    const long unsigned int integratedAddressLength = standardAddressLength
+                                                    + ((64 * 11) / 8);
 
     /* The mixin value to use with transactions */
     const uint64_t defaultMixin = CryptoNote::parameters::DEFAULT_MIXIN;


### PR DESCRIPTION
~~Don't merge yet, I don't have a synced wallet to test yet.~~

As katz pointed out, we do some weird encoding where we take the address, add a payment ID to that, and encode it with base58, along with another prefix and checksum which we've already got in the standard address.

Instead, we should just encode the paymentID + two keys, and then add the prefix and checksum to that. This brings integrated address lengths down from 231 chars to 187 chars.