### PR TITLE
turtle-service: support old flat ini config for backward compatibility

### DIFF
--- a/src/WalletService/ConfigurationManager.cpp
+++ b/src/WalletService/ConfigurationManager.cpp
@@ -39,7 +39,7 @@ bool ConfigurationManager::init(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-      std::cout << std::endl << "There was an error parsing the specified configuration file. Please check the file and try again"
+      std::cout << std::endl << "There was an error parsing the specified configuration file. Please check the file and try again: "
         << std::endl << e.what() << std::endl;
       exit(1);
     }

--- a/src/WalletService/WalletServiceConfiguration.h
+++ b/src/WalletService/WalletServiceConfiguration.h
@@ -293,7 +293,8 @@ namespace PaymentService {
     // comments, first non space starts with # or ;
     static const std::regex cfgComment{R"x(\s*[;#])x"};
     std::smatch item;
-    std::string cfgKey, cfgValue;
+    std::string cfgKey;
+    std::string stdcfgValue;
 
     for (std::string line; std::getline(data, line);)
     {
@@ -306,6 +307,7 @@ namespace PaymentService {
         if (item.size() == 4) {
           cfgKey = item[1].str();
           cfgValue = item[2].str();
+          
           if(cfgKey.compare("daemon-address") == 0)
           {
             config.daemonAddress = cfgValue;
@@ -372,8 +374,8 @@ namespace PaymentService {
       throw std::runtime_error("The --config-file you specified does not exist, please check the filename and try again.");
     }
 
-    try{
-
+    try
+    {
       json j;
       data >> j;
 

--- a/src/WalletService/WalletServiceConfiguration.h
+++ b/src/WalletService/WalletServiceConfiguration.h
@@ -285,6 +285,84 @@ namespace PaymentService {
     }
   };
 
+   inline void handleIniConfig(std::ifstream& data, WalletServiceConfiguration& config){
+    // find key=value pair, respect whitespace before/after "="
+    // g0: full match, g1: match key, g2: match value
+    static const std::regex cfgItem{R"x(\s*(\S[^ \t=]*)\s*=\s*((\s?\S+)+)\s*$)x"};
+    
+    // comments, first non space starts with # or ;
+    static const std::regex cfgComment{R"x(\s*[;#])x"};
+    std::smatch item;
+    std::string cfgKey, cfgValue;
+
+    for (std::string line; std::getline(data, line);)
+    {
+      if (line.empty() || std::regex_match(line, item, cfgComment))
+      {
+        continue;
+      }
+      else if (std::regex_match(line, item, cfgItem))
+      {
+        if (item.size() == 4) {
+          cfgKey = item[1].str();
+          cfgValue = item[2].str();
+          if(cfgKey.compare("daemon-address") == 0)
+          {
+            config.daemonAddress = cfgValue;
+          }
+          else if (cfgKey.compare("daemon-port")  == 0)
+          {
+            config.daemonPort = stoi(cfgValue);
+          }
+          else if (cfgKey.compare("log-file")  == 0)
+          {
+            config.logFile = cfgValue;
+          }
+          else if (cfgKey.compare("log-level")  == 0)
+          {
+            config.logLevel = stoi(cfgValue);
+          }
+          else if (cfgKey.compare("container-file")  == 0)
+          {
+            config.containerFile = cfgValue;
+          }
+          else if (cfgKey.compare("container-password")  == 0)
+          {
+            config.containerPassword = cfgValue;
+          }
+          else if (cfgKey.compare("bind-address")  == 0)
+          {
+            config.bindAddress = cfgValue;
+          }
+          else if (cfgKey.compare("bind-port")  == 0)
+          {
+            config.bindPort = stoi(cfgValue);
+          }
+          else if (cfgKey.compare("enable-cors")  == 0)
+          {
+            config.corsHeader = cfgValue;
+          }
+          else if (cfgKey.compare("rpc-legacy-security")  == 0)
+          {
+            config.legacySecurity = cfgValue.at(0) == '1' ? true : false;
+          }
+          else  if (cfgKey.compare("rpc-password") == 0)
+          {
+            config.rpcPassword = cfgValue;
+          }
+          else if (cfgKey.compare("server-root")  == 0)
+          {
+            config.serverRoot = cfgValue;
+          }
+          else
+          {
+            throw std::runtime_error("One or more options in your config file was invalid!");
+          }
+        }
+      }
+    }
+  };
+
   inline void handleSettings(const std::string configFile, WalletServiceConfiguration& config)
   {
     std::ifstream data(configFile);
@@ -294,67 +372,79 @@ namespace PaymentService {
       throw std::runtime_error("The --config-file you specified does not exist, please check the filename and try again.");
     }
 
-    json j;
-    data >> j;
+    try{
 
-    if (j.find("daemon-address") != j.end())
-    {
-      config.daemonAddress = j["daemon-address"].get<std::string>();
+      json j;
+      data >> j;
+
+      if (j.find("daemon-address") != j.end())
+      {
+        config.daemonAddress = j["daemon-address"].get<std::string>();
+      }
+
+      if (j.find("daemon-port") != j.end())
+      {
+        config.daemonPort = j["daemon-port"].get<int>();
+      }
+
+      if (j.find("log-file") != j.end())
+      {
+        config.logFile = j["log-file"].get<std::string>();
+      }
+
+      if (j.find("log-level") != j.end())
+      {
+        config.logLevel = j["log-level"].get<int>();
+      }
+
+      if (j.find("container-file") != j.end())
+      {
+        config.containerFile = j["container-file"].get<std::string>();
+      }
+
+      if (j.find("container-password") != j.end())
+      {
+        config.containerPassword = j["container-password"].get<std::string>();
+      }
+
+      if (j.find("bind-address") != j.end())
+      {
+        config.bindAddress = j["bind-address"].get<std::string>();
+      }
+
+      if (j.find("bind-port") != j.end())
+      {
+        config.bindPort = j["bind-port"].get<int>();
+      }
+
+      if (j.find("enable-cors") != j.end())
+      {
+        config.corsHeader = j["enable-cors"].get<std::string>();
+      }
+
+      if (j.find("rpc-legacy-security") != j.end())
+      {
+        config.legacySecurity = j["rpc-legacy-security"].get<bool>();
+      }
+
+      if (j.find("rpc-password") != j.end())
+      {
+        config.rpcPassword = j["rpc-password"].get<std::string>();
+      }
+
+      if (j.find("server-root") != j.end())
+      {
+        config.serverRoot = j["server-root"].get<std::string>();
+      }
     }
-
-    if (j.find("daemon-port") != j.end())
+    catch (std::exception& e) 
     {
-      config.daemonPort = j["daemon-port"].get<int>();
-    }
-
-    if (j.find("log-file") != j.end())
-    {
-      config.logFile = j["log-file"].get<std::string>();
-    }
-
-    if (j.find("log-level") != j.end())
-    {
-      config.logLevel = j["log-level"].get<int>();
-    }
-
-    if (j.find("container-file") != j.end())
-    {
-      config.containerFile = j["container-file"].get<std::string>();
-    }
-
-    if (j.find("container-password") != j.end())
-    {
-      config.containerPassword = j["container-password"].get<std::string>();
-    }
-
-    if (j.find("bind-address") != j.end())
-    {
-      config.bindAddress = j["bind-address"].get<std::string>();
-    }
-
-    if (j.find("bind-port") != j.end())
-    {
-      config.bindPort = j["bind-port"].get<int>();
-    }
-
-    if (j.find("enable-cors") != j.end())
-    {
-      config.corsHeader = j["enable-cors"].get<std::string>();
-    }
-
-    if (j.find("rpc-legacy-security") != j.end())
-    {
-      config.legacySecurity = j["rpc-legacy-security"].get<bool>();
-    }
-
-    if (j.find("rpc-password") != j.end())
-    {
-      config.rpcPassword = j["rpc-password"].get<std::string>();
-    }
-
-    if (j.find("server-root") != j.end())
-    {
-      config.serverRoot = j["server-root"].get<std::string>();
+        // when failed reading as json, try reading it as old flat ini
+        // clear eof + fail bits
+        data.clear();
+        // reread from start
+        data.seekg(0, std::ios::beg);
+        handleIniConfig(data, config);
     }
   }
 

--- a/src/WalletService/WalletServiceConfiguration.h
+++ b/src/WalletService/WalletServiceConfiguration.h
@@ -314,7 +314,7 @@ namespace PaymentService {
           }
           else if (cfgKey.compare("daemon-port")  == 0)
           {
-            config.daemonPort = stoi(cfgValue);
+            config.daemonPort = std::stoi(cfgValue);
           }
           else if (cfgKey.compare("log-file")  == 0)
           {
@@ -322,7 +322,7 @@ namespace PaymentService {
           }
           else if (cfgKey.compare("log-level")  == 0)
           {
-            config.logLevel = stoi(cfgValue);
+            config.logLevel = std::stoi(cfgValue);
           }
           else if (cfgKey.compare("container-file")  == 0)
           {
@@ -338,7 +338,7 @@ namespace PaymentService {
           }
           else if (cfgKey.compare("bind-port")  == 0)
           {
-            config.bindPort = stoi(cfgValue);
+            config.bindPort = std::stoi(cfgValue);
           }
           else if (cfgKey.compare("enable-cors")  == 0)
           {

--- a/src/WalletService/WalletServiceConfiguration.h
+++ b/src/WalletService/WalletServiceConfiguration.h
@@ -294,7 +294,7 @@ namespace PaymentService {
     static const std::regex cfgComment{R"x(\s*[;#])x"};
     std::smatch item;
     std::string cfgKey;
-    std::string stdcfgValue;
+    std::string cfgValue;
 
     for (std::string line; std::getline(data, line);)
     {


### PR DESCRIPTION
When reading config file as new json format failed, try to read it as old ini format.

keep `--dump-config` and `--save-config` to only use new json format.

#### Testing turtle-service with ini config (all valid options):
```
; file: valid.conf
; this is a valid ini file comment
; this config only includes valid config key
rpc-password=523d4557fe5f9824ae71eaa026c618f41d2cdfd24688978585739e5f337c80ea
container-file=/home/mywallet.twl
container-password=secr3t=-passwUrtz
enable-cors=*
daemon-address=public.turtlenode.io
daemon-port=11898
# this is also valid comment
log-level=0
```

command: `./turtle-service -c valid.conf --dump-config`

output:
```
{
  "bind-address": "127.0.0.1",
  "bind-port": 8070,
  "container-file": "/home/mywallet.twl",
  "container-password": "secr3t=-passwUrtz",
  "daemon-address": "public.turtlenode.io",
  "daemon-port": 11898,
  "enable-cors": "*",
  "log-file": "service.log",
  "log-level": 0,
  "rpc-legacy-security": false,
  "rpc-password": "523d4557fe5f9824ae71eaa026c618f41d2cdfd24688978585739e5f337c80ea",
  "server-root": ""
}
```

#### Testing turtle-service with ini config (some invalid options):
```
; file: invalid.conf
; this config only includes invalid config key
rpc-password=523d4557fe5f9824ae71eaa026c618f41d2cdfd24688978585739e5f337c80ea
container-file=/home/mywallet.twl
container-password=secr3t=-passwUrtz
enable-cors=*
daemon-address=public.turtlenode.io
daemon-port=11898
# this is also valid comment
log-level=0
this-is-not-good=hahaha
wutz-in-invalid-flag=1
```

command: `./turtle-service -c invalid.conf --dump-config`
Output: 
```
There was an error parsing the specified configuration file. Please check the file and try again: 
One or more options in your config file was invalid!
```

