### PR TITLE
Add gray_peers list to RPC GET_PEERS response

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -846,16 +846,18 @@ struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASHES {
 };
 
 struct COMMAND_RPC_GET_PEERS {
-  //TODO useful to add option to get gray peers ?
+  // TODO: rename peers to white_peers - do at v1 
   typedef EMPTY_STRUCT request;
 
   struct response {
     std::string status;
     std::vector<std::string> peers;
+    std::vector<std::string> gray_peers;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
       KV_MEMBER(peers)
+      KV_MEMBER(gray_peers)
     }
   };
 };

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -614,6 +614,13 @@ bool RpcServer::on_get_peers(const COMMAND_RPC_GET_PEERS::request& req, COMMAND_
     stream << peer.adr;
     res.peers.push_back(stream.str());
   }
+
+  for (const auto& peer : peers_gray) {
+    std::stringstream stream;
+    stream << peer.adr;
+    res.gray_peers.push_back(stream.str());
+  }
+
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }


### PR DESCRIPTION
Adds the gray_peers list to the /getpeers RPC API response.

**Old Response:**
```json
{
	"peers": ["1.1.1.1", "2.2.2.2"],
	"status": "OK"
}
```
**New Response:**
```json
{
	"gray_peers": ["3.3.3.3", "4.4.4.4"],
	"peers": ["1.1.1.1", "2.2.2.2"],
	"status": "OK"
}
```

For compatibility reasons peers has not been renamed to white_peers, but should be something considered in the future.