### PR TITLE
[ENHANCEMENT] Turtle-Service Brute Force Protection v1

### DIFF
--- a/src/WalletService/PaymentServiceConfiguration.cpp
+++ b/src/WalletService/PaymentServiceConfiguration.cpp
@@ -1,22 +1,13 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #include "PaymentServiceConfiguration.h"
 #include <config/CryptoNoteConfig.h>
+
+#include <CryptoTypes.h>
+#include "crypto/hash.h"
 
 #include <iostream>
 #include <fstream>
@@ -44,7 +35,7 @@ Configuration::Configuration() {
   secretViewKey = "";
   secretSpendKey = "";
   mnemonicSeed = "";
-  rpcPassword = "";
+  rpcPassword = Crypto::Hash();
   legacySecurity = false;
   corsHeader = "";
   scanHeight = 0;
@@ -206,7 +197,9 @@ void Configuration::init(const boost::program_options::variables_map& options) {
     legacySecurity = true;
   }
   else {
-    rpcPassword = options["rpc-password"].as<std::string>();
+    std::string passClearText = options["rpc-password"].as<std::string>();
+    std::vector<uint8_t> rawData(passClearText.begin(), passClearText.end());
+    Crypto::cn_slow_hash_v0(rawData.data(), rawData.size(), rpcPassword);
   }
 
   if (options.count("enable-cors") != 0) {

--- a/src/WalletService/PaymentServiceConfiguration.cpp
+++ b/src/WalletService/PaymentServiceConfiguration.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #include "PaymentServiceConfiguration.h"

--- a/src/WalletService/PaymentServiceConfiguration.h
+++ b/src/WalletService/PaymentServiceConfiguration.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once

--- a/src/WalletService/PaymentServiceConfiguration.h
+++ b/src/WalletService/PaymentServiceConfiguration.h
@@ -1,25 +1,16 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-//
-// This file is part of Bytecoin.
-//
-// Bytecoin is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Bytecoin is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
 
 #pragma once
 
 #include <string>
 #include <stdexcept>
 #include <cstdint>
+
+#include <CryptoTypes.h>
+#include "crypto/hash.h"
 
 #include <boost/program_options.hpp>
 
@@ -38,7 +29,7 @@ struct Configuration {
 
   std::string bindAddress;
   uint16_t bindPort;
-  std::string rpcPassword;
+  Crypto::Hash rpcPassword;
 
   std::string containerFile;
   std::string containerPassword;

--- a/src/WalletService/PaymentServiceJsonRpcServer.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcServer.cpp
@@ -8,6 +8,8 @@
 
 #include <functional>
 
+#include <CryptoTypes.h>
+#include "crypto/hash.h"
 #include "PaymentServiceJsonRpcMessages.h"
 #include "WalletService.h"
 
@@ -67,7 +69,11 @@ void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue&
         return;
       }
       clientPassword = req("password").getString();
-      if (clientPassword != config.rpcPassword) {
+
+      std::vector<uint8_t> rawData(clientPassword.begin(), clientPassword.end());
+      Crypto::Hash hashedPassword = Crypto::Hash();
+      cn_slow_hash_v0(rawData.data(), rawData.size(), hashedPassword);
+      if (hashedPassword != config.rpcPassword) {
         makeInvalidPasswordResponse(resp);
         return;
       }

--- a/src/WalletService/PaymentServiceJsonRpcServer.cpp
+++ b/src/WalletService/PaymentServiceJsonRpcServer.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #include "PaymentServiceJsonRpcServer.h"
@@ -20,7 +20,7 @@
 
 namespace PaymentService {
 
-PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, WalletService& service, Logging::ILogger& loggerGroup, PaymentService::Configuration& config) 
+PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, WalletService& service, Logging::ILogger& loggerGroup, PaymentService::Configuration& config)
   : JsonRpcServer(sys, stopEvent, loggerGroup, config)
   , service(service)
   , logger(loggerGroup, "PaymentServiceJsonRpcServer")
@@ -57,13 +57,13 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
 void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) {
   try {
     prepareJsonResponse(req, resp);
-    
+
     if (!config.legacySecurity) {
       std::string clientPassword;
       if (!req.contains("password")) {
         makeInvalidPasswordResponse(resp);
         return;
-      }   
+      }
       if (!req("password").isString()) {
         makeInvalidPasswordResponse(resp);
         return;


### PR DESCRIPTION
We will no longer store the clear text turtle-service password in plain text in memory, in addition, each authentication attempt against the service RPC is passed through the same slow hash function to attempt to slow down brute-force attacks on the password. As it is right now, it's pretty easy to just loop through passwords and pray. This helps slow that down so hopefully someone notices the attempts.