### PR TITLE
[ENHANCEMENT] Adds the ability to ignore peers that aren't running a supported version

### DIFF
--- a/src/Common/FormatTools.cpp
+++ b/src/Common/FormatTools.cpp
@@ -1,13 +1,14 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 
 #include "FormatTools.h"
 #include <cstdio>
 #include <ctime>
+#include "CryptoNoteConfig.h"
 #include "CryptoNoteCore/Core.h"
 #include "Rpc/CoreRpcServerCommandsDefinitions.h"
 #include <boost/format.hpp>
@@ -163,7 +164,7 @@ std::string get_upgrade_info(uint64_t supported_height, std::vector<uint64_t> up
     {
         if (upgrade > supported_height)
         {
-            return "The network forked at height " + std::to_string(upgrade) + ", please update your software: https://turtlecoin.lol";
+            return "The network forked at height " + std::to_string(upgrade) + ", please update your software: " + CryptoNote::LATEST_VERSION_URL;
         }
     }
 
@@ -180,7 +181,7 @@ std::string get_status_string(CryptoNote::COMMAND_RPC_GET_INFO::response iresp) 
   ss << "Height: " << iresp.height << "/" << iresp.network_height
      << " (" << get_sync_percentage(iresp.height, iresp.network_height) << "%) "
      << "on " << (iresp.testnet ? "testnet, " : "mainnet, ")
-     << (iresp.synced ? "synced, " : "syncing, ") 
+     << (iresp.synced ? "synced, " : "syncing, ")
      << "net hash " << get_mining_speed(iresp.hashrate) << ", "
      << "v" << +iresp.major_version << ","
      << get_update_status(forkStatus, iresp.network_height, iresp.upgrade_heights)

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -143,7 +143,7 @@ const uint32_t KEY_IMAGE_CHECKING_BLOCK_INDEX                = 0;
 const uint32_t UPGRADE_HEIGHT_V2                             = 1;
 const uint32_t UPGRADE_HEIGHT_V3                             = 2;
 const uint32_t UPGRADE_HEIGHT_V4                             = 350000; // Upgrade height for CN-Lite Variant 1 switch.
-const uint32_t UPGRADE_HEIGHT_CURRENT                        = UPGRADE_HEIGHT_V4; 
+const uint32_t UPGRADE_HEIGHT_CURRENT                        = UPGRADE_HEIGHT_V4;
 const unsigned UPGRADE_VOTING_THRESHOLD                      = 90;               // percent
 const uint32_t UPGRADE_VOTING_WINDOW                         = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks
 const uint32_t UPGRADE_WINDOW                                = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks
@@ -212,6 +212,11 @@ const int      RPC_DEFAULT_PORT                              =  11898;
 
 const size_t   P2P_LOCAL_WHITE_PEERLIST_LIMIT                =  1000;
 const size_t   P2P_LOCAL_GRAY_PEERLIST_LIMIT                 =  5000;
+
+// P2P Network Configuration Section - This defines our current P2P network version
+// and the minimum version for communication between nodes
+const uint8_t  P2P_CURRENT_VERSION                           = 2;
+const uint8_t  P2P_MINIMUM_VERSION                           = 1;
 
 const size_t   P2P_CONNECTION_MAX_WRITE_BUFFER_SIZE          = 32 * 1024 * 1024; // 32 MB
 const uint32_t P2P_DEFAULT_CONNECTIONS_COUNT                 = 8;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -230,7 +230,8 @@ const uint64_t P2P_DEFAULT_INVOKE_TIMEOUT                    = 60 * 2 * 1000; //
 const size_t   P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT          = 5000;          // 5 seconds
 const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
-const static boost::uuids::uuid CRYPTONOTE_NETWORK =
+const char     LATEST_VERSION_URL[]                          = "http://latest.turtlecoin.lol";
+const static boost::uuids::uuid CRYPTONOTE_NETWORK           =
 {
     {  0xb5, 0x0c, 0x4a, 0x6c, 0xcf, 0x52, 0x57, 0x41, 0x65, 0xf9, 0x91, 0xa4, 0xb6, 0xc1, 0x43, 0xe9  }
 };

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -231,7 +231,7 @@ const size_t   P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT          = 5000;          //
 const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
 const char     LATEST_VERSION_URL[]                          = "http://latest.turtlecoin.lol";
-const static boost::uuids::uuid CRYPTONOTE_NETWORK           =
+const static   boost::uuids::uuid CRYPTONOTE_NETWORK         =
 {
     {  0xb5, 0x0c, 0x4a, 0x6c, 0xcf, 0x52, 0x57, 0x41, 0x65, 0xf9, 0x91, 0xa4, 0xb6, 0xc1, 0x43, 0xe9  }
 };

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -1,19 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2018, The TurtleCoin Developers
 //
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Please see the included LICENSE file for more information.
 
 #include "CryptoNoteProtocolHandler.h"
 
@@ -691,7 +679,7 @@ void CryptoNoteProtocolHandler::relayTransactions(const std::vector<BinaryArray>
 }
 
 void CryptoNoteProtocolHandler::requestMissingPoolTransactions(const CryptoNoteConnectionContext& context) {
-  if (context.version < P2PProtocolVersion::V1) {
+  if (context.version < 1) {
     return;
   }
 
@@ -728,16 +716,16 @@ void CryptoNoteProtocolHandler::updateObservedHeight(uint32_t peerHeight, const 
       }
     }
   }
-  
+
   {
     std::lock_guard<std::mutex> lock(m_blockchainHeightMutex);
     if (peerHeight > m_blockchainHeight) {
       m_blockchainHeight = peerHeight;
-      logger(Logging::INFO, Logging::BRIGHT_GREEN) << "New Top Block Detected: " << peerHeight; 
+      logger(Logging::INFO, Logging::BRIGHT_GREEN) << "New Top Block Detected: " << peerHeight;
     }
   }
 
-  
+
   if (updated) {
     logger(TRACE) << "Observed height updated: " << m_observedHeight;
     m_observerManager.notify(&ICryptoNoteProtocolObserver::lastKnownBlockHeightUpdated, m_observedHeight);
@@ -766,7 +754,7 @@ uint32_t CryptoNoteProtocolHandler::getObservedHeight() const {
 
 uint32_t CryptoNoteProtocolHandler::getBlockchainHeight() const {
   std::lock_guard<std::mutex> lock(m_blockchainHeightMutex);
-  return m_blockchainHeight;  
+  return m_blockchainHeight;
 };
 
 bool CryptoNoteProtocolHandler::addObserver(ICryptoNoteProtocolObserver* observer) {

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -575,15 +575,15 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
     context.version = rsp.node_data.version;
 
     if (rsp.node_data.network_id != m_network_id) {
-      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Failed, wrong network! (" << rsp.node_data.network_id << "), closing connection.";
+      logger(Logging::DEBUGGING) << context << "COMMAND_HANDSHAKE Failed, wrong network! (" << rsp.node_data.network_id << "), closing connection.";
       return false;
     }
 
     if (rsp.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
-      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Failed, peer is wrong version! (" << std::to_string(rsp.node_data.version) << "), closing connection.";
+      logger(Logging::DEBUGGING) << context << "COMMAND_HANDSHAKE Failed, peer is wrong version! (" << std::to_string(rsp.node_data.version) << "), closing connection.";
       return false;
     } else if (rsp.node_data.version > CryptoNote::P2P_CURRENT_VERSION) {
-      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Warning, our software may be out of date. Please visit: "
+      logger(Logging::WARNING) << context << "COMMAND_HANDSHAKE Warning, our software may be out of date. Please visit: "
         << CryptoNote::LATEST_VERSION_URL << " for the latest version.";
     }
 
@@ -1143,17 +1143,17 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
     context.version = arg.node_data.version;
 
     if (arg.node_data.network_id != m_network_id) {
-      logger(Logging::INFO) << context << "WRONG NETWORK AGENT CONNECTED! id=" << arg.node_data.network_id;
+      logger(Logging::DEBUGGING) << context << "WRONG NETWORK AGENT CONNECTED! id=" << arg.node_data.network_id;
       context.m_state = CryptoNoteConnectionContext::state_shutdown;
       return 1;
     }
 
     if (arg.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
-      logger(Logging::INFO) << context << "UNSUPPORTED NETWORK AGENT VERSION CONNECTED! version=" << std::to_string(arg.node_data.version);
+      logger(Logging::DEBUGGING) << context << "UNSUPPORTED NETWORK AGENT VERSION CONNECTED! version=" << std::to_string(arg.node_data.version);
       context.m_state = CryptoNoteConnectionContext::state_shutdown;
       return 1;
     } else if (arg.node_data.version > CryptoNote::P2P_CURRENT_VERSION) {
-      logger(Logging::INFO) << context << "Our software may be out of date. Please visit: "
+      logger(Logging::WARNING) << context << "Our software may be out of date. Please visit: "
         << CryptoNote::LATEST_VERSION_URL << " for the latest version.";
     }
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -582,6 +582,9 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
     if (rsp.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
       logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Failed, peer is wrong version! (" << std::to_string(rsp.node_data.version) << "), closing connection.";
       return false;
+    } else if (rsp.node_data.version > CryptoNote::P2P_CURRENT_VERSION) {
+      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Warning, our software may be out of date. Please visit: "
+        << CryptoNote::LATEST_VERSION_URL << " for the latest version.";
     }
 
     if (!handle_remote_peerlist(rsp.local_peerlist, rsp.node_data.local_time, context)) {
@@ -1149,6 +1152,9 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
       logger(Logging::INFO) << context << "UNSUPPORTED NETWORK AGENT VERSION CONNECTED! version=" << std::to_string(arg.node_data.version);
       context.m_state = CryptoNoteConnectionContext::state_shutdown;
       return 1;
+    } else if (arg.node_data.version > CryptoNote::P2P_CURRENT_VERSION) {
+      logger(Logging::INFO) << context << "Our software may be out of date. Please visit: "
+        << CryptoNote::LATEST_VERSION_URL << " for the latest version.";
     }
 
     if(!context.m_is_income) {

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1,19 +1,7 @@
-// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers, The TurtleCoin developers
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2018, The TurtleCoin Developers
 //
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Please see the included LICENSE file for more information.
 
 #include "NetNode.h"
 
@@ -38,6 +26,7 @@
 #include <System/TcpConnector.h>
 
 #include "version.h"
+#include "CryptoNoteConfig.h"
 #include "Common/StdInputStream.h"
 #include "Common/StdOutputStream.h"
 #include "Common/Util.h"
@@ -586,7 +575,12 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
     context.version = rsp.node_data.version;
 
     if (rsp.node_data.network_id != m_network_id) {
-      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Failed, wrong network!  (" << rsp.node_data.network_id << "), closing connection.";
+      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Failed, wrong network! (" << rsp.node_data.network_id << "), closing connection.";
+      return false;
+    }
+
+    if (rsp.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
+      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE Failed, peer is wrong version! (" << std::to_string(rsp.node_data.version) << "), closing connection.";
       return false;
     }
 
@@ -959,7 +953,7 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
 
   bool NodeServer::get_local_node_data(basic_node_data& node_data)
   {
-    node_data.version = P2PProtocolVersion::CURRENT;
+    node_data.version = CryptoNote::P2P_CURRENT_VERSION;
     time_t local_time;
     time(&local_time);
     node_data.local_time = local_time;
@@ -1147,6 +1141,12 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
 
     if (arg.node_data.network_id != m_network_id) {
       logger(Logging::INFO) << context << "WRONG NETWORK AGENT CONNECTED! id=" << arg.node_data.network_id;
+      context.m_state = CryptoNoteConnectionContext::state_shutdown;
+      return 1;
+    }
+
+    if (arg.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
+      logger(Logging::INFO) << context << "UNSUPPORTED NETWORK AGENT VERSION CONNECTED! version=" << std::to_string(arg.node_data.version);
       context.m_state = CryptoNoteConnectionContext::state_shutdown;
       return 1;
     }

--- a/src/P2p/P2pNode.cpp
+++ b/src/P2p/P2pNode.cpp
@@ -1,19 +1,7 @@
-// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers, The TurtleCoin developers
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2018, The TurtleCoin Developers
 //
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Please see the included LICENSE file for more information.
 
 #include "P2pNode.h"
 
@@ -26,6 +14,7 @@
 #include <System/TcpConnection.h>
 #include <System/TcpConnector.h>
 
+#include "CryptoNoteConfig.h"
 #include "Common/StdInputStream.h"
 #include "Common/StdOutputStream.h"
 #include "Serialization/BinaryInputStreamSerializer.h"
@@ -165,7 +154,7 @@ void P2pNode::stop() {
 
   m_stopRequested = true;
   // clear prepared connections
-  m_connectionQueue.clear(); 
+  m_connectionQueue.clear();
   // stop processing
   m_queueEvent.set();
   workingContextGroup.interrupt();
@@ -199,7 +188,7 @@ void P2pNode::acceptLoop() {
   while (!m_stopRequested) {
     try {
       auto connection = m_listener.accept();
-      auto ctx = new P2pContext(m_dispatcher, std::move(connection), true, 
+      auto ctx = new P2pContext(m_dispatcher, std::move(connection), true,
         getRemoteAddress(connection), m_cfg.getTimedSyncInterval(), getGenesisPayload());
       logger(INFO) << "Incoming connection from " << ctx->getRemoteAddress();
       workingContextGroup.spawn([this, ctx] {
@@ -306,7 +295,7 @@ bool P2pNode::makeNewConnectionFromPeerlist(const PeerlistManager::Peerlist& pee
 
   return false;
 }
-  
+
 void P2pNode::preprocessIncomingConnection(ContextPtr ctx) {
   try {
     logger(DEBUGGING) << *ctx << "preprocessIncomingConnection";
@@ -406,6 +395,11 @@ bool P2pNode::fetchPeerList(ContextPtr connection) {
       return false;
     }
 
+    if (response.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
+      logger(ERROR) << *connection << "COMMAND_HANDSHAKE Failed, peer is wrong version: " << std::to_string(response.node_data.version);
+      return false;
+    }
+
     return handleRemotePeerList(response.local_peerlist, response.node_data.local_time);
   } catch (std::exception& e) {
     logger(INFO) << *connection << "Failed to obtain peer list: " << e.what();
@@ -450,7 +444,7 @@ std::list<PeerlistEntry> P2pNode::getLocalPeerList() const {
 basic_node_data P2pNode::getNodeData() const {
   basic_node_data nodeData;
   nodeData.network_id = m_cfg.getNetworkId();
-  nodeData.version = P2PProtocolVersion::CURRENT;
+  nodeData.version = CryptoNote::P2P_CURRENT_VERSION;
   nodeData.local_time = time(nullptr);
   nodeData.peer_id = m_myPeerId;
 
@@ -536,6 +530,12 @@ void P2pNode::handleNodeData(const basic_node_data& node, P2pContext& context) {
   if (node.network_id != m_cfg.getNetworkId()) {
     std::ostringstream msg;
     msg << context << "COMMAND_HANDSHAKE Failed, wrong network!  (" << node.network_id << ")";
+    throw std::runtime_error(msg.str());
+  }
+
+  if (node.version < CryptoNote::P2P_MINIMUM_VERSION) {
+    std::ostringstream msg;
+    msg << context << "COMMAND_HANDSHAKE Failed, peer is wrong version! (" << std::to_string(node.version) << ")";
     throw std::runtime_error(msg.str());
   }
 

--- a/src/P2p/P2pNode.cpp
+++ b/src/P2p/P2pNode.cpp
@@ -391,15 +391,15 @@ bool P2pNode::fetchPeerList(ContextPtr connection) {
     }
 
     if (response.node_data.network_id != request.node_data.network_id) {
-      logger(ERROR) << *connection << "COMMAND_HANDSHAKE failed, wrong network: " << response.node_data.network_id;
+      logger(DEBUGGING) << *connection << "COMMAND_HANDSHAKE failed, wrong network: " << response.node_data.network_id;
       return false;
     }
 
     if (response.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
-      logger(ERROR) << *connection << "COMMAND_HANDSHAKE Failed, peer is wrong version: " << std::to_string(response.node_data.version);
+      logger(DEBUGGING) << *connection << "COMMAND_HANDSHAKE Failed, peer is wrong version: " << std::to_string(response.node_data.version);
       return false;
     } else if (response.node_data.version > CryptoNote::P2P_CURRENT_VERSION) {
-      logger(ERROR) << *connection << "COMMAND_HANDSHAKE Warning, our software may be out of date. Please visit: "
+      logger(WARNING) << *connection << "COMMAND_HANDSHAKE Warning, our software may be out of date. Please visit: "
         << CryptoNote::LATEST_VERSION_URL << " for the latest version.";
     }
 

--- a/src/P2p/P2pNode.cpp
+++ b/src/P2p/P2pNode.cpp
@@ -398,6 +398,9 @@ bool P2pNode::fetchPeerList(ContextPtr connection) {
     if (response.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
       logger(ERROR) << *connection << "COMMAND_HANDSHAKE Failed, peer is wrong version: " << std::to_string(response.node_data.version);
       return false;
+    } else if (response.node_data.version > CryptoNote::P2P_CURRENT_VERSION) {
+      logger(ERROR) << *connection << "COMMAND_HANDSHAKE Warning, our software may be out of date. Please visit: "
+        << CryptoNote::LATEST_VERSION_URL << " for the latest version.";
     }
 
     return handleRemotePeerList(response.local_peerlist, response.node_data.local_time);

--- a/src/P2p/P2pProtocolDefinitions.h
+++ b/src/P2p/P2pProtocolDefinitions.h
@@ -1,19 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2018, The TurtleCoin Developers
 //
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Please see the included LICENSE file for more information.
 
 #pragma once
 
@@ -52,12 +40,6 @@ namespace CryptoNote
     uint32_t send_peerlist_sz;
   };
 
-  enum P2PProtocolVersion : uint8_t {
-    V0 = 0,
-    V1 = 1,
-    CURRENT = V1
-  };
-
   struct basic_node_data
   {
     uuid network_id;
@@ -77,7 +59,7 @@ namespace CryptoNote
       KV_MEMBER(my_port)
     }
   };
-  
+
   struct CORE_SYNC_DATA
   {
     uint32_t current_height;
@@ -114,7 +96,7 @@ namespace CryptoNote
     {
       basic_node_data node_data;
       CORE_SYNC_DATA payload_data;
-      std::list<PeerlistEntry> local_peerlist; 
+      std::list<PeerlistEntry> local_peerlist;
 
       void serialize(ISerializer& s) {
         KV_MEMBER(node_data)
@@ -163,7 +145,7 @@ namespace CryptoNote
   struct COMMAND_PING
   {
     /*
-      Used to make "callback" connection, to be sure that opponent node 
+      Used to make "callback" connection, to be sure that opponent node
       have accessible connection point. Only other nodes can add peer to peerlist,
       and ONLY in case when peer has accepted connection and answered to ping.
     */
@@ -189,9 +171,9 @@ namespace CryptoNote
     };
   };
 
-  
+
 #ifdef ALLOW_DEBUG_COMMANDS
-  //These commands are considered as insecure, and made in debug purposes for a limited lifetime. 
+  //These commands are considered as insecure, and made in debug purposes for a limited lifetime.
   //Anyone who feel unsafe with this commands can disable the ALLOW_GET_STAT_COMMAND macro.
 
   struct proof_of_trust
@@ -226,7 +208,7 @@ namespace CryptoNote
         KV_MEMBER(tr)
       }
     };
-    
+
     struct response
     {
       std::string version;


### PR DESCRIPTION
This adds new CryptoNoteConfig.h parameters `P2P_CURRENT_VERSION` and `P2P_MINIMUM_VERSION` that have been removed from `P2pProtocolDefinitions.h`

These new parameters are used for simple checks that determine if the incoming/outgoing peers are of a supported P2P network version. As such, it allows us to drop support for older nodes without inadvertently breaking the underlying P2P protocol (by changing it's structure) or forcing a network ID change as other chains have done.

This PR provides a message that is displayed when an old node tries to talk to us (and kills the connection) as well as gives us a warning if we're talking to nodes that are newer than us (keeps the connection active so we can verify an update actually exists while still syncing).

I've also added `LATEST_VERSION_URL` to `CryptoNoteConfig.h` to make it easier to update in the future if necessary or during forks as it is used in multiple places now.