### PR TITLE
[ENHANCEMENT] Update mixin to static 3, make anonymity parameter optional in sendTransaction() and friends

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -86,13 +86,24 @@ const uint64_t MINIMUM_FEE                                   = UINT64_C(10);
 
 const uint64_t MINIMUM_MIXIN_V1                              = 0;
 const uint64_t MAXIMUM_MIXIN_V1                              = 100;
+
 const uint64_t MINIMUM_MIXIN_V2                              = 7;
 const uint64_t MAXIMUM_MIXIN_V2                              = 7;
 
+const uint64_t MINIMUM_MIXIN_V3                              = 3;
+const uint64_t MAXIMUM_MIXIN_V3                              = 3;
+
+/* The heights to activate the mixin limits at */
 const uint32_t MIXIN_LIMITS_V1_HEIGHT                        = 440000;
 const uint32_t MIXIN_LIMITS_V2_HEIGHT                        = 620000;
+const uint32_t MIXIN_LIMITS_V3_HEIGHT                        = 800000;
 
-const uint64_t DEFAULT_MIXIN                                 = MINIMUM_MIXIN_V2;
+/* The mixin to use by default with zedwallet and turtle-service */
+/* DEFAULT_MIXIN_V0 is the mixin used before MIXIN_LIMITS_V1_HEIGHT is started */
+const uint64_t DEFAULT_MIXIN_V0                              = 3;
+const uint64_t DEFAULT_MIXIN_V1                              = MAXIMUM_MIXIN_V1;
+const uint64_t DEFAULT_MIXIN_V2                              = MAXIMUM_MIXIN_V2;
+const uint64_t DEFAULT_MIXIN_V3                              = MAXIMUM_MIXIN_V3;
 
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(10);
 const uint64_t DEFAULT_DUST_THRESHOLD_V2                     = UINT64_C(0);

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -958,6 +958,11 @@ bool Core::validateMixin(const std::vector<CachedTransaction> transactions,
     /* We also need to ensure that the mixin enforced is for the limit that
      was correct when the block was formed - i.e. if 0 mixin was allowed at
      block 100, but is no longer allowed - we should still validate block 100 */
+    if (height >= CryptoNote::parameters::MIXIN_LIMITS_V3_HEIGHT)
+    {
+        minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V3;
+        maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V3;
+    }
     if (height >= CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
     {
         minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V2;

--- a/src/Wallet/WalletUtils.cpp
+++ b/src/Wallet/WalletUtils.cpp
@@ -23,6 +23,26 @@
 
 namespace CryptoNote {
 
+uint64_t getDefaultMixinByHeight(const uint64_t height)
+{
+    if (height >= CryptoNote::parameters::MIXIN_LIMITS_V3_HEIGHT)
+    {
+        return CryptoNote::parameters::DEFAULT_MIXIN_V3;
+    }
+    if (height >= CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
+    {
+        return CryptoNote::parameters::DEFAULT_MIXIN_V2;
+    }
+    else if (height >= CryptoNote::parameters::MIXIN_LIMITS_V1_HEIGHT)
+    {
+        return CryptoNote::parameters::DEFAULT_MIXIN_V1;
+    }
+    else
+    {
+        return CryptoNote::parameters::DEFAULT_MIXIN_V0;
+    }
+}
+
 void throwIfKeysMismatch(const Crypto::SecretKey& secretKey, const Crypto::PublicKey& expectedPublicKey, const std::string& message) {
   Crypto::PublicKey pub;
   bool r = Crypto::secret_key_to_public_key(secretKey, pub);

--- a/src/Wallet/WalletUtils.h
+++ b/src/Wallet/WalletUtils.h
@@ -25,6 +25,7 @@
 
 namespace CryptoNote {
 
+uint64_t getDefaultMixinByHeight(const uint64_t height);
 void throwIfKeysMismatch(const Crypto::SecretKey& secretKey, const Crypto::PublicKey& expectedPublicKey, const std::string& message = "");
 bool validateAddress(const std::string& address, const CryptoNote::Currency& currency);
 

--- a/src/WalletService/PaymentServiceJsonRpcMessages.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.cpp
@@ -6,6 +6,7 @@
 
 #include "PaymentServiceJsonRpcMessages.h"
 #include "Serialization/SerializationOverloads.h"
+#include "WalletService.h"
 
 namespace PaymentService {
 
@@ -257,7 +258,7 @@ void WalletRpcOrder::serialize(CryptoNote::ISerializer& serializer) {
   }
 }
 
-void SendTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {
+void SendTransaction::Request::serialize(CryptoNote::ISerializer& serializer, const WalletService &service) {
   serializer(sourceAddresses, "addresses");
 
   if (!serializer(transfers, "transfers")) {
@@ -271,7 +272,7 @@ void SendTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {
   }
 
   if (!serializer(anonymity, "anonymity")) {
-    throw RequestSerializationError();
+    anonymity = service.getDefaultMixin();
   }
 
   bool hasExtra = serializer(extra, "extra");
@@ -288,7 +289,7 @@ void SendTransaction::Response::serialize(CryptoNote::ISerializer& serializer) {
   serializer(transactionHash, "transactionHash");
 }
 
-void CreateDelayedTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {
+void CreateDelayedTransaction::Request::serialize(CryptoNote::ISerializer& serializer, const WalletService &service) {
   serializer(addresses, "addresses");
 
   if (!serializer(transfers, "transfers")) {
@@ -302,7 +303,7 @@ void CreateDelayedTransaction::Request::serialize(CryptoNote::ISerializer& seria
   }
 
   if (!serializer(anonymity, "anonymity")) {
-    throw RequestSerializationError();
+    anonymity = service.getDefaultMixin();
   }
 
   bool hasExtra = serializer(extra, "extra");
@@ -344,13 +345,13 @@ void SendDelayedTransaction::Request::serialize(CryptoNote::ISerializer& seriali
 void SendDelayedTransaction::Response::serialize(CryptoNote::ISerializer& serializer) {
 }
 
-void SendFusionTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {
+void SendFusionTransaction::Request::serialize(CryptoNote::ISerializer& serializer, const WalletService &service) {
   if (!serializer(threshold, "threshold")) {
     throw RequestSerializationError();
   }
 
   if (!serializer(anonymity, "anonymity")) {
-    throw RequestSerializationError();
+    anonymity = service.getDefaultMixin();
   }
 
   serializer(addresses, "addresses");

--- a/src/WalletService/PaymentServiceJsonRpcMessages.h
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.h
@@ -14,9 +14,11 @@
 
 namespace PaymentService {
 
-const uint32_t DEFAULT_ANONYMITY_LEVEL = 6;
+/* Forward declaration to avoid circular dependency from including "WalletService.h" */
+class WalletService;
 
 class RequestSerializationError: public std::exception {
+
 public:
   virtual const char* what() const throw() override { return "Request error"; }
 };
@@ -321,12 +323,12 @@ struct SendTransaction {
     std::vector<WalletRpcOrder> transfers;
     std::string changeAddress;
     uint64_t fee = 0;
-    uint32_t anonymity = DEFAULT_ANONYMITY_LEVEL;
+    uint32_t anonymity;
     std::string extra;
     std::string paymentId;
     uint64_t unlockTime = 0;
 
-    void serialize(CryptoNote::ISerializer& serializer);
+    void serialize(CryptoNote::ISerializer& serializer, const WalletService &service);
   };
 
   struct Response {
@@ -342,12 +344,12 @@ struct CreateDelayedTransaction {
     std::vector<WalletRpcOrder> transfers;
     std::string changeAddress;
     uint64_t fee = 0;
-    uint32_t anonymity = DEFAULT_ANONYMITY_LEVEL;
+    uint32_t anonymity;
     std::string extra;
     std::string paymentId;
     uint64_t unlockTime = 0;
 
-    void serialize(CryptoNote::ISerializer& serializer);
+    void serialize(CryptoNote::ISerializer& serializer, const WalletService &service);
   };
 
   struct Response {
@@ -396,11 +398,11 @@ struct SendDelayedTransaction {
 struct SendFusionTransaction {
   struct Request {
     uint64_t threshold;
-    uint32_t anonymity = DEFAULT_ANONYMITY_LEVEL;
+    uint32_t anonymity;
     std::vector<std::string> addresses;
     std::string destinationAddress;
 
-    void serialize(CryptoNote::ISerializer& serializer);
+    void serialize(CryptoNote::ISerializer& serializer, const WalletService &service);
   };
 
   struct Response {

--- a/src/WalletService/PaymentServiceJsonRpcServer.h
+++ b/src/WalletService/PaymentServiceJsonRpcServer.h
@@ -34,13 +34,13 @@ private:
 
   template <typename RequestType, typename ResponseType, typename RequestHandler>
   HandlerFunction jsonHandler(RequestHandler handler) {
-    return [handler] (const Common::JsonValue& jsonRpcParams, Common::JsonValue& jsonResponse) mutable {
+    return [handler, this] (const Common::JsonValue& jsonRpcParams, Common::JsonValue& jsonResponse) mutable {
       RequestType request;
       ResponseType response;
 
       try {
         CryptoNote::JsonInputValueSerializer inputSerializer(const_cast<Common::JsonValue&>(jsonRpcParams));
-        serialize(request, inputSerializer);
+        SerializeRequest(request, inputSerializer);
       } catch (std::exception&) {
         makeGenericErrorReponse(jsonResponse, "Invalid Request", -32600);
         return;
@@ -56,6 +56,27 @@ private:
       serialize(response, outputSerializer);
       fillJsonResponse(outputSerializer.getValue(), jsonResponse);
     };
+  }
+
+  template <typename RequestType>
+  void SerializeRequest(RequestType &request, CryptoNote::JsonInputValueSerializer &inputSerializer)
+  {
+      serialize(request, inputSerializer);
+  }
+
+  void SerializeRequest(SendTransaction::Request &request, CryptoNote::JsonInputValueSerializer &inputSerializer)
+  {
+      request.serialize(inputSerializer, service);
+  }
+
+  void SerializeRequest(CreateDelayedTransaction::Request &request, CryptoNote::JsonInputValueSerializer &inputSerializer)
+  {
+      request.serialize(inputSerializer, service);
+  }
+
+  void SerializeRequest(SendFusionTransaction::Request &request, CryptoNote::JsonInputValueSerializer &inputSerializer)
+  {
+      request.serialize(inputSerializer, service);
   }
 
   std::unordered_map<std::string, HandlerFunction> handlers;

--- a/src/WalletService/WalletService.cpp
+++ b/src/WalletService/WalletService.cpp
@@ -277,7 +277,12 @@ void validateMixin(const uint32_t mixin, const uint32_t height, Logging::LoggerR
     uint64_t minMixin = 0;
     uint64_t maxMixin = std::numeric_limits<uint64_t>::max();
 
-    if (height >= CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
+    if (height >= CryptoNote::parameters::MIXIN_LIMITS_V3_HEIGHT)
+    {
+        minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V3;
+        maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V3;
+    }
+    else if (height >= CryptoNote::parameters::MIXIN_LIMITS_V2_HEIGHT)
     {
         minMixin = CryptoNote::parameters::MINIMUM_MIXIN_V2;
         maxMixin = CryptoNote::parameters::MAXIMUM_MIXIN_V2;
@@ -1360,6 +1365,11 @@ std::error_code WalletService::getFeeInfo(std::string& address, uint32_t& amount
   amount = m_node_fee;
   
   return std::error_code();
+}
+
+uint64_t WalletService::getDefaultMixin() const
+{
+    return CryptoNote::getDefaultMixinByHeight(node.getLastKnownBlockHeight());
 }
 
 void WalletService::refresh() {

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -88,6 +88,8 @@ public:
   std::error_code estimateFusion(uint64_t threshold, const std::vector<std::string>& addresses, uint32_t& fusionReadyCount, uint32_t& totalOutputCount);
   std::error_code createIntegratedAddress(const std::string& address, const std::string& paymentId, std::string& integratedAddress);
   std::error_code getFeeInfo(std::string& address, uint32_t& amount);
+  uint64_t getDefaultMixin() const;
+
 
 private:
   void refresh();

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -6,8 +6,8 @@
 #define PROJECT_COPYRIGHT "Copyright 2018, The TurtleCoin Developers"
 #define APP_VER_MAJOR 0
 #define APP_VER_MINOR 8
-#define APP_VER_REV 0
-#define APP_VER_BUILD 1268
+#define APP_VER_REV 1
+#define APP_VER_BUILD 1269
 
 #define BUILD_COMMIT_ID "@VERSION@"
 #define PROJECT_VERSION STR(APP_VER_MAJOR) "." STR(APP_VER_MINOR) "." STR(APP_VER_REV)

--- a/src/zedwallet/AddressBook.cpp
+++ b/src/zedwallet/AddressBook.cpp
@@ -14,6 +14,8 @@
 
 #include <Serialization/SerializationTools.h>
 
+#include <Wallet/WalletUtils.h>
+
 #include <zedwallet/ColouredMsg.h>
 #include <zedwallet/Tools.h>
 #include <zedwallet/Transfer.h>
@@ -200,7 +202,7 @@ void sendFromAddressBook(std::shared_ptr<WalletInfo> &walletInfo,
     auto amount = maybeAmount.x;
     auto fee = WalletConfig::defaultFee;
     auto extra = getExtraFromPaymentID(addressBookEntry.paymentID);
-    auto mixin = WalletConfig::defaultMixin;
+    auto mixin = CryptoNote::getDefaultMixinByHeight(height);
     auto integrated = addressBookEntry.integratedAddress;
 
     if (integrated)

--- a/src/zedwallet/Commands.cpp
+++ b/src/zedwallet/Commands.cpp
@@ -123,7 +123,7 @@ bool dispatchCommand(std::shared_ptr<WalletInfo> &walletInfo,
     }
     else if (command == "optimize")
     {
-        fullOptimize(walletInfo->wallet);
+        fullOptimize(walletInfo->wallet, node.getLastKnownBlockHeight());
     }
     else if (command == "ab_add")
     {

--- a/src/zedwallet/Fusion.h
+++ b/src/zedwallet/Fusion.h
@@ -7,11 +7,13 @@
 #include <Wallet/WalletGreen.h>
 
 bool fusionTX(CryptoNote::WalletGreen &wallet, 
-              CryptoNote::TransactionParameters p);
+              CryptoNote::TransactionParameters p,
+              uint64_t height);
 
-bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold);
+bool optimize(CryptoNote::WalletGreen &wallet, uint64_t threshold,
+              uint64_t height);
 
-void fullOptimize(CryptoNote::WalletGreen &wallet);
+void fullOptimize(CryptoNote::WalletGreen &wallet, uint64_t height);
 
 size_t makeFusionTransaction(CryptoNote::WalletGreen &wallet, 
-                             uint64_t threshold);
+                             uint64_t threshold, uint64_t height);

--- a/src/zedwallet/Transfer.cpp
+++ b/src/zedwallet/Transfer.cpp
@@ -37,6 +37,7 @@ namespace WalletErrors
 }
 
 #include <Wallet/WalletGreen.h>
+#include <Wallet/WalletUtils.h>
 
 bool parseAmount(std::string strAmount, uint64_t &amount)
 {
@@ -334,7 +335,7 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height,
        the fee from full balance */
     uint64_t amount = 0;
 
-    uint64_t mixin = WalletConfig::defaultMixin;
+    uint64_t mixin = CryptoNote::getDefaultMixinByHeight(height);
 
     /* If we're sending everything, obviously we don't need to ask them how
        much to send */
@@ -402,7 +403,8 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height,
        check for balance minus dust */
     if (sendAll)
     {
-        if (WalletConfig::defaultMixin != 0 && balance != balanceNoDust)
+        if (CryptoNote::getDefaultMixinByHeight(height) != 0
+         && balance != balanceNoDust)
         {
             uint64_t unsendable = balance - balanceNoDust;
 
@@ -488,7 +490,7 @@ BalanceInfo doWeHaveEnoughBalance(uint64_t amount, uint64_t fee,
 
         return NotEnoughBalance;
     }
-    else if (WalletConfig::defaultMixin != 0 &&
+    else if (CryptoNote::getDefaultMixinByHeight(height) != 0 &&
              balanceNoDust < amount + WalletConfig::minimumFee + nodeFee)
     {
         std::cout << std::endl
@@ -584,7 +586,7 @@ void sendTX(std::shared_ptr<WalletInfo> walletInfo,
         if (walletInfo->wallet.txIsTooLarge(tx))
         {
             /* If the fusion transactions didn't completely unlock, abort tx */
-            if (!fusionTX(walletInfo->wallet, p))
+            if (!fusionTX(walletInfo->wallet, p, height))
             {
                 return;
             }

--- a/src/zedwallet/WalletConfig.h
+++ b/src/zedwallet/WalletConfig.h
@@ -55,9 +55,6 @@ namespace WalletConfig
     const long unsigned int integratedAddressLength = standardAddressLength
                                                     + ((64 * 11) / 8);
 
-    /* The mixin value to use with transactions */
-    const uint64_t defaultMixin = CryptoNote::parameters::DEFAULT_MIXIN;
-
     /* The default fee value to use with transactions (in ATOMIC units!) */
     const uint64_t defaultFee = CryptoNote::parameters::MINIMUM_FEE; 
 


### PR DESCRIPTION
Sets the mixin to a static 3 at block 800,000.

Makes anonymity an optional parameter in turtle-service. If it is not specified, the DEFAULT_MIXIN_V? will be used where ? is based on the current height.

This means only the turtle-service executable will need updating, and not GUI wallets such as nest, to check for a before/after height to set the anonymity param.

I had to modify the serialization a tad to pass through WalletService, and it does appear to serialize correctly, but I wouldn't mind some extra eyes on this.

TODO: api-docs need updating with both reset from height and this new sendTransaction() modifications. Also might want to modify the pool, and nest.

[I'll fix my fucked up git repo after these PR's are done]