### PR TITLE
[ENHANCEMENT] Allow scanning from a specific height when importing a wallet

### DIFF
--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -133,13 +133,14 @@ public:
   virtual ~IWallet() {}
 
   virtual void initialize(const std::string& path, const std::string& password) = 0;
-  virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey) = 0;
+  virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey, const uint64_t scanHeight, const bool newAddress) = 0;
   virtual void load(const std::string& path, const std::string& password, std::string& extra) = 0;
   virtual void load(const std::string& path, const std::string& password) = 0;
   virtual void shutdown() = 0;
 
   virtual void changePassword(const std::string& oldPassword, const std::string& newPassword) = 0;
   virtual void save(WalletSaveLevel saveLevel = WalletSaveLevel::SAVE_ALL, const std::string& extra = "") = 0;
+  virtual void reset(const uint64_t scanHeight) = 0;
   virtual void exportWallet(const std::string& path, bool encrypt = true, WalletSaveLevel saveLevel = WalletSaveLevel::SAVE_ALL, const std::string& extra = "") = 0;
 
   virtual size_t getAddressCount() const = 0;

--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -147,10 +147,13 @@ public:
   virtual KeyPair getAddressSpendKey(size_t index) const = 0;
   virtual KeyPair getAddressSpendKey(const std::string& address) const = 0;
   virtual KeyPair getViewKey() const = 0;
+
   virtual std::string createAddress() = 0;
-  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) = 0;
-  virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) = 0;
-  virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys) = 0;
+  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey, const uint64_t scanHeight, const bool newAddress) = 0;
+  virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey, const uint64_t scanHeight, const bool newAddress) = 0;
+
+  virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys, const uint64_t scanHeight, const bool newAddress) = 0;
+
   virtual void deleteAddress(const std::string& address) = 0;
 
   virtual uint64_t getActualBalance() const = 0;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -70,6 +70,11 @@ TurtleCoind --print-genesis-tx --genesis-block-reward-address TRTLv2Fyavy8CXG8BP
 */
 const char     GENESIS_COINBASE_TX_HEX[]                     = "010a01ff000188f3b501029b2e4c0281c0b02e7c53291a94d1d0cbff8883f8024f5142ee494ffbbd088071210142694232c5b04151d9e4c27d31ec7a68ea568b19488cfcb422659a07a0e44dd5";
 
+/* This is the unix timestamp of the first "mined" block (technically block 2, not the genesis block)
+   You can get this value by doing "print_block 2" in TurtleCoind. It is used to know what timestamp
+   to import from when the block height cannot be found in the node or the node is offline. */
+const uint64_t GENESIS_BLOCK_TIMESTAMP                       = 1512800692;
+
 const size_t   CRYPTONOTE_REWARD_BLOCKS_WINDOW               = 100;
 const size_t   CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE     = 100000; //size of block (bytes) after which reward for block calculated using block size
 const size_t   CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2  = 20000;

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -149,7 +149,9 @@ WalletGreen::~WalletGreen() {
 void WalletGreen::createViewWallet(const std::string &path,
                                    const std::string &password,
                                    const std::string address,
-                                   const Crypto::SecretKey &viewSecretKey)
+                                   const Crypto::SecretKey &viewSecretKey,
+                                   const uint64_t scanHeight,
+                                   bool newAddress)
 {
     CryptoNote::AccountPublicAddress publicKeys;
     uint64_t prefix;
@@ -160,7 +162,8 @@ void WalletGreen::createViewWallet(const std::string &path,
     }
 
     initializeWithViewKey(path, password, viewSecretKey);
-    createAddress(publicKeys.spendPublicKey);
+
+    createAddress(publicKeys.spendPublicKey, scanHeight, newAddress);
 }
 
 void WalletGreen::initialize(const std::string& path, const std::string& password) {
@@ -782,7 +785,7 @@ void WalletGreen::subscribeWallets() {
       sub.keys.spendSecretKey = wallet.spendSecretKey;
       sub.transactionSpendableAge = m_transactionSoftLockTime;
       sub.syncStart.height = 0;
-      sub.syncStart.timestamp = std::max(static_cast<uint64_t>(wallet.creationTimestamp), ACCOUNT_CREATE_TIME_ACCURACY) - ACCOUNT_CREATE_TIME_ACCURACY;
+      sub.syncStart.timestamp = wallet.creationTimestamp;
 
       auto& subscription = m_synchronizer.addSubscription(sub);
       bool r = index.modify(it, [&subscription](WalletRecord& rec) { rec.container = &subscription.getContainer(); });
@@ -959,71 +962,112 @@ KeyPair WalletGreen::getViewKey() const {
   return {m_viewPublicKey, m_viewSecretKey};
 }
 
-std::string WalletGreen::createAddress() {
-  KeyPair spendKey;
-  Crypto::generate_keys(spendKey.publicKey, spendKey.secretKey);
-  uint64_t creationTimestamp = static_cast<uint64_t>(time(nullptr));
+std::string WalletGreen::createAddress()
+{
+    KeyPair spendKey;
 
-  return doCreateAddress(spendKey.publicKey, spendKey.secretKey, creationTimestamp);
+    Crypto::generate_keys(spendKey.publicKey, spendKey.secretKey);
+
+    return doCreateAddress(spendKey.publicKey, spendKey.secretKey, 0, true);
 }
 
-std::string WalletGreen::createAddress(const Crypto::SecretKey& spendSecretKey) {
-  Crypto::PublicKey spendPublicKey;
-  if (!Crypto::secret_key_to_public_key(spendSecretKey, spendPublicKey)) {
-    m_logger(ERROR, BRIGHT_RED) << "createAddress(" << spendSecretKey << ") Failed to convert secret key to public key";
-    throw std::system_error(make_error_code(CryptoNote::error::KEY_GENERATION_ERROR));
-  }
-
-  return doCreateAddress(spendPublicKey, spendSecretKey, 0);
-}
-
-std::string WalletGreen::createAddress(const Crypto::PublicKey& spendPublicKey) {
-  if (!Crypto::check_key(spendPublicKey)) {
-    m_logger(ERROR, BRIGHT_RED) << "createAddress(" << spendPublicKey << ") Wrong public key format";
-    throw std::system_error(make_error_code(error::WRONG_PARAMETERS), "Wrong public key format");
-  }
-
-  return doCreateAddress(spendPublicKey, NULL_SECRET_KEY, 0);
-}
-
-std::vector<std::string> WalletGreen::createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys) {
-  std::vector<NewAddressData> addressDataList(spendSecretKeys.size());
-  for (size_t i = 0; i < spendSecretKeys.size(); ++i) {
+std::string WalletGreen::createAddress(const Crypto::SecretKey& spendSecretKey, const uint64_t scanHeight, const bool newAddress)
+{
     Crypto::PublicKey spendPublicKey;
-    if (!Crypto::secret_key_to_public_key(spendSecretKeys[i], spendPublicKey)) {
-      m_logger(ERROR, BRIGHT_RED) << "createAddressList(): failed to convert secret key to public key, secret key " << spendSecretKeys[i];
-      throw std::system_error(make_error_code(CryptoNote::error::KEY_GENERATION_ERROR));
+
+    if (!Crypto::secret_key_to_public_key(spendSecretKey, spendPublicKey))
+    {
+        m_logger(ERROR, BRIGHT_RED) << "createAddress(" << spendSecretKey << ") Failed to convert secret key to public key";
+        throw std::system_error(make_error_code(CryptoNote::error::KEY_GENERATION_ERROR));
     }
 
-    addressDataList[i].spendSecretKey = spendSecretKeys[i];
-    addressDataList[i].spendPublicKey = spendPublicKey;
-    addressDataList[i].creationTimestamp = 0;
-  }
-
-  return doCreateAddressList(addressDataList);
+    return doCreateAddress(spendPublicKey, spendSecretKey, scanHeight, newAddress);
 }
 
-std::string WalletGreen::doCreateAddress(const Crypto::PublicKey& spendPublicKey, const Crypto::SecretKey& spendSecretKey, uint64_t creationTimestamp) {
-  assert(creationTimestamp <= std::numeric_limits<uint64_t>::max() - m_currency.blockFutureTimeLimit(0));
+std::string WalletGreen::createAddress(const Crypto::PublicKey& spendPublicKey, const uint64_t scanHeight, const bool newAddress)
+{
+    if (!Crypto::check_key(spendPublicKey))
+    {
+        m_logger(ERROR, BRIGHT_RED) << "createAddress(" << spendPublicKey << ") Wrong public key format";
+        throw std::system_error(make_error_code(error::WRONG_PARAMETERS), "Wrong public key format");
+    }
 
-  std::vector<NewAddressData> addressDataList;
-  addressDataList.push_back(NewAddressData{ spendPublicKey, spendSecretKey, creationTimestamp });
-  std::vector<std::string> addresses = doCreateAddressList(addressDataList);
-  assert(addresses.size() == 1);
-
-  return addresses.front();
+    return doCreateAddress(spendPublicKey, NULL_SECRET_KEY, scanHeight, newAddress);
 }
 
-std::vector<std::string> WalletGreen::doCreateAddressList(const std::vector<NewAddressData>& addressDataList) {
+std::vector<std::string> WalletGreen::createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys, const uint64_t scanHeight, const bool newAddress)
+{
+    std::vector<NewAddressData> addressDataList(spendSecretKeys.size());
+
+    for (size_t i = 0; i < spendSecretKeys.size(); ++i)
+    {
+        Crypto::PublicKey spendPublicKey;
+
+        if (!Crypto::secret_key_to_public_key(spendSecretKeys[i], spendPublicKey))
+        {
+            m_logger(ERROR, BRIGHT_RED) << "createAddressList(): failed to convert secret key to public key, secret key " << spendSecretKeys[i];
+            throw std::system_error(make_error_code(CryptoNote::error::KEY_GENERATION_ERROR));
+        }
+
+        addressDataList[i].spendSecretKey = spendSecretKeys[i];
+        addressDataList[i].spendPublicKey = spendPublicKey;
+    }
+
+    return doCreateAddressList(addressDataList, scanHeight, newAddress);
+}
+
+std::string WalletGreen::doCreateAddress(const Crypto::PublicKey& spendPublicKey, const Crypto::SecretKey& spendSecretKey, const uint64_t scanHeight, const bool newAddress)
+{
+    std::vector<NewAddressData> addressDataList;
+
+    addressDataList.push_back(NewAddressData{ spendPublicKey, spendSecretKey });
+
+    std::vector<std::string> addresses = doCreateAddressList(addressDataList, scanHeight, newAddress);
+
+    assert(addresses.size() == 1);
+
+    return addresses.front();
+}
+
+std::vector<std::string> WalletGreen::doCreateAddressList(const std::vector<NewAddressData>& addressDataList, const uint64_t scanHeight, const bool newAddress) {
   throwIfNotInitialized();
   throwIfStopped();
 
   stopBlockchainSynchronizer();
 
   std::vector<std::string> addresses;
-  try {
-    uint64_t minCreationTimestamp = std::numeric_limits<uint64_t>::max();
 
+  bool resetRequired = false;
+
+  const auto& walletsIndex = m_walletsContainer.get<RandomAccessIndex>();
+
+  /* If there are already existing wallets, we need to check their creation
+     timestamps. If their creation timestamps are greater than the timestamp
+     of the wallet we are currently adding, we will have to rescan from this
+     lower height to get the blocks we need. */
+  if (!walletsIndex.empty() && !newAddress)
+  {
+      uint64_t timestamp = scanHeightToTimestamp(scanHeight);
+
+      time_t minTimestamp = std::numeric_limits<time_t>::max();
+
+      for (const WalletRecord& wallet : walletsIndex)
+      {
+          std::cout << wallet.creationTimestamp << std::endl;
+
+          if (wallet.creationTimestamp < minTimestamp)
+          {
+              minTimestamp = wallet.creationTimestamp;
+          }
+      }
+
+      if (timestamp < static_cast<uint64_t>(minTimestamp))
+      {
+          resetRequired = true;
+      }
+  }
+
+  try {
     {
       if (addressDataList.size() > 1) {
         m_containerStorage.setAutoFlush(false);
@@ -1037,19 +1081,19 @@ std::vector<std::string> WalletGreen::doCreateAddressList(const std::vector<NewA
       });
 
       for (auto& addressData : addressDataList) {
-        assert(addressData.creationTimestamp <= std::numeric_limits<uint64_t>::max() - m_currency.blockFutureTimeLimit(0));
-        std::string address = addWallet(addressData.spendPublicKey, addressData.spendSecretKey, addressData.creationTimestamp);
-        m_logger(INFO, BRIGHT_WHITE) << "New wallet added " << address << ", creation timestamp " << addressData.creationTimestamp;
-        addresses.push_back(std::move(address));
+        std::string address = addWallet(addressData, scanHeight, newAddress);
 
-        minCreationTimestamp = std::min(minCreationTimestamp, addressData.creationTimestamp);
+        addresses.push_back(std::move(address));
       }
     }
 
     m_containerStorage.setAutoFlush(true);
-    auto currentTime = static_cast<uint64_t>(time(nullptr));
-    if (minCreationTimestamp + m_currency.blockFutureTimeLimit(0) < currentTime) {
-      m_logger(DEBUGGING) << "Reset is required";
+
+    if (resetRequired)
+    {
+      m_logger(DEBUGGING) << "A reset is required to scan from this new lower "
+                          << "block height" << std::endl;
+
       save(WalletSaveLevel::SAVE_KEYS_AND_TRANSACTIONS, m_extra);
       shutdown();
       load(m_path, m_password);
@@ -1065,7 +1109,10 @@ std::vector<std::string> WalletGreen::doCreateAddressList(const std::vector<NewA
   return addresses;
 }
 
-std::string WalletGreen::addWallet(const Crypto::PublicKey& spendPublicKey, const Crypto::SecretKey& spendSecretKey, uint64_t creationTimestamp) {
+std::string WalletGreen::addWallet(const NewAddressData &addressData, uint64_t scanHeight, bool newAddress) {
+  const SecretKey spendSecretKey = addressData.spendSecretKey;
+  const PublicKey spendPublicKey = addressData.spendPublicKey;
+
   auto& index = m_walletsContainer.get<KeysIndex>();
 
   auto trackingMode = getTrackingMode();
@@ -1083,10 +1130,7 @@ std::string WalletGreen::addWallet(const Crypto::PublicKey& spendPublicKey, cons
       m_currency.accountAddressAsString(AccountPublicAddress{spendPublicKey, m_viewPublicKey});
     throw std::system_error(make_error_code(error::ADDRESS_ALREADY_EXISTS));
   }
-
-  m_containerStorage.push_back(encryptKeyPair(spendPublicKey, spendSecretKey, creationTimestamp));
-  incNextIv();
-
+  
   try {
     AccountSubscription sub;
     sub.keys.address.viewPublicKey = m_viewPublicKey;
@@ -1094,8 +1138,19 @@ std::string WalletGreen::addWallet(const Crypto::PublicKey& spendPublicKey, cons
     sub.keys.viewSecretKey = m_viewSecretKey;
     sub.keys.spendSecretKey = spendSecretKey;
     sub.transactionSpendableAge = m_transactionSoftLockTime;
-    sub.syncStart.height = 0;
-    sub.syncStart.timestamp = std::max(creationTimestamp, ACCOUNT_CREATE_TIME_ACCURACY) - ACCOUNT_CREATE_TIME_ACCURACY;
+    sub.syncStart.height = scanHeight;
+
+    if (newAddress)
+    {
+        sub.syncStart.timestamp = getCurrentTimestampAdjusted();
+    }
+    else
+    {
+        sub.syncStart.timestamp = scanHeightToTimestamp(scanHeight);
+    }
+
+    m_containerStorage.push_back(encryptKeyPair(spendPublicKey, spendSecretKey, sub.syncStart.timestamp));
+    incNextIv();
 
     auto& trSubscription = m_synchronizer.addSubscription(sub);
     ITransfersContainer* container = &trSubscription.getContainer();
@@ -1104,7 +1159,7 @@ std::string WalletGreen::addWallet(const Crypto::PublicKey& spendPublicKey, cons
     wallet.spendPublicKey = spendPublicKey;
     wallet.spendSecretKey = spendSecretKey;
     wallet.container = container;
-    wallet.creationTimestamp = static_cast<time_t>(creationTimestamp);
+    wallet.creationTimestamp = static_cast<time_t>(sub.syncStart.timestamp);
     trSubscription.addObserver(this);
 
     index.insert(insertIt, std::move(wallet));
@@ -1116,7 +1171,7 @@ std::string WalletGreen::addWallet(const Crypto::PublicKey& spendPublicKey, cons
     }
 
     auto address = m_currency.accountAddressAsString({ spendPublicKey, m_viewPublicKey });
-    m_logger(DEBUGGING) << "Wallet added " << address << ", creation timestamp " << creationTimestamp;
+    m_logger(DEBUGGING) << "Wallet added " << address << ", creation timestamp " << sub.syncStart.timestamp;
     return address;
   } catch (const std::exception& e) {
     m_logger(ERROR) << "Failed to add wallet: " << e.what();
@@ -1129,6 +1184,87 @@ std::string WalletGreen::addWallet(const Crypto::PublicKey& spendPublicKey, cons
 
     throw;
   }
+}
+
+CryptoNote::BlockDetails WalletGreen::getBlock(uint64_t blockHeight)
+{
+    CryptoNote::BlockDetails block;
+
+    if (m_node.getLastKnownBlockHeight() == 0)
+    {
+        return block;
+    }
+
+    std::promise<std::error_code> errorPromise;
+
+    auto e = errorPromise.get_future();
+
+    auto callback = [&errorPromise](std::error_code e)
+    {
+        errorPromise.set_value(e);
+    };
+
+    m_node.getBlock(blockHeight, block, callback);
+
+    e.get();
+
+    return block;
+}
+
+uint64_t WalletGreen::scanHeightToTimestamp(const uint64_t scanHeight)
+{
+    if (scanHeight == 0)
+    {
+        return 0;
+    }
+
+    /* Get the block timestamp from the node if the node has it */
+    uint64_t timestamp = static_cast<uint64_t>(getBlock(scanHeight).timestamp);
+
+    if (timestamp != 0)
+    {
+        return timestamp;
+    }
+
+    /* Get the amount of seconds since the blockchain launched */
+    uint64_t secondsSinceLaunch = scanHeight * 
+                                  CryptoNote::parameters::DIFFICULTY_TARGET;
+
+    /* Add a bit of a buffer in case of difficulty weirdness, blocks coming
+       out too fast */
+    secondsSinceLaunch *= 0.95;
+
+    /* Get the genesis block timestamp and add the time since launch */
+    timestamp = CryptoNote::parameters::GENESIS_BLOCK_TIMESTAMP
+              + secondsSinceLaunch;
+
+    /* Timestamp in the future */
+    if (timestamp >= static_cast<uint64_t>(std::time(nullptr)))
+    {
+        return getCurrentTimestampAdjusted();
+    }
+
+    return timestamp;
+}
+
+uint64_t WalletGreen::getCurrentTimestampAdjusted()
+{
+    /* Get the current time as a unix timestamp */
+    std::time_t time = std::time(nullptr);
+
+    /* Take the amount of time a block can potentially be in the past/future */
+    std::initializer_list<uint64_t> limits =
+    {
+        CryptoNote::parameters::CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT,
+        CryptoNote::parameters::CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V3,
+        CryptoNote::parameters::CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V4
+    };
+
+    /* Get the largest adjustment possible */
+    uint64_t adjust = std::max(limits);
+
+    /* Take the earliest timestamp that will include all possible blocks */
+    return time - adjust;
 }
 
 void WalletGreen::deleteAddress(const std::string& address) {

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -50,13 +50,14 @@ public:
   virtual ~WalletGreen();
 
   virtual void initialize(const std::string& path, const std::string& password) override;
-  virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey) override;
+  virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey, const uint64_t scanHeight, bool newAddress) override;
   virtual void load(const std::string& path, const std::string& password, std::string& extra) override;
   virtual void load(const std::string& path, const std::string& password) override;
   virtual void shutdown() override;
 
   virtual void changePassword(const std::string& oldPassword, const std::string& newPassword) override;
   virtual void save(WalletSaveLevel saveLevel = WalletSaveLevel::SAVE_ALL, const std::string& extra = "") override;
+  virtual void reset(const uint64_t scanHeight) override;
   virtual void exportWallet(const std::string& path, bool encrypt = true, WalletSaveLevel saveLevel = WalletSaveLevel::SAVE_ALL, const std::string& extra = "") override;
 
   virtual size_t getAddressCount() const override;
@@ -141,13 +142,15 @@ protected:
   Crypto::chacha8_iv getNextIv() const;
   static void incIv(Crypto::chacha8_iv& iv);
   void incNextIv();
-  void initWithKeys(const std::string& path, const std::string& password, const Crypto::PublicKey& viewPublicKey, const Crypto::SecretKey& viewSecretKey);
+  void initWithKeys(const std::string& path, const std::string& password, const Crypto::PublicKey& viewPublicKey, const Crypto::SecretKey& viewSecretKey, const uint64_t scanHeight, const bool newAddress);
   std::string doCreateAddress(const Crypto::PublicKey& spendPublicKey, const Crypto::SecretKey& spendSecretKey, const uint64_t scanHeight, const bool newAddress);
   std::vector<std::string> doCreateAddressList(const std::vector<NewAddressData>& addressDataList, const uint64_t scanHeight, const bool newAddress);
 
+  CryptoNote::BlockDetails getBlock(const uint64_t blockHeight);
+
   uint64_t scanHeightToTimestamp(const uint64_t scanHeight);
+
   uint64_t getCurrentTimestampAdjusted();
-  CryptoNote::BlockDetails getBlock(uint64_t blockHeight);
 
   struct InputInfo {
     TransactionTypes::InputKeyInfo keyInfo;

--- a/src/Wallet/WalletSerializationV2.cpp
+++ b/src/Wallet/WalletSerializationV2.cpp
@@ -149,7 +149,7 @@ void WalletSerializerV2::load(Common::IInputStream& source, uint8_t version) {
   s(saveLevelValue, "saveLevel");
   WalletSaveLevel saveLevel = static_cast<WalletSaveLevel>(saveLevelValue);
 
-  loadKeyListAndBanalces(s, saveLevel == WalletSaveLevel::SAVE_ALL);
+  loadKeyListAndBalances(s, saveLevel == WalletSaveLevel::SAVE_ALL);
 
   if (saveLevel == WalletSaveLevel::SAVE_KEYS_AND_TRANSACTIONS || saveLevel == WalletSaveLevel::SAVE_ALL) {
     loadTransactions(s);
@@ -171,7 +171,7 @@ void WalletSerializerV2::save(Common::IOutputStream& destination, WalletSaveLeve
   uint8_t saveLevelValue = static_cast<uint8_t>(saveLevel);
   s(saveLevelValue, "saveLevel");
 
-  saveKeyListAndBanalces(s, saveLevel == WalletSaveLevel::SAVE_ALL);
+  saveKeyListAndBalances(s, saveLevel == WalletSaveLevel::SAVE_ALL);
 
   if (saveLevel == WalletSaveLevel::SAVE_KEYS_AND_TRANSACTIONS || saveLevel == WalletSaveLevel::SAVE_ALL) {
     saveTransactions(s);
@@ -195,7 +195,7 @@ std::unordered_set<Crypto::PublicKey>& WalletSerializerV2::deletedKeys() {
   return m_deletedKeys;
 }
 
-void WalletSerializerV2::loadKeyListAndBanalces(CryptoNote::ISerializer& serializer, bool saveCache) {
+void WalletSerializerV2::loadKeyListAndBalances(CryptoNote::ISerializer& serializer, bool saveCache) {
   size_t walletCount;
   serializer(walletCount, "walletCount");
 
@@ -239,7 +239,7 @@ void WalletSerializerV2::loadKeyListAndBanalces(CryptoNote::ISerializer& seriali
   }
 }
 
-void WalletSerializerV2::saveKeyListAndBanalces(CryptoNote::ISerializer& serializer, bool saveCache) {
+void WalletSerializerV2::saveKeyListAndBalances(CryptoNote::ISerializer& serializer, bool saveCache) {
   auto walletCount = m_walletsContainer.get<RandomAccessIndex>().size();
   serializer(walletCount, "walletCount");
   for (auto wallet : m_walletsContainer.get<RandomAccessIndex>()) {

--- a/src/Wallet/WalletSerializationV2.h
+++ b/src/Wallet/WalletSerializationV2.h
@@ -53,8 +53,8 @@ public:
   static const uint8_t SERIALIZATION_VERSION = 6;
 
 private:
-  void loadKeyListAndBanalces(CryptoNote::ISerializer& serializer, bool saveCache);
-  void saveKeyListAndBanalces(CryptoNote::ISerializer& serializer, bool saveCache);
+  void loadKeyListAndBalances(CryptoNote::ISerializer& serializer, bool saveCache);
+  void saveKeyListAndBalances(CryptoNote::ISerializer& serializer, bool saveCache);
     
   void loadTransactions(CryptoNote::ISerializer& serializer);
   void saveTransactions(CryptoNote::ISerializer& serializer);

--- a/src/WalletService/PaymentGateService.cpp
+++ b/src/WalletService/PaymentGateService.cpp
@@ -99,7 +99,8 @@ WalletConfiguration PaymentGateService::getWalletConfig() const {
     config.gateConfiguration.syncFromZero,
     config.gateConfiguration.secretViewKey,
     config.gateConfiguration.secretSpendKey,
-    config.gateConfiguration.mnemonicSeed
+    config.gateConfiguration.mnemonicSeed,
+    config.gateConfiguration.scanHeight,
   };
 }
 

--- a/src/WalletService/PaymentServiceConfiguration.cpp
+++ b/src/WalletService/PaymentServiceConfiguration.cpp
@@ -46,6 +46,7 @@ Configuration::Configuration() {
   rpcPassword = "";
   legacySecurity = false;
   corsHeader = "";
+  scanHeight = 0;
 }
 
 void Configuration::initOptions(boost::program_options::options_description& desc) {
@@ -71,6 +72,7 @@ void Configuration::initOptions(boost::program_options::options_description& des
       ("SYNC_FROM_ZERO", "sync from timestamp 0")
       ("address", "print wallet addresses and exit")
       ("enable-cors", po::value<std::string>(), "Adds header 'Access-Control-Allow-Origin' to walletd's RPC responses. Uses the value as domain. Use * for all.");
+      ("scan-height", po::value<uint64_t>(), "The height to begin scanning a wallet from");
 }
 
 void Configuration::init(const boost::program_options::variables_map& options) {
@@ -201,6 +203,10 @@ void Configuration::init(const boost::program_options::variables_map& options) {
 
   if (options.count("enable-cors") != 0) {
     corsHeader = options["enable-cors"].as<std::string>();
+  }
+
+  if (options.count("scan-height") != 0) {
+    scanHeight = options["scan-height"].as<uint64_t>();
   }
 
 }

--- a/src/WalletService/PaymentServiceConfiguration.h
+++ b/src/WalletService/PaymentServiceConfiguration.h
@@ -58,6 +58,8 @@ struct Configuration {
   bool legacySecurity;
 
   size_t logLevel;
+
+  uint64_t scanHeight;
 };
 
 } //namespace PaymentService

--- a/src/WalletService/PaymentServiceJsonRpcMessages.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.cpp
@@ -25,7 +25,21 @@ void Export::Response::serialize(CryptoNote::ISerializer& serializer) {
 }
 
 void Reset::Request::serialize(CryptoNote::ISerializer& serializer) {
-  serializer(viewSecretKey, "viewSecretKey");
+  bool hasKey = serializer(viewSecretKey, "viewSecretKey");
+
+  bool hasScanHeight = serializer(scanHeight, "scanHeight");
+  bool hasNewAddress = serializer(newAddress, "newAddress");
+
+  /* Can't specify both that it is a new address, and a height to begin
+     scanning from */
+  if (hasNewAddress && hasScanHeight) {
+    throw RequestSerializationError();
+  }
+
+  /* It's not a reset if you're not resetting :thinking: */
+  if (!hasKey && hasNewAddress) {
+    throw RequestSerializationError();
+  };
 }
 
 void Reset::Response::serialize(CryptoNote::ISerializer& serializer) {

--- a/src/WalletService/PaymentServiceJsonRpcMessages.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.cpp
@@ -69,8 +69,17 @@ void CreateAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
   bool hasSecretKey = serializer(spendSecretKey, "spendSecretKey");
   bool hasPublicKey = serializer(spendPublicKey, "spendPublicKey");
 
+  bool hasNewAddress = serializer(newAddress, "newAddress");
+  bool hasScanHeight = serializer(scanHeight, "scanHeight");
+
   if (hasSecretKey && hasPublicKey) {
     //TODO: replace it with error codes
+    throw RequestSerializationError();
+  }
+
+  /* Can't specify both that it is a new address, and a height to begin
+     scanning from */
+  if (hasNewAddress && hasScanHeight) {
     throw RequestSerializationError();
   }
 }
@@ -82,6 +91,15 @@ void CreateAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
 void CreateAddressList::Request::serialize(CryptoNote::ISerializer& serializer) {
   if (!serializer(spendSecretKeys, "spendSecretKeys")) {
     //TODO: replace it with error codes
+    throw RequestSerializationError();
+  }
+
+  bool hasNewAddress = serializer(newAddress, "newAddress");
+  bool hasScanHeight = serializer(scanHeight, "scanHeight");
+
+  /* Can't specify both that it is a new address, and a height to begin
+     scanning from */
+  if (hasNewAddress && hasScanHeight) {
     throw RequestSerializationError();
   }
 }

--- a/src/WalletService/PaymentServiceJsonRpcMessages.h
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.h
@@ -47,6 +47,10 @@ struct Reset {
   struct Request {
     std::string viewSecretKey;
 
+    uint64_t scanHeight;
+
+    bool newAddress;
+
     void serialize(CryptoNote::ISerializer& serializer);
   };
 

--- a/src/WalletService/PaymentServiceJsonRpcMessages.h
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.h
@@ -113,6 +113,10 @@ struct CreateAddress {
     std::string spendSecretKey;
     std::string spendPublicKey;
 
+    uint64_t scanHeight;
+
+    bool newAddress;
+
     void serialize(CryptoNote::ISerializer& serializer);
   };
 
@@ -126,6 +130,10 @@ struct CreateAddress {
 struct CreateAddressList {
   struct Request {
     std::vector<std::string> spendSecretKeys;
+
+    uint64_t scanHeight;
+
+    bool newAddress;
 
     void serialize(CryptoNote::ISerializer& serializer);
   };

--- a/src/WalletService/PaymentServiceJsonRpcServer.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcServer.cpp
@@ -117,9 +117,9 @@ std::error_code PaymentServiceJsonRpcServer::handleExport(const Export::Request&
 
 std::error_code PaymentServiceJsonRpcServer::handleReset(const Reset::Request& request, Reset::Response& response) {
   if (request.viewSecretKey.empty()) {
-    return service.resetWallet();
+    return service.resetWallet(request.scanHeight);
   } else {
-    return service.replaceWithNewWallet(request.viewSecretKey);
+    return service.replaceWithNewWallet(request.viewSecretKey, request.scanHeight, request.newAddress);
   }
 }
 

--- a/src/WalletService/PaymentServiceJsonRpcServer.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcServer.cpp
@@ -127,14 +127,14 @@ std::error_code PaymentServiceJsonRpcServer::handleCreateAddress(const CreateAdd
   if (request.spendSecretKey.empty() && request.spendPublicKey.empty()) {
     return service.createAddress(response.address);
   } else if (!request.spendSecretKey.empty()) {
-    return service.createAddress(request.spendSecretKey, response.address);
+    return service.createAddress(request.spendSecretKey, request.scanHeight, request.newAddress, response.address);
   } else {
-    return service.createTrackingAddress(request.spendPublicKey, response.address);
+    return service.createTrackingAddress(request.spendPublicKey, request.scanHeight, request.newAddress, response.address);
   }
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleCreateAddressList(const CreateAddressList::Request& request, CreateAddressList::Response& response) {
-  return service.createAddressList(request.spendSecretKeys, response.addresses);
+  return service.createAddressList(request.spendSecretKeys, request.scanHeight, request.newAddress, response.addresses);
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleDeleteAddress(const DeleteAddress::Request& request, DeleteAddress::Response& response) {

--- a/src/WalletService/WalletService.cpp
+++ b/src/WalletService/WalletService.cpp
@@ -362,7 +362,7 @@ void generateNewWallet(const CryptoNote::Currency& currency, const WalletConfigu
     CryptoNote::AccountBase::generateViewFromSpend(spendKey.secretKey, private_view_key);
 
     wallet->initializeWithViewKey(conf.walletFile, conf.walletPassword, private_view_key);
-    address = wallet->createAddress(spendKey.secretKey);
+    address = wallet->createAddress(spendKey.secretKey, 0, true);
 
 	  log(Logging::INFO, Logging::BRIGHT_WHITE) << "New wallet is generated. Address: " << address;
   }
@@ -386,7 +386,7 @@ void generateNewWallet(const CryptoNote::Currency& currency, const WalletConfigu
 
     CryptoNote::AccountBase::generateViewFromSpend(private_spend_key, private_view_key);
     wallet->initializeWithViewKey(conf.walletFile, conf.walletPassword, private_view_key);
-    address = wallet->createAddress(private_spend_key);
+    address = wallet->createAddress(private_spend_key, conf.scanHeight, false);
     log(Logging::INFO, Logging::BRIGHT_WHITE) << "Imported wallet successfully.";
   }
   else
@@ -414,7 +414,7 @@ void generateNewWallet(const CryptoNote::Currency& currency, const WalletConfigu
 		  Crypto::SecretKey private_view_key = *(struct Crypto::SecretKey *) &private_view_key_hash;
 
 		  wallet->initializeWithViewKey(conf.walletFile, conf.walletPassword, private_view_key);
-		  address = wallet->createAddress(private_spend_key);
+		  address = wallet->createAddress(private_spend_key, conf.scanHeight, false);
 		  log(Logging::INFO, Logging::BRIGHT_WHITE) << "Imported wallet successfully.";
 	  }
   }
@@ -608,7 +608,7 @@ std::error_code WalletService::replaceWithNewWallet(const std::string& viewSecre
   return std::error_code();
 }
 
-std::error_code WalletService::createAddress(const std::string& spendSecretKeyText, std::string& address) {
+std::error_code WalletService::createAddress(const std::string& spendSecretKeyText, uint64_t scanHeight, bool newAddress, std::string& address) {
   try {
     System::EventLock lk(readyEvent);
 
@@ -620,7 +620,7 @@ std::error_code WalletService::createAddress(const std::string& spendSecretKeyTe
       return make_error_code(CryptoNote::error::WalletServiceErrorCode::WRONG_KEY_FORMAT);
     }
 
-    address = wallet.createAddress(secretKey);
+    address = wallet.createAddress(secretKey, scanHeight, newAddress);
   } catch (std::system_error& x) {
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Error while creating address: " << x.what();
     return x.code();
@@ -631,7 +631,7 @@ std::error_code WalletService::createAddress(const std::string& spendSecretKeyTe
   return std::error_code();
 }
 
-std::error_code WalletService::createAddressList(const std::vector<std::string>& spendSecretKeysText, std::vector<std::string>& addresses) {
+std::error_code WalletService::createAddressList(const std::vector<std::string>& spendSecretKeysText, uint64_t scanHeight, bool newAddress, std::vector<std::string>& addresses) {
   try {
     System::EventLock lk(readyEvent);
 
@@ -657,7 +657,7 @@ std::error_code WalletService::createAddressList(const std::vector<std::string>&
       secretKeys.push_back(std::move(key));
     }
 
-    addresses = wallet.createAddressList(secretKeys);
+    addresses = wallet.createAddressList(secretKeys, scanHeight, newAddress);
   } catch (std::system_error& x) {
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Error while creating addresses: " << x.what();
     return x.code();
@@ -685,7 +685,7 @@ std::error_code WalletService::createAddress(std::string& address) {
   return std::error_code();
 }
 
-std::error_code WalletService::createTrackingAddress(const std::string& spendPublicKeyText, std::string& address) {
+std::error_code WalletService::createTrackingAddress(const std::string& spendPublicKeyText, uint64_t scanHeight, bool newAddress, std::string& address) {
   try {
     System::EventLock lk(readyEvent);
 
@@ -697,7 +697,7 @@ std::error_code WalletService::createTrackingAddress(const std::string& spendPub
       return make_error_code(CryptoNote::error::WalletServiceErrorCode::WRONG_KEY_FORMAT);
     }
 
-    address = wallet.createAddress(publicKey);
+    address = wallet.createAddress(publicKey, scanHeight, true);
   } catch (std::system_error& x) {
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Error while creating tracking address: " << x.what();
     return x.code();

--- a/src/WalletService/WalletService.cpp
+++ b/src/WalletService/WalletService.cpp
@@ -1381,10 +1381,6 @@ void WalletService::refresh() {
 
 void WalletService::reset(const uint64_t scanHeight) {
   wallet.reset(scanHeight);
-
-  inited = false;
-  refreshContext.wait();
-  init();
 }
 
 void WalletService::replaceWithNewWallet(const Crypto::SecretKey& viewSecretKey, const uint64_t scanHeight, const bool newAddress) {

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -35,6 +35,7 @@ struct WalletConfiguration {
   std::string secretViewKey;
   std::string secretSpendKey;
   std::string mnemonicSeed;
+  uint64_t scanHeight;
 };
 
 void generateNewWallet(const CryptoNote::Currency& currency, const WalletConfiguration& conf, Logging::ILogger& logger, System::Dispatcher& dispatcher);
@@ -54,10 +55,10 @@ public:
   std::error_code exportWallet(const std::string& fileName);
   std::error_code resetWallet();
   std::error_code replaceWithNewWallet(const std::string& viewSecretKey);
-  std::error_code createAddress(const std::string& spendSecretKeyText, std::string& address);
-  std::error_code createAddressList(const std::vector<std::string>& spendSecretKeysText, std::vector<std::string>& addresses);
+  std::error_code createAddress(const std::string& spendSecretKeyText, uint64_t scanHeight, bool newAddress, std::string& address);
+  std::error_code createAddressList(const std::vector<std::string>& spendSecretKeysText, uint64_t scanHeight, bool newAddress, std::vector<std::string>& addresses);
   std::error_code createAddress(std::string& address);
-  std::error_code createTrackingAddress(const std::string& spendPublicKeyText, std::string& address);
+  std::error_code createTrackingAddress(const std::string& spendPublicKeyText, uint64_t scanHeight, bool newAddress, std::string& address);
   std::error_code deleteAddress(const std::string& address);
   std::error_code getSpendkeys(const std::string& address, std::string& publicSpendKeyText, std::string& secretSpendKeyText);
   std::error_code getBalance(const std::string& address, uint64_t& availableBalance, uint64_t& lockedAmount);

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -91,7 +91,7 @@ public:
 
 private:
   void refresh();
-  void reset(const uint64_t scanHeight, const bool newAddress);
+  void reset(const uint64_t scanHeight);
 
   void loadWallet();
   void loadTransactionIdIndex();

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -53,10 +53,10 @@ public:
 
   std::error_code saveWalletNoThrow();
   std::error_code exportWallet(const std::string& fileName);
-  std::error_code resetWallet();
-  std::error_code replaceWithNewWallet(const std::string& viewSecretKey);
-  std::error_code createAddress(const std::string& spendSecretKeyText, uint64_t scanHeight, bool newAddress, std::string& address);
-  std::error_code createAddressList(const std::vector<std::string>& spendSecretKeysText, uint64_t scanHeight, bool newAddress, std::vector<std::string>& addresses);
+  std::error_code resetWallet(const uint64_t scanHeight);
+  std::error_code replaceWithNewWallet(const std::string& viewSecretKey, const uint64_t scanHeight, const bool newAddress);
+  std::error_code createAddress(const std::string& spendSecretKeyText, const uint64_t scanHeight, const bool newAddress, std::string& address);
+  std::error_code createAddressList(const std::vector<std::string>& spendSecretKeysText, const uint64_t scanHeight, const bool newAddress, std::vector<std::string>& addresses);
   std::error_code createAddress(std::string& address);
   std::error_code createTrackingAddress(const std::string& spendPublicKeyText, uint64_t scanHeight, bool newAddress, std::string& address);
   std::error_code deleteAddress(const std::string& address);
@@ -91,13 +91,13 @@ public:
 
 private:
   void refresh();
-  void reset();
+  void reset(const uint64_t scanHeight, const bool newAddress);
 
   void loadWallet();
   void loadTransactionIdIndex();
   void getNodeFee();
 
-  void replaceWithNewWallet(const Crypto::SecretKey& viewSecretKey);
+  void replaceWithNewWallet(const Crypto::SecretKey& viewSecretKey, const uint64_t scanHeight, const bool newAddress);
 
   std::vector<CryptoNote::TransactionsInBlockInfo> getTransactions(const Crypto::Hash& blockHash, size_t blockCount) const;
   std::vector<CryptoNote::TransactionsInBlockInfo> getTransactions(uint32_t firstBlockIndex, size_t blockCount) const;

--- a/src/zedwallet/CommandImplementations.cpp
+++ b/src/zedwallet/CommandImplementations.cpp
@@ -305,27 +305,23 @@ void status(CryptoNote::INode &node, CryptoNote::WalletGreen &wallet)
 
 void reset(CryptoNote::INode &node, std::shared_ptr<WalletInfo> &walletInfo)
 {
-    std::cout << InformationMsg("This process may take some time to complete. "
-                                "You can't make any transactions during the process.")
-              << std::endl;
+    uint64_t scanHeight = getScanHeight();
+
+    std::cout << InformationMsg("This process may take some time to complete.")
+              << std::endl
+              << InformationMsg("You can't make any transactions during the ")
+              << InformationMsg("process.")
+              << std::endl << std::endl;
     
-    if (!confirm("Are you sure?")){
+    if (!confirm("Are you sure?"))
+    {
         return;
     }
     
     std::cout << InformationMsg("Resetting wallet...") << std::endl;
 
-    walletInfo->knownTransactionCount = 0;
+    walletInfo->wallet.reset(scanHeight);
 
-    /* Wallet is now unitialized. You must reinit with load, initWithKeys,
-       or whatever. This function wipes the cache, then saves the wallet. */
-    walletInfo->wallet.clearCacheAndShutdown();
-
-    /* Now, we reopen the wallet. It now has no cached tx's, and balance */
-    walletInfo->wallet.load(walletInfo->walletFileName,
-                            walletInfo->walletPass);
-
-    /* Now we rescan the chain to re-discover our balance and transactions */
     syncWallet(node, walletInfo);
 }
 

--- a/src/zedwallet/Open.cpp
+++ b/src/zedwallet/Open.cpp
@@ -17,6 +17,7 @@
 
 #include <zedwallet/ColouredMsg.h>
 #include <zedwallet/CommandImplementations.h>
+#include <zedwallet/Tools.h>
 #include <zedwallet/Transfer.h>
 #include <zedwallet/Types.h>
 #include <zedwallet/PasswordContainer.h>
@@ -121,7 +122,9 @@ std::shared_ptr<WalletInfo> importFromKeys(CryptoNote::WalletGreen &wallet,
 
     connectingMsg();
 
-    wallet.initializeWithViewKey(walletFileName, walletPass, privateViewKey);
+    wallet.initializeWithViewKey(
+        walletFileName, walletPass, privateViewKey, scanHeight, false
+    );
 
     const std::string walletAddress = wallet.createAddress(
         privateSpendKey, scanHeight, false
@@ -150,7 +153,9 @@ std::shared_ptr<WalletInfo> generateWallet(CryptoNote::WalletGreen &wallet)
     CryptoNote::AccountBase::generateViewFromSpend(spendKey.secretKey,
                                                    privateViewKey);
 
-    wallet.initializeWithViewKey(walletFileName, walletPass, privateViewKey);
+    wallet.initializeWithViewKey(
+        walletFileName, walletPass, privateViewKey, 0, true
+    );
 
     const std::string walletAddress = wallet.createAddress(
         spendKey.secretKey, 0, true
@@ -465,47 +470,6 @@ std::string getWalletPassword(bool verifyPwd, std::string msg)
     Tools::PasswordContainer pwdContainer;
     pwdContainer.read_password(verifyPwd, msg);
     return pwdContainer.password();
-}
-
-uint64_t getScanHeight()
-{
-    while (true)
-    {
-        std::cout << "What height would you like to begin scanning "
-                  << "your wallet from?"
-                  << std::endl
-                  << "This can greatly speed up the initial wallet "
-                  << "scanning process."
-                  << std::endl
-                  << "If you do not know the exact height, "
-                  << std::endl
-                  << "err on the side of caution so transactions do not "
-                  << "get missed."
-                  << std::endl
-                  << "Hit enter for the default of zero: ";
-
-        std::string stringHeight;
-
-        std::getline(std::cin, stringHeight);
-
-        /* Remove commas so user can enter height as e.g. 200,000 */
-        boost::erase_all(stringHeight, ",");
-
-        if (stringHeight == "")
-        {
-            return 0;
-        }
-
-        try
-        {
-            return std::stoi(stringHeight);
-        }
-        catch (const std::invalid_argument &)
-        {
-            std::cout << WarningMsg("Failed to parse height - input is not ")
-                      << WarningMsg("a number!") << std::endl << std::endl;
-        }
-    }
 }
 
 void viewWalletMsg()

--- a/src/zedwallet/Open.h
+++ b/src/zedwallet/Open.h
@@ -40,5 +40,3 @@ void viewWalletMsg();
 void connectingMsg();
 
 void promptSaveKeys(CryptoNote::WalletGreen &wallet);
-
-uint64_t getScanHeight();

--- a/src/zedwallet/Open.h
+++ b/src/zedwallet/Open.h
@@ -40,3 +40,5 @@ void viewWalletMsg();
 void connectingMsg();
 
 void promptSaveKeys(CryptoNote::WalletGreen &wallet);
+
+uint64_t getScanHeight();

--- a/src/zedwallet/Tools.cpp
+++ b/src/zedwallet/Tools.cpp
@@ -247,3 +247,44 @@ std::string createIntegratedAddress(std::string address, std::string paymentID)
         paymentID + keys
     );
 }
+
+uint64_t getScanHeight()
+{
+    while (true)
+    {
+        std::cout << "What height would you like to begin scanning "
+                  << "your wallet from?"
+                  << std::endl
+                  << "This can greatly speed up the initial wallet "
+                  << "scanning process."
+                  << std::endl
+                  << "If you do not know the exact height, "
+                  << std::endl
+                  << "err on the side of caution so transactions do not "
+                  << "get missed."
+                  << std::endl
+                  << "Hit enter for the default of zero: ";
+
+        std::string stringHeight;
+
+        std::getline(std::cin, stringHeight);
+
+        /* Remove commas so user can enter height as e.g. 200,000 */
+        boost::erase_all(stringHeight, ",");
+
+        if (stringHeight == "")
+        {
+            return 0;
+        }
+
+        try
+        {
+            return std::stoi(stringHeight);
+        }
+        catch (const std::invalid_argument &)
+        {
+            std::cout << WarningMsg("Failed to parse height - input is not ")
+                      << WarningMsg("a number!") << std::endl << std::endl;
+        }
+    }
+}

--- a/src/zedwallet/Tools.h
+++ b/src/zedwallet/Tools.h
@@ -27,3 +27,5 @@ std::string unixTimeToDate(uint64_t timestamp);
 std::string createIntegratedAddress(std::string address, std::string paymentID);
 
 uint64_t getDivisor();
+
+uint64_t getScanHeight();

--- a/src/zedwallet/ZedWallet.h
+++ b/src/zedwallet/ZedWallet.h
@@ -28,4 +28,3 @@ std::string getCommand(std::shared_ptr<WalletInfo> &walletInfo);
 
 Maybe<std::shared_ptr<WalletInfo>> handleAction(CryptoNote::WalletGreen &wallet,
                                                 Action action, Config &config);
-


### PR DESCRIPTION
Adds support to both turtle-service and zedwallet for starting the wallet scanning at a specific height when importing.

If a wallet is created with no parameters, i.e. it is a completely fresh wallet, not imported, it will always be scanned from the timestamp when it was created. There is no way for it to have any transactions previously, so it is pointless to scan those blocks.

When a wallet is created with parameters, such as a mnemonic seed, a view key, or a view and spend key, an optional scan height can be given. This causes the wallet to ignore any blocks before this point, massively speeding up sync times.

It is worth noting that the block hashes still need to be received from the node. However, this process is far faster than the standard sync process. From my tests I found it took roughly 7 minutes and 30 seconds to sync 500,000 blocks from a public node. I assume a local node would be faster.

On the turtle-service side, the createAddress() and createAddressList() calls now have two new *optional* parameters.

These are newAddress (bool), and scanHeight (uint64_t). You cannot specify both at once.

If newAddress is set to true, the wallet will be assumed to be scanned from the current timestamp, with no transactions in the past.

If scanHeight is set to > 0, the wallet will skip blocks before this height when scanning.

If you wish to apply a scanHeight whilst creating a wallet with turtle-service, the config parameter `--scanHeight` can be used for this.

You can also reset from a given height, both in turtle-service, and zedwallet. In turtle-service, this adds the same two optional parameters, to the reset() method, newAddress (bool, and scanHeight (uint64_t).

You cannot specify both at once.
You cannot specify newAddress unless the optional viewSecretKey is specified. (It makes no sense to perform a reset with a timestamp of now, that is not a reset.)