### PR TITLE
The HTTP Server is a bit too noisy in the logs

### DIFF
--- a/src/Rpc/HttpServer.cpp
+++ b/src/Rpc/HttpServer.cpp
@@ -91,7 +91,7 @@ void HttpServer::acceptLoop() {
 
   } catch (System::InterruptedException&) {
   } catch (std::exception& e) {
-    logger(WARNING) << "Connection error: " << e.what();
+    logger(DEBUGGING) << "Connection error: " << e.what();
   }
 }
 


### PR DESCRIPTION
It's not uncommon for poorly implemented RPC clients to not do things how we expect them to do things. This isn't an error on our part and as such we shouldn't warn it that way.