### PR TITLE
NOTIFY_MISSING_TXS failure is expected

### DIFF
--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -813,7 +813,7 @@ int CryptoNoteProtocolHandler::handle_notify_missing_txs(int command, NOTIFY_MIS
   std::vector<Crypto::Hash> missedHashes;
   m_core.getTransactions(arg.missing_txs, txs, missedHashes);
   if (!missedHashes.empty()) {
-    logger(Logging::ERROR) << "Failed to Handle NOTIFY_MISSING_TXS, Unable to retrieve requested transactions, Dropping Connection";
+    logger(Logging::DEBUGGING) << "Failed to Handle NOTIFY_MISSING_TXS, Unable to retrieve requested transactions, Dropping Connection";
     context.m_state = CryptoNoteConnectionContext::state_shutdown;
     return 1;
   }


### PR DESCRIPTION
With lite blocks, it's expected for this to fail, if a peer doesn't have the transactions yet.