### PR TITLE
Fix attempting to retrieve non-existent blocks

### DIFF
--- a/src/CryptoNoteCore/BlockchainCache.cpp
+++ b/src/CryptoNoteCore/BlockchainCache.cpp
@@ -595,7 +595,7 @@ size_t BlockchainCache::getTransactionCount() const {
 }
 
 std::vector<RawBlock> BlockchainCache::getBlocksByHeight(
-    const uint64_t startHeight, const uint64_t endHeight) const
+    const uint64_t startHeight, uint64_t endHeight) const
 {
     if (endHeight < startIndex)
     {
@@ -611,7 +611,16 @@ std::vector<RawBlock> BlockchainCache::getBlocksByHeight(
 
     uint64_t startOffset = std::max(startHeight, static_cast<uint64_t>(startIndex));
 
-    for (uint64_t i = startOffset; i < endHeight - 1; i++)
+    uint64_t blockCount = storage->getBlockCount();
+
+    /* Make sure we don't overflow the storage (for example, the block might
+       not exist yet) */
+    if (endHeight > startIndex + blockCount)
+    {
+        endHeight = startIndex + blockCount;
+    }
+
+    for (uint64_t i = startOffset; i < endHeight; i++)
     {
         blocks.push_back(storage->getBlockByIndex(i - startIndex));
     }

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1346,7 +1346,7 @@ bool Core::getGlobalIndexesForRange(
                 getBinaryArrayHash(toBinaryArray(block.baseTransaction))
             );
         }
-
+        
         indexes = mainChain->getGlobalIndexes(transactionHashes);
 
         return true;

--- a/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
+++ b/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
@@ -1631,7 +1631,7 @@ std::vector<Crypto::Hash> DatabaseBlockchainCache::getBlockHashesByTimestamps(ui
 }
 
 std::vector<RawBlock> DatabaseBlockchainCache::getBlocksByHeight(
-    const uint64_t startHeight, const uint64_t endHeight) const
+    const uint64_t startHeight, uint64_t endHeight) const
 {
     auto blockBatch = BlockchainReadBatch().requestRawBlocks(startHeight, endHeight);
 

--- a/src/CryptoNoteCore/IBlockchainCache.h
+++ b/src/CryptoNoteCore/IBlockchainCache.h
@@ -186,7 +186,7 @@ public:
 
   virtual std::vector<RawBlock> getBlocksByHeight(
     const uint64_t startHeight,
-    const uint64_t endHeight) const = 0;
+    uint64_t endHeight) const = 0;
 };
 
 }


### PR DESCRIPTION
This was causing std::bad_alloc on getGlobalIndexesByRange()