### PR TITLE
Live node swapping, improving handling unexpected exception

### DIFF
--- a/src/WalletBackend/WalletBackend.h
+++ b/src/WalletBackend/WalletBackend.h
@@ -222,7 +222,11 @@ class WalletBackend
         std::vector<WalletTypes::Transaction> getTransactionsRange(
             const uint64_t startHeight, const uint64_t endHeight) const;
 
+        /* Get the node fee and address ({0, ""} if empty) */
         std::tuple<uint64_t, std::string> getNodeFee() const;
+
+        /* Swap to a different daemon node */
+        WalletError swapNode(std::string daemonHost, uint16_t daemonPort);
         
         /////////////////////////////
         /* Public member variables */

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -698,3 +698,8 @@ uint64_t WalletSynchronizer::getCurrentScanHeight() const
 {
     return m_transactionSynchronizerStatus.getHeight();
 }
+
+void WalletSynchronizer::swapNode(const std::shared_ptr<CryptoNote::NodeRpcProxy> daemon)
+{
+    m_daemon = daemon;
+}

--- a/src/WalletBackend/WalletSynchronizer.h
+++ b/src/WalletBackend/WalletSynchronizer.h
@@ -68,6 +68,8 @@ class WalletSynchronizer
 
         uint64_t getCurrentScanHeight() const;
 
+        void swapNode(const std::shared_ptr<CryptoNote::NodeRpcProxy> daemon);
+
         /////////////////////////////
         /* Public member variables */
         /////////////////////////////

--- a/src/zedwallet++/CommandDispatcher.cpp
+++ b/src/zedwallet++/CommandDispatcher.cpp
@@ -137,6 +137,10 @@ bool handleCommand(
     {
         status(walletBackend);
     }
+    else if (command == "swap_node")
+    {
+        swapNode(walletBackend);
+    }
     /* This should never happen */
     else
     {

--- a/src/zedwallet++/CommandImplementations.cpp
+++ b/src/zedwallet++/CommandImplementations.cpp
@@ -16,6 +16,7 @@
 
 #include <zedwallet++/ColouredMsg.h>
 #include <zedwallet++/Commands.h>
+#include <zedwallet++/GetInput.h>
 #include <zedwallet++/Menu.h>
 #include <zedwallet++/Open.h>
 #include <zedwallet++/Sync.h>
@@ -595,4 +596,15 @@ void advanced(const std::shared_ptr<WalletBackend> walletBackend)
         printCommands(advancedCommands(),
                       basicCommands().size());
     }
+}
+
+void swapNode(const std::shared_ptr<WalletBackend> walletBackend)
+{
+    const auto [host, port] = getDaemonAddress();
+
+    std::cout << InformationMsg("\nSwapping node, this may take some time...\n");
+
+    walletBackend->swapNode(host, port);
+
+    std::cout << SuccessMsg("Node swap complete.\n\n");
 }

--- a/src/zedwallet++/CommandImplementations.h
+++ b/src/zedwallet++/CommandImplementations.h
@@ -53,3 +53,5 @@ void createIntegratedAddress();
 void help(const std::shared_ptr<WalletBackend> walletBackend);
 
 void advanced(const std::shared_ptr<WalletBackend> walletBackend);
+
+void swapNode(const std::shared_ptr<WalletBackend> walletBackend);

--- a/src/zedwallet++/Commands.cpp
+++ b/src/zedwallet++/Commands.cpp
@@ -29,6 +29,7 @@ std::vector<Command> nodeDownCommands()
     {
         Command("try_again", "Try to connect to the node again"),
         Command("continue", "Continue to the wallet interface regardless"),
+        Command("swap_node", "Specify a new daemon address/port to connect to"),
         Command("exit", "Exit the program"),
     };
 }
@@ -62,6 +63,7 @@ std::vector<AdvancedCommand> allCommands()
         AdvancedCommand("save_csv", "Save all wallet transactions to a CSV file", true, true),
         AdvancedCommand("send_all", "Send all your balance to someone", false, true),
         AdvancedCommand("status", "Display sync status and network hashrate", true, true),
+        AdvancedCommand("swap_node", "Specify a new daemon address/port to sync from", true, true),
     };
 }
 

--- a/src/zedwallet++/GetInput.cpp
+++ b/src/zedwallet++/GetInput.cpp
@@ -266,6 +266,39 @@ std::tuple<bool, uint64_t> getAmountToAtomic(
     }
 }
 
+std::tuple<std::string, uint16_t> getDaemonAddress()
+{
+    while (true)
+    {
+        std::cout << InformationMsg("\nEnter the daemon address you want to use.\n"
+                                    "You can omit the port, and it will default to ")
+                  << InformationMsg(CryptoNote::RPC_DEFAULT_PORT)
+                  << ".\n\nHit enter for the default of localhost: ";
+
+        std::string address;
+
+        std::string host = "127.0.0.1";
+
+        uint16_t port = CryptoNote::RPC_DEFAULT_PORT;
+
+        /* Fixes infinite looping when someone does a ctrl + c */
+        if (!std::getline(std::cin, address) || address == "")
+        {
+            return {host, port};
+        }
+
+        ZedUtilities::trim(address);
+
+        if (!ZedUtilities::parseDaemonAddressFromString(host, port, address))
+        {
+            std::cout << WarningMsg("\nInvalid daemon address! Try again.\n");
+            continue;
+        }
+
+        return {host, port};
+    }
+}
+
 /* Template instantations that we are going to use - this allows us to have
    the template implementation in the .cpp file. */
 template

--- a/src/zedwallet++/GetInput.h
+++ b/src/zedwallet++/GetInput.h
@@ -31,3 +31,5 @@ template<typename T>
 std::string getInput(
     const std::vector<T> &availableCommands,
     const std::string prompt);
+
+std::tuple<std::string, uint16_t> getDaemonAddress();

--- a/src/zedwallet++/Menu.cpp
+++ b/src/zedwallet++/Menu.cpp
@@ -128,6 +128,19 @@ bool checkNodeStatus(const std::shared_ptr<WalletBackend> walletBackend)
         {
             return true;
         }
+        /* User wants to try a different node */
+        else if (command == "swap_node")
+        {
+            const auto [host, port] = getDaemonAddress();
+
+            std::cout << InformationMsg("\nSwapping node, this may take some time...\n");
+
+            walletBackend->swapNode(host, port);
+
+            std::cout << SuccessMsg("Node swap complete.\n\n");
+
+            continue;
+        }
     }
 
     return true;

--- a/src/zedwallet++/ParseArguments.h
+++ b/src/zedwallet++/ParseArguments.h
@@ -18,7 +18,7 @@ struct Config
     std::string host;
     
     /* The daemon port */
-    int port = CryptoNote::RPC_DEFAULT_PORT;
+    uint16_t port = CryptoNote::RPC_DEFAULT_PORT;
 
     /* The wallet file path */
     std::string walletFile;

--- a/src/zedwallet++/TransactionMonitor.h
+++ b/src/zedwallet++/TransactionMonitor.h
@@ -10,7 +10,6 @@
 class TransactionMonitor
 {
     public:
-
         TransactionMonitor(
             const std::shared_ptr<WalletBackend> walletBackend) :
             m_walletBackend(walletBackend),

--- a/src/zedwallet++/Utilities.cpp
+++ b/src/zedwallet++/Utilities.cpp
@@ -258,7 +258,7 @@ std::vector<std::string> split(const std::string& str, char delim = ' ')
     return cont;
 }
 
-bool parseDaemonAddressFromString(std::string& host, int port, const std::string& address)
+bool parseDaemonAddressFromString(std::string &host, uint16_t &port, const std::string address)
 {
     std::vector<std::string> parts = split(address, ':');
 

--- a/src/zedwallet++/Utilities.h
+++ b/src/zedwallet++/Utilities.h
@@ -47,7 +47,7 @@ uint64_t getScanHeight();
 
 std::vector<std::string> split(const std::string& str, char delim);
 
-bool parseDaemonAddressFromString(std::string& host, int port, const std::string& address);
+bool parseDaemonAddressFromString(std::string &host, uint16_t &port, const std::string address);
 
 template <typename T, typename Function>
 std::vector<T> filter(const std::vector<T> &input, Function predicate)

--- a/src/zedwallet++/ZedWallet.cpp
+++ b/src/zedwallet++/ZedWallet.cpp
@@ -50,11 +50,46 @@ void shutdown(
     exit(0);
 }
 
+void cleanup(
+    std::thread &txMonitorThread,
+    std::thread &ctrlCWatcher,
+    std::atomic<bool> &stop,
+    std::shared_ptr<TransactionMonitor> txMonitor)
+{
+    /* Stop the transaction monitor */
+    txMonitor->stop();
+
+    /* Signal the ctrlCWatcher to stop */
+    stop = true;
+
+    /* Wait for the transaction monitor to stop */
+    if (txMonitorThread.joinable())
+    {
+        txMonitorThread.join();
+    }
+
+    /* Wait for the ctrlCWatcher to stop */
+    if (ctrlCWatcher.joinable())
+    {
+        ctrlCWatcher.join();
+    }
+}
+
 int main(int argc, char **argv)
 {
     Config config = parseArguments(argc, argv);
 
     std::cout << InformationMsg(CryptoNote::getProjectCLIHeader()) << std::endl;
+
+    /* Declare outside the try/catch, so if an exception is thrown, it doesn't
+       cause the threads to go out of scope, calling std::terminate
+       (since we didn't join them) */
+    std::thread ctrlCWatcher, txMonitorThread;
+
+    std::shared_ptr<TransactionMonitor> txMonitor(nullptr);
+
+    /* Atomic bool to signal if ctrl_c is used */
+    std::atomic<bool> ctrl_c(false), stop(false);
 
     try
     {
@@ -66,11 +101,8 @@ int main(int argc, char **argv)
             return 0;
         }
 
-        /* Atomic bool to signal if ctrl_c is used */
-        std::atomic<bool> ctrl_c(false), stop(false);
-
         /* Launch the thread which watches for the shutdown signal */
-        std::thread ctrlCWatcher(
+        ctrlCWatcher = std::thread(
             shutdown, std::ref(ctrl_c), std::ref(stop), std::ref(walletBackend)
         );
 
@@ -86,32 +118,17 @@ int main(int argc, char **argv)
         }
 
         /* Init the transaction monitor */
-        TransactionMonitor txMonitor(walletBackend);
+        txMonitor = std::make_shared<TransactionMonitor>(walletBackend);
 
         /* Launch the transaction monitor in another thread */
-        std::thread txMonitorThread(&TransactionMonitor::start, &txMonitor);
+        txMonitorThread = std::thread(&TransactionMonitor::start, txMonitor.get());
 
         /* Launch the wallet interface */
-        mainLoop(walletBackend, txMonitor.getMutex());
+        mainLoop(walletBackend, txMonitor->getMutex());
 
-        /* Stop the transaction monitor */
-        txMonitor.stop();
-
-        /* Wait for the transaction monitor to stop */
-        if (txMonitorThread.joinable())
-        {
-            txMonitorThread.join();
-        }
-
-        /* Signal the ctrlCWatcher to stop */
-        stop = true;
-
-        /* Wait for the ctrlCWatcher to stop */
-        if (ctrlCWatcher.joinable())
-        {
-            ctrlCWatcher.join();
-        }
-
+        /* Cleanup the threads */
+        cleanup(txMonitorThread, ctrlCWatcher, stop, txMonitor);
+        
         std::cout << InformationMsg("\nSaving and shutting down...\n");
 
         /* Wallet backend destructor gets called here, which saves */
@@ -126,6 +143,9 @@ int main(int argc, char **argv)
         std::cout << "Hit enter to exit: ";
 
         getchar();
+
+        /* Cleanup the threads */
+        cleanup(txMonitorThread, ctrlCWatcher, stop, txMonitor);
     }
         
     std::cout << "Thanks for stopping by..." << std::endl;


### PR DESCRIPTION
* Lets us swap nodes without restarting the program
* Offers this as a command in zedwallet, and if we can't find the daemon on launch
* Fixes std::terminate() being called when an unexpected exception occurs, due to the std::thread's going out of scope without calling .join()

Example:

![image](https://user-images.githubusercontent.com/22151537/48670088-872e6d80-eb09-11e8-94c4-bd7ce7202a4e.png)