### PR TITLE
Attempt to fix ctrl+c handling (TurtleCoind)

### DIFF
--- a/external/linenoise/linenoise.h
+++ b/external/linenoise/linenoise.h
@@ -70,6 +70,7 @@ int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
+void linenoiseSetRaiseOnInt(int r);
 
 typedef size_t (linenoisePrevCharLen)(const char *buf, size_t buf_len, size_t pos, size_t *col_len);
 typedef size_t (linenoiseNextCharLen)(const char *buf, size_t buf_len, size_t pos, size_t *col_len);

--- a/src/Common/ConsoleHandler.cpp
+++ b/src/Common/ConsoleHandler.cpp
@@ -189,7 +189,7 @@ namespace Common {
         m_thread.join();
       }
     } catch (std::exception& e) {
-      std::cerr << "Exception in ConsoleHandler::wait - " << e.what() << std::endl;
+      //std::cerr << "Exception in ConsoleHandler::wait - " << e.what() << std::endl;
     }
   }
 
@@ -269,6 +269,7 @@ namespace Common {
     char *cline;
     linenoiseSetCompletionCallback( completionCallback );
     linenoiseHistorySetMaxLen(256);
+    linenoiseSetRaiseOnInt(1);
     linenoiseSetEncodingFunctions(linenoiseUtf8PrevCharLen, linenoiseUtf8NextCharLen, linenoiseUtf8ReadCode);
     while(!m_consoleReader.stopped() && (cline = linenoise("\033[0m")) != NULL) {
         try{
@@ -277,12 +278,12 @@ namespace Common {
                 line = std::string(cline);
                 linenoiseFree(cline);
                 boost::algorithm::trim(line);
-                std::cout << "" << std::endl;
                 if (!line.empty()) {
+                    std::cout << "" << std::endl;
                     handleCommand(line);
+                    std::cout << "" << std::endl;
                 }
             }
-            std::cout.flush();
         } catch (std::exception&) {
             // do nothing    
         }


### PR DESCRIPTION
- fixes a need to double ctrl+c to quit.
- if prompt currently contains a command, ctrl+c will reset the line/cancel the command
- if prompt is empty, ctrl+c raise terminate signal/quit