### PR TITLE
[BUGFIX] Daemon would not allow you to specify checkpoints file

### DIFF
--- a/src/Daemon/DaemonConfiguration.h
+++ b/src/Daemon/DaemonConfiguration.h
@@ -118,7 +118,7 @@ namespace {
       ("data-dir", "Specify the <path> to the Blockchain data directory", cxxopts::value<std::string>()->default_value(config.dataDirectory), "<path>")
       ("dump-config", "Prints the current configuration to the screen", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
       ("load-checkpoints", "Specify a file <path> containing a CSV of Blockchain checkpoints for faster sync. A value of 'default' uses the built-in checkpoints.",
-        cxxopts::value<std::string>()->default_value(config.checkPoints)->implicit_value("default"), "<path>")
+        cxxopts::value<std::string>()->default_value(config.checkPoints), "<path>")
       ("log-file", "Specify the <path> to the log file", cxxopts::value<std::string>()->default_value(config.logFile), "<path>")
       ("log-level", "Specify log level", cxxopts::value<int>()->default_value(std::to_string(config.logLevel)), "#")
       ("no-console", "Disable daemon console commands", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
@@ -127,7 +127,7 @@ namespace {
     options.add_options("RPC")
       ("enable-blockexplorer", "Enable the Blockchain Explorer RPC", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
       ("enable-cors", "Adds header 'Access-Control-Allow-Origin' to the RPC responses using the <domain>. Uses the value specified as the domain. Use * for all.",
-        cxxopts::value<std::vector<std::string>>()->implicit_value("*"), "<domain>")
+        cxxopts::value<std::vector<std::string>>(), "<domain>")
       ("fee-address", "Sets the convenience charge <address> for light wallets that use the daemon", cxxopts::value<std::string>(), "<address>")
       ("fee-amount", "Sets the convenience charge amount for light wallets that use the daemon", cxxopts::value<int>()->default_value("0"), "#");
 


### PR DESCRIPTION
implicit_value uses that value unless you do a `=somethingelse` that's not cool. This fixes that so that something like `--load-checkpoints checkpoints.csv` and `--load-checkpoints=checkpoints.csv` works