### PR TITLE
Fix new (random) addresses not being scanned

### DIFF
--- a/src/WalletBackend/SubWallets.cpp
+++ b/src/WalletBackend/SubWallets.cpp
@@ -116,6 +116,8 @@ std::tuple<WalletError, std::string> SubWallets::addSubWallet()
         Utilities::getCurrentTimestampAdjusted(), isPrimaryAddress
     );
 
+    m_publicSpendKeys.push_back(spendKey.publicKey);
+
     return {SUCCESS, address};
 }
 
@@ -220,6 +222,13 @@ WalletError SubWallets::deleteSubWallet(const std::string address)
     /* Remove or update the transactions */
     deleteAddressTransactions(m_transactions, spendKey);
     deleteAddressTransactions(m_lockedTransactions, spendKey);
+
+    const auto it2 = std::find(m_publicSpendKeys.begin(), m_publicSpendKeys.end(), spendKey);
+
+    if (it2 != m_publicSpendKeys.end())
+    {
+        m_publicSpendKeys.erase(it2);
+    }
 
     return SUCCESS;
 }

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -233,6 +233,8 @@ std::tuple<bool, uint64_t> WalletSynchronizer::processTransactionOutputs(
 
     std::vector<uint64_t> globalIndexes;
 
+    const auto spendKeys = m_subWallets->m_publicSpendKeys;
+
     for (size_t outputIndex = 0; outputIndex < tx.keyOutputs.size(); outputIndex++)
     {
         const uint64_t amount = tx.keyOutputs[outputIndex].amount;
@@ -250,8 +252,6 @@ std::tuple<bool, uint64_t> WalletSynchronizer::processTransactionOutputs(
             /* Not our output */
             continue;
         }
-
-        const auto spendKeys = m_subWallets->m_publicSpendKeys;
 
         /* See if the derived spend key matches any of our spend keys */
         auto ourSpendKey = std::find(spendKeys.begin(), spendKeys.end(),


### PR DESCRIPTION
New randomly created addresses weren't being scanned for transactions because we forgot to add the public spend key.

Also need to delete the public spend key when we remove the wallet (not necessary I don't think, but should be done).

And we can grab the spend keys outside the loop - They'll only change in-between scanning of transactions, not midway through.