### PR TITLE
[BUGFIX] Fix local node height in NodeRpcProxy

### DIFF
--- a/include/INode.h
+++ b/include/INode.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -87,6 +87,8 @@ public:
   virtual uint32_t getLocalBlockCount() const = 0;
   virtual uint32_t getKnownBlockCount() const = 0;
   virtual uint64_t getLastLocalBlockTimestamp() const = 0;
+  virtual uint64_t getNodeHeight() const = 0;
+
   virtual std::string getInfo() = 0;
   virtual void getFeeInfo() = 0;
 

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 
@@ -98,8 +98,8 @@ void NodeRpcProxy::init(const INode::Callback& callback) {
 
   m_state = STATE_INITIALIZING;
   resetInternalState();
-  m_workerThread = std::thread([this, callback] { 
-    workerThread(callback); 
+  m_workerThread = std::thread([this, callback] {
+    workerThread(callback);
   });
 }
 
@@ -131,9 +131,9 @@ void NodeRpcProxy::workerThread(const INode::Callback& initialized_callback) {
       m_state = STATE_INITIALIZED;
       m_cv_initialized.notify_all();
     }
-	
+
     getFeeInfo();
-	
+
     updateNodeStatus();
 
     initialized_callback(std::error_code());
@@ -242,6 +242,8 @@ void NodeRpcProxy::updateBlockchainStatus() {
       m_observerManager.notify(&INodeObserver::lastKnownBlockHeightUpdated, m_networkHeight.load(std::memory_order_relaxed));
     }
 
+    m_nodeHeight.store(getInfoResp.height, std::memory_order_relaxed);
+
     updatePeerCount(getInfoResp.incoming_connections_count + getInfoResp.outgoing_connections_count);
   }
 
@@ -272,15 +274,15 @@ void NodeRpcProxy::updatePoolState(const std::vector<std::unique_ptr<ITransactio
 void NodeRpcProxy::getFeeInfo() {
   CryptoNote::COMMAND_RPC_GET_FEE_ADDRESS::request ireq = AUTO_VAL_INIT(ireq);
   CryptoNote::COMMAND_RPC_GET_FEE_ADDRESS::response iresp = AUTO_VAL_INIT(iresp);
-  
+
   std::error_code ec = jsonCommand("/feeinfo", ireq, iresp);
-  
+
   if (ec || iresp.status != CORE_RPC_STATUS_OK) {
     return;
   }
   m_fee_address = iresp.address;
   m_fee_amount = iresp.amount;
-  
+
   return;
 }
 
@@ -300,8 +302,8 @@ std::string NodeRpcProxy::getInfo() {
 
   if (ec || iresp.status != CORE_RPC_STATUS_OK) {
     return std::string("Problem retrieving information from RPC server.");
-  } 
-    
+  }
+
   return Common::get_status_string(iresp);
 }
 
@@ -345,6 +347,10 @@ uint32_t NodeRpcProxy::getLocalBlockCount() const {
 
 uint32_t NodeRpcProxy::getKnownBlockCount() const {
   return m_networkHeight.load(std::memory_order_relaxed) + 1;
+}
+
+uint64_t NodeRpcProxy::getNodeHeight() const {
+  return m_nodeHeight.load(std::memory_order_relaxed);
 }
 
 uint64_t NodeRpcProxy::getLastLocalBlockTimestamp() const {

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -53,6 +53,8 @@ public:
   virtual uint32_t getLocalBlockCount() const override;
   virtual uint32_t getKnownBlockCount() const override;
   virtual uint64_t getLastLocalBlockTimestamp() const override;
+  virtual uint64_t getNodeHeight() const override;
+
   virtual std::string getInfo() override;
   virtual void getFeeInfo() override;
 
@@ -75,7 +77,7 @@ public:
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
   virtual std::string feeAddress() override;
   virtual uint32_t feeAmount() override;
-  
+
   unsigned int rpcTimeout() const { return m_rpcTimeout; }
   void rpcTimeout(unsigned int val) { m_rpcTimeout = val; }
 
@@ -146,6 +148,7 @@ private:
   bool m_stop = false;
   std::atomic<size_t> m_peerCount;
   std::atomic<uint32_t> m_networkHeight;
+  std::atomic<uint64_t> m_nodeHeight;
 
   BlockHeaderInfo lastLocalBlockHeaderInfo;
   //protect it with mutex if decided to add worker threads

--- a/src/WalletService/NodeFactory.cpp
+++ b/src/WalletService/NodeFactory.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #include "NodeFactory.h"
@@ -26,6 +26,8 @@ public:
   virtual uint32_t getLocalBlockCount() const override { return 0; }
   virtual uint32_t getKnownBlockCount() const override { return 0; }
   virtual uint64_t getLastLocalBlockTimestamp() const override { return 0; }
+  virtual uint64_t getNodeHeight() const override { return 0; }
+
   virtual std::string getInfo() override { return std::string(); }
   virtual void getFeeInfo() override { }
 

--- a/src/WalletService/PaymentServiceJsonRpcMessages.h
+++ b/src/WalletService/PaymentServiceJsonRpcMessages.h
@@ -95,7 +95,7 @@ struct GetStatus {
   struct Response {
     uint32_t blockCount;
     uint32_t knownBlockCount;
-    uint32_t localDaemonBlockCount;
+    uint64_t localDaemonBlockCount;
     std::string lastBlockHash;
     uint32_t peerCount;
 

--- a/src/WalletService/WalletService.cpp
+++ b/src/WalletService/WalletService.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #include "WalletService.h"
@@ -329,7 +329,7 @@ std::vector<std::string> collectDestinationAddresses(const std::vector<PaymentSe
 
 std::vector<CryptoNote::WalletOrder> convertWalletRpcOrdersToWalletOrders(const std::vector<PaymentService::WalletRpcOrder>& orders, const std::string nodeAddress, const uint32_t nodeFee) {
   std::vector<CryptoNote::WalletOrder> result;
-  
+
   if (!nodeAddress.empty() && nodeFee != 0) {
     result.reserve(orders.size() + 1);
     result.emplace_back(CryptoNote::WalletOrder {nodeAddress, nodeFee});
@@ -458,17 +458,17 @@ void WalletService::init() {
 
   getNodeFee();
   refreshContext.spawn([this] { refresh(); });
-  
+
   inited = true;
 }
 
 void WalletService::getNodeFee() {
   logger(Logging::DEBUGGING) <<
     "Trying to retrieve node fee information." << std::endl;
-    
+
   m_node_address = node.feeAddress();
   m_node_fee = node.feeAmount();
-  
+
   if (!m_node_address.empty() && m_node_fee != 0) {
     // Partially borrowed from <zedwallet/Tools.h>
     uint32_t div = static_cast<uint32_t>(pow(10, CryptoNote::parameters::CRYPTONOTE_DISPLAY_DECIMAL_POINT));
@@ -477,15 +477,15 @@ void WalletService::getNodeFee() {
     std::stringstream stream;
     stream << std::setfill('0') << std::setw(CryptoNote::parameters::CRYPTONOTE_DISPLAY_DECIMAL_POINT) << cents;
     std::string amount = std::to_string(coins) + "." + stream.str();
-    
-    logger(Logging::INFO, Logging::RED) << 
+
+    logger(Logging::INFO, Logging::RED) <<
       "You have connected to a node that charges " <<
       "a fee to send transactions." << std::endl;
-    
-    logger(Logging::INFO, Logging::RED) << 
+
+    logger(Logging::INFO, Logging::RED) <<
       "The fee for sending transactions is: " <<
       amount << " per transaction." << std::endl ;
-    
+
     logger(Logging::INFO, Logging::RED) <<
       "If you don't want to pay the node fee, please " <<
       "relaunch this program and specify a different " <<
@@ -985,11 +985,11 @@ std::error_code WalletService::sendTransaction(SendTransaction::Request& request
     std::transform(request.paymentId.begin(), request.paymentId.end(), request.paymentId.begin(), ::toupper);
 
     std::vector<std::string> paymentIDs;
-    
+
     for (auto &transfer : request.transfers)
     {
         std::string addr = transfer.address;
-        
+
         /* It's not a standard address. Is it an integrated address? */
         if (!CryptoNote::validateAddress(addr, currency))
         {
@@ -1248,13 +1248,13 @@ std::error_code WalletService::getUnconfirmedTransactionHashes(const std::vector
 }
 
 /* blockCount = the blocks the wallet has synced. knownBlockCount = the top block the daemon knows of. localDaemonBlockCount = the blocks the daemon has synced. */
-std::error_code WalletService::getStatus(uint32_t& blockCount, uint32_t& knownBlockCount, uint32_t& localDaemonBlockCount, std::string& lastBlockHash, uint32_t& peerCount) {
+std::error_code WalletService::getStatus(uint32_t& blockCount, uint32_t& knownBlockCount, uint64_t& localDaemonBlockCount, std::string& lastBlockHash, uint32_t& peerCount) {
   try {
     System::EventLock lk(readyEvent);
 
-    System::RemoteContext<std::tuple<uint32_t, uint32_t, uint32_t>> remoteContext(dispatcher, [this] () {
+    System::RemoteContext<std::tuple<uint32_t, uint64_t, uint32_t>> remoteContext(dispatcher, [this] () {
       /* Daemon remote height, daemon local height, peer count */
-      return std::make_tuple(node.getKnownBlockCount(), node.getLocalBlockCount(), static_cast<uint32_t>(node.getPeerCount()));
+      return std::make_tuple(node.getKnownBlockCount(), node.getNodeHeight(), static_cast<uint32_t>(node.getPeerCount()));
     });
 
     std::tie(knownBlockCount, localDaemonBlockCount, peerCount) = remoteContext.get();
@@ -1359,7 +1359,7 @@ std::error_code WalletService::createIntegratedAddress(const std::string &addres
 std::error_code WalletService::getFeeInfo(std::string& address, uint32_t& amount) {
   address = m_node_address;
   amount = m_node_fee;
-  
+
   return std::error_code();
 }
 

--- a/src/WalletService/WalletService.h
+++ b/src/WalletService/WalletService.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -82,7 +82,7 @@ public:
   std::error_code deleteDelayedTransaction(const std::string& transactionHash);
   std::error_code sendDelayedTransaction(const std::string& transactionHash);
   std::error_code getUnconfirmedTransactionHashes(const std::vector<std::string>& addresses, std::vector<std::string>& transactionHashes);
-  std::error_code getStatus(uint32_t& blockCount, uint32_t& knownBlockCount, uint32_t& localDaemonBlockCount, std::string& lastBlockHash, uint32_t& peerCount);
+  std::error_code getStatus(uint32_t& blockCount, uint32_t& knownBlockCount, uint64_t& localDaemonBlockCount, std::string& lastBlockHash, uint32_t& peerCount);
   std::error_code sendFusionTransaction(uint64_t threshold, uint32_t anonymity, const std::vector<std::string>& addresses,
     const std::string& destinationAddress, std::string& transactionHash);
   std::error_code estimateFusion(uint64_t threshold, const std::vector<std::string>& addresses, uint32_t& fusionReadyCount, uint32_t& totalOutputCount);


### PR DESCRIPTION
@woodyjon reported that `turtle-service` was reporting that the `localDaemonBlockCount` was returning a value of `1` while the daemon was syncing. That kind of defeated the purpose.

As a result, as part of the `/getinfo` call that NodeRpcProxy performs, we'll just snatch the `height` parameter, store it some place, and return that for `localDaemonBlockCount` instead. This gives us results such as the following when we `getStatus` against `turtle-service`.

```javascript
{
  "jsonrpc": "2.0",
  "result": {
    "blockCount": 1,
    "knownBlockCount": 795776,
    "lastBlockHash": "7fb97df81221dd1366051b2d0bc7f49c66c22ac4431d879c895b06d66ef66f4c",
    "localDaemonBlockCount": 14200,
    "peerCount": 8
  }
}
```

```javascript
{
  "jsonrpc": "2.0",
  "result": {
    "blockCount": 1,
    "knownBlockCount": 795783,
    "lastBlockHash": "7fb97df81221dd1366051b2d0bc7f49c66c22ac4431d879c895b06d66ef66f4c",
    "localDaemonBlockCount": 37417,
    "peerCount": 8
  }
}
```

```javascript
{
  "jsonrpc": "2.0",
  "result": {
    "blockCount": 1,
    "knownBlockCount": 795798,
    "lastBlockHash": "7fb97df81221dd1366051b2d0bc7f49c66c22ac4431d879c895b06d66ef66f4c",
    "localDaemonBlockCount": 147047,
    "peerCount": 8
  }
}
```