### PR TITLE
[ENHANCEMENT] Flag for aarch64 (aka ARM64) so that it builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@ enable_language(C)
 enable_language(CXX)
 find_package(Threads)
 
+# Need this to build on aarch64 (aka Arm64) - you must have a 64bit ARM CPU.
+if(NOT MSVC)
+  execute_process(COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE)
+  message(STATUS "Setting up for ${ARCHITECTURE}")
+  if(${ARCHITECTURE} STREQUAL "aarch64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+endif()
+
 set(VERSION "0.1")
 # $Format:Packaged from commit %H%nset(COMMIT %h)%nset(REFS "%d")$
 


### PR DESCRIPTION
Someone wanna give this a go on a Raspberry PI 3 B+?

[turtlecoin-0.7.1rc-arm64.tar.gz](https://github.com/turtlecoin/turtlecoin/files/2304750/turtlecoin-0.7.1rc-arm64.tar.gz)

This was built on my ARM Cortex-A53 w/ Ubuntu Xenial

```
ldd TurtleCoind
linux-vdso.so.1 =>  (0x0000ffff8b7b1000)
libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff8b747000)
libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff8b69a000)
libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff8b553000)
/lib/ld-linux-aarch64.so.1 (0x0000ffff8b786000)
```

```
2018-Aug-21 03:46:23.542002 INFO    Block 19800 (0218f8a5369ca2390db3cffb279238dacce2be46750a6472e89ebe8d4b3fa442) added to main chain
2018-Aug-21 03:46:25.262487 INFO    Block 19900 (f760790b6d8ac9412811ebe803d4e2e59395bc0f797c23fc8c688b3d80ad3c1a) added to main chain
2018-Aug-21 03:46:27.067416 INFO    CHECKPOINT PASSED FOR INDEX 20000 aed3a0fe6adc5a828e4b9cfa97cea53d2ae565089b583756058e5c71682fde4d
2018-Aug-21 03:46:27.070796 INFO    Block 20000 (aed3a0fe6adc5a828e4b9cfa97cea53d2ae565089b583756058e5c71682fde4d) added to main chain
2018-Aug-21 03:46:28.810582 INFO    Block 20100 (ec35ee0dfb09015ba2bd441174ef788ad1c34b4dbb6cdfc551514040332b6e59) added to main chain
```