### PR TITLE
[ADMINISTRATIVE] Make chacha8_key trivially copyable

### DIFF
--- a/src/crypto/chacha8.h
+++ b/src/crypto/chacha8.h
@@ -27,11 +27,6 @@ namespace Crypto {
 #pragma pack(push, 1)
   struct chacha8_key {
     uint8_t data[CHACHA8_KEY_SIZE];
-
-    ~chacha8_key()
-    {
-      memset(data, 0, sizeof(data));
-    }
   };
 
   // MS VC 2012 doesn't interpret `class chacha8_iv` as POD in spite of [9.0.10], so it is a struct


### PR DESCRIPTION
memcpy() is used to copy around chacha8_keys. For this to be correct, chacha8_key must have a trivial destructor, since the destructor will not be called for the destination of the copy.

This destructor just wipes the data in memory so the key is no longer available, however, this is essentially pointless as WalletService.cpp keeps the password in plaintext in memory.

The main reason for doing this is because on gcc8 it kicks out a ton of these warnings: 

```
In file included from /home/zach/Code/turtlecoin/turtlecoin/src/Wallet/WalletIndices.h:34,
                 from /home/zach/Code/turtlecoin/turtlecoin/src/Wallet/WalletGreen.h:26,
                 from /home/zach/Code/turtlecoin/turtlecoin/src/zedwallet/Types.h:11,
                 from /home/zach/Code/turtlecoin/turtlecoin/src/zedwallet/Transfer.h:9,
                 from /home/zach/Code/turtlecoin/turtlecoin/src/zedwallet/Transfer.cpp:6:
/home/zach/Code/turtlecoin/turtlecoin/src/crypto/chacha8.h: In function ‘void Crypto::generate_chacha8_key(const string&, Crypto::chacha8_key&)’:
/home/zach/Code/turtlecoin/turtlecoin/src/crypto/chacha8.h:53:40: warning: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of non-trivially copyable type ‘struct Crypto::chacha8_key’; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
     memcpy(&key, &pwd_hash, sizeof(key));
                                        ^
/home/zach/Code/turtlecoin/turtlecoin/src/crypto/chacha8.h:28:10: note: ‘struct Crypto::chacha8_key’ declared here
   struct chacha8_key {
```

Which just clutter up the logs.