### PR TITLE
[ENHANCEMENT] Add a confirmation when importing a view wallet

### DIFF
--- a/src/zedwallet/CommandDispatcher.cpp
+++ b/src/zedwallet/CommandDispatcher.cpp
@@ -119,39 +119,33 @@ bool handleCommand(const std::string command,
     return true;
 }
 
-std::tuple<bool, std::shared_ptr<WalletInfo>>
-    handleLaunchCommand(CryptoNote::WalletGreen &wallet,
-                        std::string launchCommand, Config &config)
+std::shared_ptr<WalletInfo> handleLaunchCommand(CryptoNote::WalletGreen &wallet,
+                                                std::string launchCommand,
+                                                Config &config)
 {
-    std::shared_ptr<WalletInfo> walletInfo = nullptr;
-
-    bool success = true;
-
     if (launchCommand == "create")
     {
-        walletInfo = generateWallet(wallet);
+        return generateWallet(wallet);
     }
     else if (launchCommand == "open")
     {
-        std::tie(success, walletInfo) = openWallet(wallet, config);
+        return openWallet(wallet, config);
     }
     else if (launchCommand == "seed_restore")
     {
-        walletInfo = mnemonicImportWallet(wallet);
+        return mnemonicImportWallet(wallet);
     }
     else if (launchCommand == "key_restore")
     {
-        walletInfo = importWallet(wallet);
+        return importWallet(wallet);
     }
     else if (launchCommand == "view_wallet")
     {
-        walletInfo = createViewWallet(wallet);
+        return createViewWallet(wallet);
     }
     /* This should never happen */
     else
     {
         throw std::runtime_error("Command was defined but not hooked up!");
     }
-
-    return std::make_tuple(success, walletInfo);
 }

--- a/src/zedwallet/CommandDispatcher.h
+++ b/src/zedwallet/CommandDispatcher.h
@@ -10,6 +10,6 @@ bool handleCommand(const std::string command,
                    std::shared_ptr<WalletInfo> walletInfo,
                    CryptoNote::INode &node);
 
-std::tuple<bool, std::shared_ptr<WalletInfo>>
-    handleLaunchCommand(CryptoNote::WalletGreen &wallet,
-                        std::string launchCommand, Config &config);
+std::shared_ptr<WalletInfo> handleLaunchCommand(CryptoNote::WalletGreen &wallet,
+                                                std::string launchCommand,
+                                                Config &config);

--- a/src/zedwallet/Menu.cpp
+++ b/src/zedwallet/Menu.cpp
@@ -109,16 +109,13 @@ std::tuple<bool, std::shared_ptr<WalletInfo>>
             return std::make_tuple(true, nullptr);
         }
 
-        bool success;
-        std::shared_ptr<WalletInfo> walletInfo;
-
-        /* Handle the users action */
-        std::tie(success, walletInfo) = handleLaunchCommand(
+        /* Handle the user input */
+        std::shared_ptr<WalletInfo> walletInfo = handleLaunchCommand(
             wallet, launchCommand, config
         );
 
         /* Action failed, for example wallet file is corrupted. */
-        if (!success)
+        if (walletInfo == nullptr)
         {
             std::cout << InformationMsg("Returning to selection screen...")
                       << std::endl;

--- a/src/zedwallet/Open.cpp
+++ b/src/zedwallet/Open.cpp
@@ -23,6 +23,19 @@
 
 std::shared_ptr<WalletInfo> createViewWallet(CryptoNote::WalletGreen &wallet)
 {
+    std::cout << WarningMsg("View wallets are only for viewing incoming ")
+              << WarningMsg("transactions, and cannot make transfers.")
+              << std::endl;
+
+    bool create = confirm("Is this OK?");
+
+    std::cout << std::endl;
+
+    if (!create)
+    {
+        return nullptr;
+    }
+    
     Crypto::SecretKey privateViewKey = getPrivateKey("Private View Key: ");
 
     std::string address;
@@ -179,8 +192,8 @@ std::shared_ptr<WalletInfo> generateWallet(CryptoNote::WalletGreen &wallet)
                                         walletAddress, false, wallet);
 }
 
-std::tuple<bool, std::shared_ptr<WalletInfo>>
-    openWallet(CryptoNote::WalletGreen &wallet, Config &config)
+std::shared_ptr<WalletInfo> openWallet(CryptoNote::WalletGreen &wallet,
+                                       Config &config)
 {
     const std::string walletFileName = getExistingWalletFileName(config);
 
@@ -238,11 +251,8 @@ std::tuple<bool, std::shared_ptr<WalletInfo>>
                           << std::endl << std::endl;
             }
 
-            return std::make_tuple(true,
-                std::make_shared<WalletInfo>(
-                    walletFileName, walletPass, walletAddress, viewWallet,
-                    wallet
-                )
+            return std::make_shared<WalletInfo>(
+                walletFileName, walletPass, walletAddress, viewWallet, wallet
             );
 
         }
@@ -276,7 +286,7 @@ std::tuple<bool, std::shared_ptr<WalletInfo>>
 
                     std::cout << WarningMsg(msg.str()) << std::endl;
 
-                    return std::make_tuple(false, nullptr);
+                    return nullptr;
                 }
             }
 
@@ -311,7 +321,7 @@ std::tuple<bool, std::shared_ptr<WalletInfo>>
                           << WarningMsg(".")
                           << std::endl << std::endl;
 
-                return std::make_tuple(false, nullptr);
+                return nullptr;
             }
             else
             {
@@ -319,7 +329,7 @@ std::tuple<bool, std::shared_ptr<WalletInfo>>
                 std::cout << "Please report this error message and what "
                           << "you did to cause it." << std::endl << std::endl;
 
-                return std::make_tuple(false, nullptr);
+                return nullptr;
             }
         }
     }

--- a/src/zedwallet/Open.h
+++ b/src/zedwallet/Open.h
@@ -10,8 +10,10 @@ std::shared_ptr<WalletInfo> importFromKeys(CryptoNote::WalletGreen &wallet,
                                            Crypto::SecretKey privateSpendKey,
                                            Crypto::SecretKey privateViewKey);
 
-std::tuple<bool, std::shared_ptr<WalletInfo>>
-    openWallet(CryptoNote::WalletGreen &wallet, Config &config);
+std::shared_ptr<WalletInfo> openWallet(CryptoNote::WalletGreen &wallet,
+                                       Config &config);
+
+std::shared_ptr<WalletInfo> createViewWallet(CryptoNote::WalletGreen &wallet);
 
 std::shared_ptr<WalletInfo> importWallet(CryptoNote::WalletGreen &wallet);
 


### PR DESCRIPTION
A user managed to import a view wallet and didn't know why they couldn't make transfers, so here's a confirmation to make it explicit.

![image](https://user-images.githubusercontent.com/22151537/45696433-81dd9280-bb5b-11e8-8bd4-6eb252613a87.png)
