### PR TITLE
[ENHANCEMENT] Adding node convenience charges to turtle-service

### DIFF
--- a/src/WalletService/PaymentServiceJsonRpcMessages.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.cpp
@@ -1,19 +1,8 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #include "PaymentServiceJsonRpcMessages.h"
 #include "Serialization/SerializationOverloads.h"
@@ -365,6 +354,14 @@ void CreateIntegratedAddress::Request::serialize(CryptoNote::ISerializer& serial
 
 void CreateIntegratedAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
   serializer(integratedAddress, "integratedAddress");
+}
+
+void NodeFeeInfo::Request::serialize(CryptoNote::ISerializer& serializer) {
+}
+
+void NodeFeeInfo::Response::serialize(CryptoNote::ISerializer& serializer) {
+  serializer(address, "address");
+  serializer(amount, "amount");
 }
 
 }

--- a/src/WalletService/PaymentServiceJsonRpcMessages.h
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.h
@@ -1,19 +1,8 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #pragma once
 
@@ -436,6 +425,19 @@ struct CreateIntegratedAddress {
   struct Response {
     std::string integratedAddress;
 
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+};
+
+struct NodeFeeInfo {
+  struct Request {
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+  
+  struct Response {
+    std::string address;
+    uint32_t amount;
+    
     void serialize(CryptoNote::ISerializer& serializer);
   };
 };

--- a/src/WalletService/PaymentServiceJsonRpcServer.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcServer.cpp
@@ -1,19 +1,8 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #include "PaymentServiceJsonRpcServer.h"
 
@@ -59,6 +48,7 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
   handlers.emplace("sendFusionTransaction", jsonHandler<SendFusionTransaction::Request, SendFusionTransaction::Response>(std::bind(&PaymentServiceJsonRpcServer::handleSendFusionTransaction, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("estimateFusion", jsonHandler<EstimateFusion::Request, EstimateFusion::Response>(std::bind(&PaymentServiceJsonRpcServer::handleEstimateFusion, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("createIntegratedAddress", jsonHandler<CreateIntegratedAddress::Request, CreateIntegratedAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateIntegratedAddress, this, std::placeholders::_1, std::placeholders::_2)));
+  handlers.emplace("feeinfo", jsonHandler<NodeFeeInfo::Request, NodeFeeInfo::Response>(std::bind(&PaymentServiceJsonRpcServer::handleNodeFeeInfo, this, std::placeholders::_1, std::placeholders::_2)));
 }
 
 void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) {
@@ -237,6 +227,10 @@ std::error_code PaymentServiceJsonRpcServer::handleEstimateFusion(const Estimate
 
 std::error_code PaymentServiceJsonRpcServer::handleCreateIntegratedAddress(const CreateIntegratedAddress::Request& request, CreateIntegratedAddress::Response& response) {
   return service.createIntegratedAddress(request.address, request.paymentId, response.integratedAddress);
+}
+
+std::error_code PaymentServiceJsonRpcServer::handleNodeFeeInfo(const NodeFeeInfo::Request& request, NodeFeeInfo::Response& response) {
+  return service.getFeeInfo(response.address, response.amount);
 }
 
 }

--- a/src/WalletService/PaymentServiceJsonRpcServer.h
+++ b/src/WalletService/PaymentServiceJsonRpcServer.h
@@ -1,19 +1,8 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #pragma once
 
@@ -97,7 +86,8 @@ private:
   std::error_code handleSendFusionTransaction(const SendFusionTransaction::Request& request, SendFusionTransaction::Response& response);
   std::error_code handleEstimateFusion(const EstimateFusion::Request& request, EstimateFusion::Response& response);
   std::error_code handleCreateIntegratedAddress(const CreateIntegratedAddress::Request& request, CreateIntegratedAddress::Response& response);
-
+  std::error_code handleNodeFeeInfo(const NodeFeeInfo::Request& request, NodeFeeInfo::Response& response);
+  
 };
 
 }//namespace PaymentService

--- a/src/WalletService/WalletService.cpp
+++ b/src/WalletService/WalletService.cpp
@@ -1,19 +1,8 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #include "WalletService.h"
 
@@ -333,9 +322,15 @@ std::vector<std::string> collectDestinationAddresses(const std::vector<PaymentSe
   return result;
 }
 
-std::vector<CryptoNote::WalletOrder> convertWalletRpcOrdersToWalletOrders(const std::vector<PaymentService::WalletRpcOrder>& orders) {
+std::vector<CryptoNote::WalletOrder> convertWalletRpcOrdersToWalletOrders(const std::vector<PaymentService::WalletRpcOrder>& orders, const std::string nodeAddress, const uint32_t nodeFee) {
   std::vector<CryptoNote::WalletOrder> result;
-  result.reserve(orders.size());
+  
+  if (!nodeAddress.empty() && nodeFee != 0) {
+    result.reserve(orders.size() + 1);
+    result.emplace_back(CryptoNote::WalletOrder {nodeAddress, nodeFee});
+  } else {
+    result.reserve(orders.size());
+  }
 
   for (const auto& order: orders) {
     result.emplace_back(CryptoNote::WalletOrder {order.address, order.amount});
@@ -452,9 +447,41 @@ void WalletService::init() {
   loadWallet();
   loadTransactionIdIndex();
 
+  getNodeFee();
   refreshContext.spawn([this] { refresh(); });
-
+  
   inited = true;
+}
+
+void WalletService::getNodeFee() {
+  logger(Logging::DEBUGGING) <<
+    "Trying to retrieve node fee information." << std::endl;
+    
+  m_node_address = node.feeAddress();
+  m_node_fee = node.feeAmount();
+  
+  if (!m_node_address.empty() && m_node_fee != 0) {
+    // Partially borrowed from <zedwallet/Tools.h>
+    uint32_t div = static_cast<uint32_t>(pow(10, CryptoNote::parameters::CRYPTONOTE_DISPLAY_DECIMAL_POINT));
+    uint32_t coins = m_node_fee / div;
+    uint32_t cents = m_node_fee % div;
+    std::stringstream stream;
+    stream << std::setfill('0') << std::setw(CryptoNote::parameters::CRYPTONOTE_DISPLAY_DECIMAL_POINT) << cents;
+    std::string amount = std::to_string(coins) + "." + stream.str();
+    
+    logger(Logging::INFO, Logging::RED) << 
+      "You have connected to a node that charges " <<
+      "a fee to send transactions." << std::endl;
+    
+    logger(Logging::INFO, Logging::RED) << 
+      "The fee for sending transactions is: " <<
+      amount << " per transaction." << std::endl ;
+    
+    logger(Logging::INFO, Logging::RED) <<
+      "If you don't want to pay the node fee, please " <<
+      "relaunch this program and specify a different " <<
+      "node or run your own." << std::endl;
+  }
 }
 
 void WalletService::saveWallet() {
@@ -949,7 +976,7 @@ std::error_code WalletService::sendTransaction(SendTransaction::Request& request
     std::transform(request.paymentId.begin(), request.paymentId.end(), request.paymentId.begin(), ::toupper);
 
     std::vector<std::string> paymentIDs;
-
+    
     for (auto &transfer : request.transfers)
     {
         std::string addr = transfer.address;
@@ -1051,7 +1078,7 @@ std::error_code WalletService::sendTransaction(SendTransaction::Request& request
     }
 
     sendParams.sourceAddresses = request.sourceAddresses;
-    sendParams.destinations = convertWalletRpcOrdersToWalletOrders(request.transfers);
+    sendParams.destinations = convertWalletRpcOrdersToWalletOrders(request.transfers, m_node_address, m_node_fee);
     sendParams.fee = request.fee;
     sendParams.mixIn = request.anonymity;
     sendParams.unlockTimestamp = request.unlockTime;
@@ -1090,7 +1117,7 @@ std::error_code WalletService::createDelayedTransaction(const CreateDelayedTrans
     }
 
     sendParams.sourceAddresses = request.addresses;
-    sendParams.destinations = convertWalletRpcOrdersToWalletOrders(request.transfers);
+    sendParams.destinations = convertWalletRpcOrdersToWalletOrders(request.transfers, m_node_address, m_node_fee);
     sendParams.fee = request.fee;
     sendParams.mixIn = request.anonymity;
     sendParams.unlockTimestamp = request.unlockTime;
@@ -1322,6 +1349,13 @@ std::error_code WalletService::createIntegratedAddress(const std::string &addres
       paymentId + keys
   );
 
+  return std::error_code();
+}
+
+std::error_code WalletService::getFeeInfo(std::string& address, uint32_t& amount) {
+  address = m_node_address;
+  amount = m_node_fee;
+  
   return std::error_code();
 }
 

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -1,19 +1,8 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #pragma once
 
@@ -97,6 +86,7 @@ public:
     const std::string& destinationAddress, std::string& transactionHash);
   std::error_code estimateFusion(uint64_t threshold, const std::vector<std::string>& addresses, uint32_t& fusionReadyCount, uint32_t& totalOutputCount);
   std::error_code createIntegratedAddress(const std::string& address, const std::string& paymentId, std::string& integratedAddress);
+  std::error_code getFeeInfo(std::string& address, uint32_t& amount);
 
 private:
   void refresh();
@@ -104,6 +94,7 @@ private:
 
   void loadWallet();
   void loadTransactionIdIndex();
+  void getNodeFee();
 
   void replaceWithNewWallet(const Crypto::SecretKey& viewSecretKey);
 
@@ -126,6 +117,8 @@ private:
   System::Dispatcher& dispatcher;
   System::Event readyEvent;
   System::ContextGroup refreshContext;
+  std::string m_node_address;
+  uint32_t m_node_fee;
 
   std::map<std::string, size_t> transactionIdIndex;
 };

--- a/src/WalletService/main.cpp
+++ b/src/WalletService/main.cpp
@@ -39,7 +39,7 @@
 #include <errno.h>
 #endif
 
-#define SERVICE_NAME "Payment Gate"
+#define SERVICE_NAME "Turtle-Service"
 
 PaymentGateService* ppg;
 
@@ -304,7 +304,7 @@ int main(int argc, char** argv) {
       return 0; //help message requested or so
     }
 
-    Logging::LoggerRef(pg.getLogger(), "main")(Logging::INFO) << "walletd v" << PROJECT_VERSION_LONG;
+    Logging::LoggerRef(pg.getLogger(), "main")(Logging::INFO) << "turtle-service v" << PROJECT_VERSION_LONG;
 
     const auto& config = pg.getConfig();
 


### PR DESCRIPTION
This pull exposes the `feeinfo` JSON RPC method for `turtle-service` that relays the information from `/feeinfo` from a daemon.

It also automatically applies the node convenience charges to all transactions sent through `turtle-service` if the node being used specifies one. It does **not** charge this fee on fusion transactions.

Please do not merge without review from others.