### PR TITLE
[ENHANCEMENT] Travis Build AARCH64 Release Binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-sudo: true
+sudo: false
 language: cpp
-compiler: gcc
-env:
-- CXXFLAGS="-std=gnu++11"
+
 matrix:
   include:
   - os: linux
@@ -11,29 +9,61 @@ matrix:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        #- g++-4.9
         - libboost1.55-all-dev
     env:
-    - MATRIX_EVAL="CC=gcc && CXX=g++
+    - MATRIX_EVAL="CC=gcc && CXX=g++"
+    - LABEL="linux"
+    - STRIP="strip"
   - os: osx
+    env:
+    - MATRIX_EVAL="CC=gcc && CXX=g++"
+    - CXXFLAGS="-std=gnu++11"
+    - LABEL="osx"
+    - STRIP="strip"
+  - os: linux
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - gcc-aarch64-linux-gnu
+        - g++-aarch64-linux-gnu
+    env:
+    - MATRIX_EVAL="CC=aarch64-linux-gnu-gcc && CXX=aarch64-linux-gnu-g++"
+    - LABEL="aarch64"
+    - STRIP="aarch64-linux-gnu-strip"
+
 before_install:
+- eval $MATRIX_EVAL
+
 install:
+- if [[ "$LABEL" == "aarch64" ]]; then wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then tar zxvf boost_1_55_0.tar.gz >/dev/null ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then cd boost_1_55_0 ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then ./bootstrap.sh ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then curl https://gist.githubusercontent.com/brandonlehmann/06a8cebbbd5e91814067fcd741879f2f/raw/41fc014ac53f64a6f465356a5b1e29179101b23f/fix_boost_aarch64.sh | sh ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then ./b2 toolset=gcc-aarch64 --with-system --with-filesystem --with-thread --with-date_time --with-chrono --with-regex --with-serialization --with-program_options >/dev/null ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then export CUSTOM_BOOST_ROOT="-DBOOST_ROOT=`pwd`" ; fi
+- if [[ "$LABEL" == "aarch64" ]]; then cd .. ; fi
+
 script:
 - mkdir build && cd build
-- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. && make -j2
+- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. ${CUSTOM_BOOST_ROOT} && make -j2
+
 before_deploy:
 - cd src
-- strip TurtleCoind miner zedwallet turtle-service
+- ${STRIP} TurtleCoind miner zedwallet turtle-service
 - mkdir turtlecoin-${TRAVIS_TAG}
 - mv TurtleCoind miner zedwallet turtle-service  turtlecoin-${TRAVIS_TAG}/
 - cp ../../LICENSE turtlecoin-${TRAVIS_TAG}/
-- tar cvfz turtlecoin-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz turtlecoin-${TRAVIS_TAG}/
+- tar cvfz turtlecoin-${TRAVIS_TAG}-${LABEL}.tar.gz turtlecoin-${TRAVIS_TAG}/
+
 deploy:
   provider: releases
   api_key:
     secure: XyM7qAnX9Slm4bX7WYPOnWGRuXfuwc7wnJHb7wN4WGy+GefXm3xSFoNIZdmTY1XnJ2HpIAXuuHL2aey8KKt+gEXbhp882z6m9jZWOdog3cjObdRCsOuETNE0rbXasDvntdhm1Jn7PM+mkN6O9GoqRVaEnyyIwCGEFA7Cc/d2KgtqpTu0NB6nIPZbTgJnudHDQYEWl0kwA1UjkYrEIRlAOFTaRHBUsUHPTFW8758mgerYitLm27BNJTbo74lYe65iExtguKFN/VRVXDl08/2i3gnAxzWJ2K0qUZu7PD8ePd+2UC1wwE2Dc1uiTOmhDgVeuQO6k0tuipjIA+dh5r7A8/YPyOX4zoZ4ac+g1mWSRO1VS/WQ2Uvq2XU848KACLJ+ky3kHWZKowTSl/v3+3rU4c6kqYJHShkH5XlFp503yRqlaqOow4ogz020eIEHEFCgwLhNxZSEUzKP4rEZPpboZyNJbW7lL92UxMZDZm1zKMvnrY5zi2HltYzIQyOjDvmXUxQD8blz1C66lqfBc6mApjDRZVLUcfTT4WIGAWc6opTYJAJpCg34zGAQgXoFaOG0cH3ApsREmBd1dg9d8cJscedy9qZjn3HsmibmdRiGctB5o08JrjfM5sZVk620iKFgovis7q7XfIKb3rQdSfsiRwsfZEwhE2lvY3bf9B0VMrU=
   file:
-    - turtlecoin-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz
+    - turtlecoin-${TRAVIS_TAG}-${LABEL}.tar.gz
   skip_cleanup: true
   on:
     repo: turtlecoin/turtlecoin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_SKIP_INSTALL_RULES OFF FORCE)
 set(CMAKE_SKIP_PACKAGE_ALL_DEPENDENCY ON FORCE)
 set(CMAKE_SUPPRESS_REGENERATION ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(FIND_BOOST_VERSION 1.55)
 
 # We do not support 32-bit builds. When and if we do, this can be removed.
 if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -23,7 +24,7 @@ if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
 endif()
 
 ## We only build static binaries -- this is left here for our dependencies
-set(STATIC ON CACHE BOOL FORCE "Link libraries statically? Forced to ON") 
+set(STATIC ON CACHE BOOL FORCE "Link libraries statically? Forced to ON")
 set(ENABLE_LINENOISE ON CACHE FORCE BOOL "Enable line editing support (completion & history) support? Forced to ON")
 
 # This section helps us set up RocksDB for maximum portability
@@ -86,7 +87,7 @@ if(NOT MSVC)
     # Since glibc 2.20 _BSD_SOURCE is deprecated, this macro is recomended instead
     add_definitions("-D_DEFAULT_SOURCE -D_GNU_SOURCE")
   endif()
-  
+
   ## This is here to support building for multiple architecture types... but we all know how well that usually goes...
   set(ARCH default CACHE STRING "CPU to build for: -march value or default")
   if("${ARCH}" STREQUAL "default")
@@ -94,7 +95,7 @@ if(NOT MSVC)
   else()
     set(ARCH_FLAG "-march=${ARCH}")
   endif()
-  
+
   ## These options generate all those nice warnings we see while building
   set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings  -Wno-error=extra -Wno-error=unused-function -Wno-error=deprecated-declarations -Wno-error=sign-compare -Wno-error=strict-aliasing -Wno-error=type-limits -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized -Wno-error=unused-result")
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
@@ -102,38 +103,37 @@ if(NOT MSVC)
   else()
     set(WARNINGS "${WARNINGS} -Wlogical-op -Wno-error=maybe-uninitialized -Wno-error=clobbered -Wno-error=unused-but-set-variable")
   endif()
-  
+
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT (CMAKE_C_COMPILER_VERSION VERSION_LESS 5.1))
     set(WARNINGS "${WARNINGS} -Wno-error=odr")
   endif()
   set(C_WARNINGS "-Waggregate-return -Wnested-externs -Wold-style-definition -Wstrict-prototypes")
   set(CXX_WARNINGS "-Wno-reorder -Wno-missing-field-initializers")
 
-  message(STATUS "Targeting system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64") # Need this to build on aarch64 (aka Arm64) - you must have a 64bit ARM CPU.
+  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64" OR $ENV{LABEL} STREQUAL "aarch64")
     set(MAES_FLAG "")
-  elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64") # -maes is not supported on some ARM cpus
+  elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64" AND NOT $ENV{LABEL} STREQUAL "aarch64")
     set(MAES_FLAG "-maes")
   endif()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 ${STATICASSERTC_FLAG} ${WARNINGS} ${C_WARNINGS} ${ARCH_FLAG} ${MAES_FLAG}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ${STATICASSERTCPP_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${ARCH_FLAG} ${MAES_FLAG}")
-  
+
   if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   endif()
-  
+
   ## Setting up DEBUG flags
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT (CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8))
     set(DEBUG_FLAGS "-g3 -Og -gdwarf-4 -fvar-tracking -fvar-tracking-assignments -fno-inline -fno-omit-frame-pointer")
   else()
     set(DEBUG_FLAGS "-g3 -O0 -fno-omit-frame-pointer")
   endif()
-  
+
   ## Setting up RELEASE flags
   set(RELEASE_FLAGS "-Ofast -DNDEBUG -Wno-unused-variable")
-  
+
   if(NOT APPLE)
     # There is a clang bug that does not allow to compile code that uses AES-NI intrinsics if -flto is enabled
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
@@ -143,13 +143,13 @@ if(NOT MSVC)
       set(CMAKE_RANLIB gcc-ranlib)
     endif()
   endif()
-  
+
   ## Set up the normal CMake flags as we've built them
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${DEBUG_FLAGS}")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${DEBUG_FLAGS}")
   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${RELEASE_FLAGS}")
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${RELEASE_FLAGS}")
-  
+
   ## Statically link our binaries
   if(NOT APPLE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
@@ -159,7 +159,8 @@ endif()
 ## Go get us some static BOOST libraries
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_STATIC_RUNTIME ON)
-find_package(Boost 1.55 REQUIRED COMPONENTS system filesystem thread date_time chrono regex serialization program_options)
+find_package(Boost ${FIND_BOOST_VERSION} REQUIRED COMPONENTS system filesystem thread date_time chrono regex serialization program_options)
+message(STATUS "Boost Found: ${Boost_INCLUDE_DIRS}")
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 if(APPLE)
   set(Boost_LIBRARIES "${Boost_LIBRARIES}")
@@ -173,7 +174,7 @@ add_subdirectory(src)
 ## We need to setup the RocksDB build environment to match our system
 if(NOT MSVC)
   execute_process(
-    COMMAND cmake ${CMAKE_CURRENT_SOURCE_DIR}/external/rocksdb -DWITH_GFLAGS=0 -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DPORTABLE=ON -B${PROJECT_BINARY_DIR}/rocksdb
+    COMMAND cmake ${CMAKE_CURRENT_SOURCE_DIR}/external/rocksdb -DWITH_GFLAGS=0 -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DPORTABLE=ON -B${PROJECT_BINARY_DIR}/rocksdb 
   )
   set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${PROJECT_BINARY_DIR}/rocksdb/librocksdb.a")
 endif()

--- a/scripts/fix_boost_aarch64.sh
+++ b/scripts/fix_boost_aarch64.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed -i 's/using gcc/using gcc : aarch64 : aarch64-linux-gnu-g++/g' project-config.jam


### PR DESCRIPTION
The long story short here is that there is no cross-compile ready copies of Boost for AARCH64 in the regular Ubuntu repos. As a result, if we are building for AARCH64 then we need to go download Boost (1.55), set it up in our local folder, link against it, and cross-compile away.

I'll work on adding directions to the main readme on how to Cross compile from Ubuntu
