### PR TITLE
Fix transfering being semi broken with multiple addresses in one container

### DIFF
--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1437,7 +1437,8 @@ size_t WalletGreen::transfer(const TransactionParameters& transactionParameters)
 
 uint64_t WalletGreen::getBalanceMinusDust(const std::vector<std::string>& addresses)
 {
-    std::vector<WalletOuts> wallets = pickWallets(addresses);
+    std::vector<WalletOuts> wallets = addresses.empty() ? pickWalletsWithMoney() : pickWallets(addresses);
+
     std::vector<OutputToTransfer> unused;
 
     /* We want to get the full balance, so don't stop getting outputs early */

--- a/src/zedwallet/Transfer.cpp
+++ b/src/zedwallet/Transfer.cpp
@@ -288,10 +288,7 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height,
 
     const uint64_t balance = walletInfo->wallet.getActualBalance();
 
-    const uint64_t balanceNoDust = walletInfo->wallet.getBalanceMinusDust
-    (
-        {walletInfo->walletAddress}
-    );
+    const uint64_t balanceNoDust = walletInfo->wallet.getBalanceMinusDust({});
     
     const auto maybeAddress = getAddress("What address do you want to transfer"
                                          " to?: ");


### PR DESCRIPTION
When trying to send a transaction with money in an address other than the primary, it would report that it is unspendable, due to only gathering the balance minus dust from the main address.