### PR TITLE
Fix service segfaults caused by initialization order

### DIFF
--- a/src/WalletService/PaymentGateService.cpp
+++ b/src/WalletService/PaymentGateService.cpp
@@ -44,12 +44,12 @@ PaymentGateService::PaymentGateService() :
   stopEvent(nullptr),
   config(),
   service(nullptr),
-  logger(std::make_shared<Logging::LoggerGroup>()),
-  currencyBuilder(logger),
   fileLogger(Logging::TRACE),
-  consoleLogger(Logging::INFO) {
-  consoleLogger.setPattern("%D %T %L ");
-  fileLogger.setPattern("%D %T %L ");
+  consoleLogger(Logging::INFO)
+{
+    currencyBuilder = std::make_shared<CryptoNote::CurrencyBuilder>(logger);
+    consoleLogger.setPattern("%D %T %L ");
+    fileLogger.setPattern("%D %T %L ");
 }
 
 bool PaymentGateService::init(int argc, char** argv) {
@@ -92,7 +92,7 @@ WalletConfiguration PaymentGateService::getWalletConfig() const {
 }
 
 const CryptoNote::Currency PaymentGateService::getCurrency() {
-  return currencyBuilder.currency();
+  return currencyBuilder->currency();
 }
 
 void PaymentGateService::run() {
@@ -129,7 +129,7 @@ void PaymentGateService::stop() {
 
 void PaymentGateService::runRpcProxy(Logging::LoggerRef& log) {
   log(Logging::INFO) << "Starting Payment Gate with remote node";
-  CryptoNote::Currency currency = currencyBuilder.currency();
+  CryptoNote::Currency currency = currencyBuilder->currency();
 
   std::unique_ptr<CryptoNote::INode> node(
     PaymentService::NodeFactory::createNode(

--- a/src/WalletService/PaymentGateService.h
+++ b/src/WalletService/PaymentGateService.h
@@ -41,9 +41,11 @@ private:
   System::Event* stopEvent;
   PaymentService::ConfigurationManager config;
   PaymentService::WalletService* service;
-  CryptoNote::CurrencyBuilder currencyBuilder;
 
-  std::shared_ptr<Logging::LoggerGroup> logger = nullptr;
+  std::shared_ptr<Logging::LoggerGroup> logger = std::make_shared<Logging::LoggerGroup>();
+
+  std::shared_ptr<CryptoNote::CurrencyBuilder> currencyBuilder;
+
   std::ofstream fileStream;
   Logging::StreamLogger fileLogger;
   Logging::ConsoleLogger consoleLogger;


### PR DESCRIPTION
The logger wasn't correctly initialized when we called currencyBuilder with it. I was under the impression that passing a temporary `shared_ptr` was OK, but it seems not.

We could actually fix this by simply initializing in the header, as I have now done, and changed the order. Initialization of class members is based on their declaration in the file, so the logger would then be defined when the currentBuilder was created, in the initialization list.

However, this form of logic is pretty brittle, and can cause the code to start segfaulting again, just by swapping the order of some variables in the header.

So, I made currency builder a shared_ptr, and initialized it in the constructor body, instead.
