### PR TITLE
[ENHANCEMENT] Add daemon local height to wallet getStatus()

### DIFF
--- a/src/WalletService/PaymentServiceJsonRpcMessages.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.cpp
@@ -69,6 +69,7 @@ void GetStatus::Request::serialize(CryptoNote::ISerializer& serializer) {
 void GetStatus::Response::serialize(CryptoNote::ISerializer& serializer) {
   serializer(blockCount, "blockCount");
   serializer(knownBlockCount, "knownBlockCount");
+  serializer(localDaemonBlockCount, "localDaemonBlockCount");
   serializer(lastBlockHash, "lastBlockHash");
   serializer(peerCount, "peerCount");
 }

--- a/src/WalletService/PaymentServiceJsonRpcMessages.h
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.h
@@ -95,6 +95,7 @@ struct GetStatus {
   struct Response {
     uint32_t blockCount;
     uint32_t knownBlockCount;
+    uint32_t localDaemonBlockCount;
     std::string lastBlockHash;
     uint32_t peerCount;
 

--- a/src/WalletService/PaymentServiceJsonRpcServer.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcServer.cpp
@@ -211,7 +211,7 @@ std::error_code PaymentServiceJsonRpcServer::handleGetMnemonicSeed(const GetMnem
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleGetStatus(const GetStatus::Request& request, GetStatus::Response& response) {
-  return service.getStatus(response.blockCount, response.knownBlockCount, response.lastBlockHash, response.peerCount);
+  return service.getStatus(response.blockCount, response.knownBlockCount, response.localDaemonBlockCount, response.lastBlockHash, response.peerCount);
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleGetAddresses(const GetAddresses::Request& request, GetAddresses::Response& response) {

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -82,7 +82,7 @@ public:
   std::error_code deleteDelayedTransaction(const std::string& transactionHash);
   std::error_code sendDelayedTransaction(const std::string& transactionHash);
   std::error_code getUnconfirmedTransactionHashes(const std::vector<std::string>& addresses, std::vector<std::string>& transactionHashes);
-  std::error_code getStatus(uint32_t& blockCount, uint32_t& knownBlockCount, std::string& lastBlockHash, uint32_t& peerCount);
+  std::error_code getStatus(uint32_t& blockCount, uint32_t& knownBlockCount, uint32_t& localDaemonBlockCount, std::string& lastBlockHash, uint32_t& peerCount);
   std::error_code sendFusionTransaction(uint64_t threshold, uint32_t anonymity, const std::vector<std::string>& addresses,
     const std::string& destinationAddress, std::string& transactionHash);
   std::error_code estimateFusion(uint64_t threshold, const std::vector<std::string>& addresses, uint32_t& fusionReadyCount, uint32_t& totalOutputCount);


### PR DESCRIPTION
I've tested with a synced node, but when I tried to test with an unsynced node, it was just returning 1. I think it was the daemon playing up though, since zedwallet did the same.