### PR TITLE
Revert "WARNING: Breaking change. removes additional binary serializers from the wallet <-> node communication payloads"

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -56,7 +56,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST {
     std::vector<Crypto::Hash> block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
     
     void serialize(ISerializer &s) {
-      KV_MEMBER(block_ids);
+      serializeAsBinary(block_ids, "block_ids", s);
     }
   };
 
@@ -97,7 +97,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES {
 
     void serialize(ISerializer &s) {
       KV_MEMBER(tailBlockId)
-      KV_MEMBER(knownTxsIds);
+      serializeAsBinary(knownTxsIds, "knownTxsIds", s);
     }
   };
 
@@ -110,7 +110,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES {
     void serialize(ISerializer &s) {
       KV_MEMBER(isTailBlockActual)
       KV_MEMBER(addedTxs)
-      KV_MEMBER(deletedTxsIds);
+      serializeAsBinary(deletedTxsIds, "deletedTxsIds", s);
       KV_MEMBER(status)
     }
   };
@@ -123,7 +123,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES_LITE {
 
     void serialize(ISerializer &s) {
       KV_MEMBER(tailBlockId)
-      KV_MEMBER(knownTxsIds);
+      serializeAsBinary(knownTxsIds, "knownTxsIds", s);
     }
   };
 
@@ -136,7 +136,7 @@ struct COMMAND_RPC_GET_POOL_CHANGES_LITE {
     void serialize(ISerializer &s) {
       KV_MEMBER(isTailBlockActual)
       KV_MEMBER(addedTxs)
-      KV_MEMBER(deletedTxsIds);
+      serializeAsBinary(deletedTxsIds, "deletedTxsIds", s);
       KV_MEMBER(status)
     }
   };
@@ -178,11 +178,6 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_request {
 struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_out_entry {
   uint32_t global_amount_index;
   Crypto::PublicKey out_key;
-  
-  void serialize(ISerializer &s) {
-    KV_MEMBER(global_amount_index)
-    KV_MEMBER(out_key);
-  }
 };
 #pragma pack(pop)
 
@@ -192,7 +187,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_outs_for_amount {
 
   void serialize(ISerializer &s) {
     KV_MEMBER(amount)
-    KV_MEMBER(outs);
+    serializeAsBinary(outs, "outs", s);
   }
 };
 
@@ -673,7 +668,7 @@ struct COMMAND_RPC_QUERY_BLOCKS {
     uint64_t timestamp;
 
     void serialize(ISerializer &s) {
-      KV_MEMBER(block_ids);
+      serializeAsBinary(block_ids, "block_ids", s);
       KV_MEMBER(timestamp)
     }
   };
@@ -701,7 +696,7 @@ struct COMMAND_RPC_QUERY_BLOCKS_LITE {
     uint64_t timestamp;
 
     void serialize(ISerializer &s) {
-      KV_MEMBER(blockIds);
+      serializeAsBinary(blockIds, "block_ids", s);
       KV_MEMBER(timestamp)
     }
   };
@@ -728,7 +723,7 @@ struct COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HEIGHTS {
     std::vector<uint32_t> blockHeights;
 
     void serialize(ISerializer& s) {
-      KV_MEMBER(blockHeights);
+      serializeAsBinary(blockHeights, "blockHeights", s);
     }
   };
 
@@ -748,7 +743,7 @@ struct COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HASHES {
     std::vector<Crypto::Hash> blockHashes;
 
     void serialize(ISerializer& s) {
-      KV_MEMBER(blockHashes);
+      serializeAsBinary(blockHashes, "blockHashes", s);
     }
   };
 
@@ -820,7 +815,7 @@ struct COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID {
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
-      KV_MEMBER(transactionHashes);
+      serializeAsBinary(transactionHashes, "transactionHashes", s);
     }
   };
 };
@@ -830,7 +825,7 @@ struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASHES {
     std::vector<Crypto::Hash> transactionHashes;
 
     void serialize(ISerializer &s) {
-      KV_MEMBER(transactionHashes);
+      serializeAsBinary(transactionHashes, "transactionHashes", s);
     }
   };
 


### PR DESCRIPTION
This reverts commit 99670d42184600991187f491122730c18d8d6478.

Well.. geez... this is embarrassing.