### PR TITLE
Fix scan height not working in turtle service

### DIFF
--- a/src/WalletService/PaymentServiceConfiguration.cpp
+++ b/src/WalletService/PaymentServiceConfiguration.cpp
@@ -184,6 +184,10 @@ void Configuration::init(const boost::program_options::variables_map& options) {
     }
   }
 
+  if (options.count("scan-height") != 0) {
+    scanHeight = options["scan-height"].as<uint64_t>();
+  }
+
   // If generating a container skip the authentication parameters.
   if (generateNewContainer) {
     return;
@@ -204,11 +208,6 @@ void Configuration::init(const boost::program_options::variables_map& options) {
   if (options.count("enable-cors") != 0) {
     corsHeader = options["enable-cors"].as<std::string>();
   }
-
-  if (options.count("scan-height") != 0) {
-    scanHeight = options["scan-height"].as<uint64_t>();
-  }
-
 }
 
 } //namespace PaymentService


### PR DESCRIPTION
--scan-height only applies when generating a new container, as it's saved to part of the file.

Unfortunately, I just popped it at the end of configuration, without noticing that halfway through the configuration, we return, if generating a new container. 

Hence, the scan height parameter never got assigned.

Oops!