### PR TITLE
settle on gray > grey for variable naming

### DIFF
--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -865,12 +865,12 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
         //start from white list
         if(!make_expected_connections_count(true, expected_white_connections))
           return false;
-        //and then do grey list
+        //and then do gray list
         if(!make_expected_connections_count(false, m_config.m_net_config.connections_count))
           return false;
       }else
       {
-        //start from grey list
+        //start from gray list
         if(!make_expected_connections_count(false, m_config.m_net_config.connections_count))
           return false;
         //and then do white list

--- a/src/P2p/P2pNode.cpp
+++ b/src/P2p/P2pNode.cpp
@@ -245,10 +245,10 @@ void P2pNode::connectPeers() {
     if (outgoingConnections < expectedWhiteConnections) {
       //start from white list
       makeExpectedConnectionsCount(m_peerlist.getWhite(), expectedWhiteConnections);
-      //and then do grey list
+      //and then do gray list
       makeExpectedConnectionsCount(m_peerlist.getGray(), totalExpectedConnectionsCount);
     } else {
-      //start from grey list
+      //start from gray list
       makeExpectedConnectionsCount(m_peerlist.getGray(), totalExpectedConnectionsCount);
       //and then do white list
       makeExpectedConnectionsCount(m_peerlist.getWhite(), totalExpectedConnectionsCount);

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -269,7 +269,7 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t outgoing_connections_count;
     uint64_t incoming_connections_count;
     uint64_t white_peerlist_size;
-    uint64_t grey_peerlist_size;
+    uint64_t gray_peerlist_size;
     uint32_t last_known_block_index;
     uint32_t network_height;
     std::vector<uint64_t> upgrade_heights;
@@ -292,7 +292,7 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(outgoing_connections_count)
       KV_MEMBER(incoming_connections_count)
       KV_MEMBER(white_peerlist_size)
-      KV_MEMBER(grey_peerlist_size)
+      KV_MEMBER(gray_peerlist_size)
       KV_MEMBER(last_known_block_index)
       KV_MEMBER(network_height)
       KV_MEMBER(upgrade_heights)

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -463,7 +463,7 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.outgoing_connections_count = m_p2p.get_outgoing_connections_count();
   res.incoming_connections_count = total_conn - res.outgoing_connections_count;
   res.white_peerlist_size = m_p2p.getPeerlistManager().get_white_peers_count();
-  res.grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
+  res.gray_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
   res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocol.getObservedHeight()) - 1;
   res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
   res.upgrade_heights = CryptoNote::parameters::FORK_HEIGHTS_SIZE == 0 ? std::vector<uint64_t>() : std::vector<uint64_t>(CryptoNote::parameters::FORK_HEIGHTS, CryptoNote::parameters::FORK_HEIGHTS + CryptoNote::parameters::FORK_HEIGHTS_SIZE);


### PR DESCRIPTION
For standardization and sanity I changed the variable ``grey_peerlist_size`` to ``gray_peerlist_size`` based on least mentions (gray vs grey). All other variables use the variations ``gray`` in their names.