### PR TITLE
[ADMINISTRATIVE] Moar Make Targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,3 +124,8 @@ set_property(TARGET TurtleCoind PROPERTY OUTPUT_NAME "TurtleCoind")
 set_property(TARGET zedwallet PROPERTY OUTPUT_NAME "zedwallet")
 set_property(TARGET service PROPERTY OUTPUT_NAME "turtle-service")
 set_property(TARGET miner PROPERTY OUTPUT_NAME "miner")
+
+# Additional make targets
+add_custom_target(pool DEPENDS TurtleCoind service)
+add_custom_target(solominer DEPENDS TurtleCoind zedwallet miner)
+add_custom_target(wallet DEPENDS TurtleCoind zedwallet)


### PR DESCRIPTION
See https://github.com/turtlecoin/meta/issues/112

Enables the following make targets (for slimmer builds):

* `make pool`
  * `TurtleCoind`
  * `turtle-service`
* `make solominer`
  * `TurtleCoind`
  * `zedwallet`
  * `miner`
* `make wallet`
  * `TurtleCoind`
  * `zedwallet`