### PR TITLE
[BUGFIX] Core.addBlock() to accept transactions with older mixin values for a period of time.

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -594,7 +594,7 @@ std::error_code Core::addBlock(const CachedBlock& cachedBlock, RawBlock&& rawBlo
   uint32_t mixinChangeWindow = blockIndex;
   if (mixinChangeWindow > CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW)
   {
-    mixinChangeWindow = mixinChangeWindow - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW
+    mixinChangeWindow = mixinChangeWindow - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
   }
 
   if (!validateMixin(transactions, blockIndex) && !validateMixin(transactions, mixinChangeWindow))

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -591,7 +591,12 @@ std::error_code Core::addBlock(const CachedBlock& cachedBlock, RawBlock&& rawBlo
   // This allows us to accept blocks with transaction mixins for the mined money unlock window
   // that may be using older mixin rules on the network. This helps to clear out the transaction
   // pool during a network soft fork that requires a mixin lower or upper bound change
-  uint32_t mixinChangeWindow = blockIndex - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
+  uint32_t mixinChangeWindow = blockIndex;
+  if (mixinChangeWindow > CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW)
+  {
+    mixinChangeWindow = mixinChangeWindow - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW
+  }
+
   if (!validateMixin(transactions, blockIndex) && !validateMixin(transactions, mixinChangeWindow))
   {
       return error::TransactionValidationError::INVALID_MIXIN;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -588,7 +588,11 @@ std::error_code Core::addBlock(const CachedBlock& cachedBlock, RawBlock&& rawBlo
     return error::BlockValidationError::DIFFICULTY_OVERHEAD;
   }
 
-  if (!validateMixin(transactions, blockIndex))
+  // This allows us to accept blocks with transaction mixins for the mined money unlock window
+  // that may be using older mixin rules on the network. This helps to clear out the transaction
+  // pool during a network soft fork that requires a mixin lower or upper bound change
+  uint32_t mixinChangeWindow = blockIndex - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
+  if (!validateMixin(transactions, blockIndex) && !validateMixin(transactions, mixinChangeWindow))
   {
       return error::TransactionValidationError::INVALID_MIXIN;
   }


### PR DESCRIPTION
Hopefully addresses #491 