### PR TITLE
[BUGFIX] [ENHANCEMENT] Fix funky output with multithreaded linenoise, and unexpected slow shutdown

### DIFF
--- a/external/linenoise/linenoise.hpp
+++ b/external/linenoise/linenoise.hpp
@@ -1607,7 +1607,15 @@ inline bool enableRawMode(int fd) {
      * no start/stop output control. */
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
     /* output modes - disable post processing */
+
+    /* This line has been commented out due to causing issues whilst writing
+       to the terminal on another thread, whilst waiting for input with
+       readline. See further - https://github.com/antirez/linenoise/issues/128
+
     raw.c_oflag &= ~(OPOST);
+
+    */
+
     /* control modes - set 8 bit chars */
     raw.c_cflag |= (CS8);
     /* local modes - choing off, canonical off, no extended functions,

--- a/src/zedwallet/ZedWallet.h
+++ b/src/zedwallet/ZedWallet.h
@@ -13,5 +13,5 @@ int main(int argc, char **argv);
 void run(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
          Config &config);
 
-bool shutdown(CryptoNote::WalletGreen &wallet, CryptoNote::INode &node,
+bool shutdown(std::shared_ptr<WalletInfo> walletInfo, CryptoNote::INode &node,
               bool &alreadyShuttingDown);


### PR DESCRIPTION
Added this change - https://github.com/antirez/linenoise/issues/128 - to fix output being funky whilst writing to the terminal and one thread and reading on another.

Call shutdown() when exiting before loading the wallet to provide visual feedback of why `exit` is not instantly exiting.