### PR TITLE
Slight path tweaks to prevent 'duplicate' swagger paths

### DIFF
--- a/src/WalletApi/ApiDispatcher.cpp
+++ b/src/WalletApi/ApiDispatcher.cpp
@@ -172,12 +172,12 @@ ApiDispatcher::ApiDispatcher(
             .Get("/transactions/\\d+/\\d+", router(&ApiDispatcher::getTransactionsFromHeightToHeight, walletMustBeOpen, viewWalletsAllowed))
 
             /* Get the transactions starting at the given block, for 1000 blocks, belonging to the given address */
-            .Get("/transactions/" + ApiConstants::addressRegex + "/\\d+", router(
+            .Get("/transactions/address/" + ApiConstants::addressRegex + "/\\d+", router(
                 &ApiDispatcher::getTransactionsFromHeightWithAddress, walletMustBeOpen, viewWalletsAllowed)
             )
 
             /* Get the transactions starting at the given block, and ending at the given block, belonging to the given address */
-            .Get("/transactions/" + ApiConstants::addressRegex + "/\\d+/\\d+", router(
+            .Get("/transactions/address/" + ApiConstants::addressRegex + "/\\d+/\\d+", router(
                 &ApiDispatcher::getTransactionsFromHeightToHeightWithAddress, walletMustBeOpen, viewWalletsAllowed)
             )
 
@@ -187,7 +187,7 @@ ApiDispatcher::ApiDispatcher(
             )
 
             /* Get details for the given transaction hash, if known */
-            .Get("/transactions/" + ApiConstants::hashRegex, router(&ApiDispatcher::getTransactionDetails, walletMustBeOpen, viewWalletsAllowed))
+            .Get("/transactions/hash/" + ApiConstants::hashRegex, router(&ApiDispatcher::getTransactionDetails, walletMustBeOpen, viewWalletsAllowed))
 
             /* Get balance for the wallet */
             .Get("/balance", router(&ApiDispatcher::getBalance, walletMustBeOpen, viewWalletsAllowed))

--- a/src/WalletApi/ApiDispatcher.cpp
+++ b/src/WalletApi/ApiDispatcher.cpp
@@ -1146,7 +1146,7 @@ std::tuple<WalletError, uint16_t> ApiDispatcher::getTransactionsFromHeightWithAd
     httplib::Response &res,
     const nlohmann::json &body) const
 {
-    std::string stripped = req.path.substr(std::string("/transactions/").size());
+    std::string stripped = req.path.substr(std::string("/transactions/address/").size());
 
     uint64_t splitPos = stripped.find_first_of("/");
 
@@ -1209,7 +1209,7 @@ std::tuple<WalletError, uint16_t> ApiDispatcher::getTransactionsFromHeightToHeig
     httplib::Response &res,
     const nlohmann::json &body) const
 {
-    std::string stripped = req.path.substr(std::string("/transactions/").size());
+    std::string stripped = req.path.substr(std::string("/transactions/address/").size());
 
     uint64_t splitPos = stripped.find_first_of("/");
 
@@ -1287,7 +1287,7 @@ std::tuple<WalletError, uint16_t> ApiDispatcher::getTransactionDetails(
     httplib::Response &res,
     const nlohmann::json &body) const
 {
-    std::string hashStr = req.path.substr(std::string("/transactions/").size());
+    std::string hashStr = req.path.substr(std::string("/transactions/hash/").size());
 
     Crypto::Hash hash;
 


### PR DESCRIPTION
I was doing swagger query parameters wrong (using `[]` instead of `{}`) to indicate parameters that are part of the URL. Once fixed, swagger couldn't figure out that the paths would be different, for example,
`/transactions/{hash}` vs `/transactions/{address}`.

So, just added a small amount to the path to fix any conflicts.

Swagger updates: https://github.com/zpalmtree/wallet-api-docs/commit/2d90804182c08b955e2f4bab3ff3e0457ead1632

Updated site: https://www.futuregadget.xyz/api-docs/