### PR TITLE
Reuse daemon connections in miner and zedwallet-beta

### DIFF
--- a/external/cpp-httplib/httplib.h
+++ b/external/cpp-httplib/httplib.h
@@ -5,6 +5,17 @@
 //  MIT License
 //
 
+/* send() on a closed socket will crash our program. MSG_NOSIGNAL disables this.
+   However, this is not available on windows (it doesn't crash our program),
+   so we can set it to 0. If it's not on osx, we can use SO_NOSIGPIPE instead */
+#ifndef MSG_NOSIGNAL
+    #ifdef SO_NOSIGPIPE
+        #define MSG_NOSIGNAL SO_NOSIGPIPE
+    #else
+        #define MSG_NOSIGNAL 0
+    #endif
+#endif
+
 #ifndef CPPHTTPLIB_HTTPLIB_H
 #define CPPHTTPLIB_HTTPLIB_H
 

--- a/external/cpp-httplib/httplib.h
+++ b/external/cpp-httplib/httplib.h
@@ -5,17 +5,6 @@
 //  MIT License
 //
 
-/* send() on a closed socket will crash our program. MSG_NOSIGNAL disables this.
-   However, this is not available on windows (it doesn't crash our program),
-   so we can set it to 0. If it's not on osx, we can use SO_NOSIGPIPE instead */
-#ifndef MSG_NOSIGNAL
-    #ifdef SO_NOSIGPIPE
-        #define MSG_NOSIGNAL SO_NOSIGPIPE
-    #else
-        #define MSG_NOSIGNAL 0
-    #endif
-#endif
-
 #ifndef CPPHTTPLIB_HTTPLIB_H
 #define CPPHTTPLIB_HTTPLIB_H
 
@@ -84,6 +73,17 @@ typedef int socket_t;
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 #include <zlib.h>
+#endif
+
+/* send() on a closed socket will crash our program. MSG_NOSIGNAL disables this.
+   However, this is not available on windows (it doesn't crash our program),
+   so we can set it to 0. If it's not on osx, we can use SO_NOSIGPIPE instead */
+#ifndef MSG_NOSIGNAL
+    #ifdef SO_NOSIGPIPE
+        #define MSG_NOSIGNAL SO_NOSIGPIPE
+    #else
+        #define MSG_NOSIGNAL 0
+    #endif
 #endif
 
 /*

--- a/src/Common/StringTools.cpp
+++ b/src/Common/StringTools.cpp
@@ -264,4 +264,25 @@ std::string timeIntervalToString(uint64_t intervalInSeconds) {
   return ss.str();
 }
 
+/* Trims any whitespace from left and right */
+void trim(std::string &str)
+{
+    rightTrim(str);
+    leftTrim(str);
+}
+
+void leftTrim(std::string &str)
+{
+    std::string whitespace = " \t\n\r\f\v";
+
+    str.erase(0, str.find_first_not_of(whitespace));
+}
+
+void rightTrim(std::string &str)
+{
+    std::string whitespace = " \t\n\r\f\v";
+
+    str.erase(str.find_last_not_of(whitespace) + 1);
+}
+
 }

--- a/src/Common/StringTools.h
+++ b/src/Common/StringTools.h
@@ -113,4 +113,10 @@ bool parseIpAddressAndPort(uint32_t& ip, uint32_t& port, const std::string& addr
 
 std::string timeIntervalToString(uint64_t intervalInSeconds);
 
+void trim(std::string &str);
+
+void leftTrim(std::string &str);
+
+void rightTrim(std::string &str);
+
 }

--- a/src/HTTP/HttpResponse.cpp
+++ b/src/HTTP/HttpResponse.cpp
@@ -56,6 +56,7 @@ namespace CryptoNote {
 HttpResponse::HttpResponse() {
   status = STATUS_200;
   headers["Server"] = "CryptoNote-based HTTP server";
+  headers["Connection"] = "keep-alive";
 }
 
 void HttpResponse::setStatus(HTTP_STATUS s) {

--- a/src/Miner/BlockchainMonitor.h
+++ b/src/Miner/BlockchainMonitor.h
@@ -9,6 +9,8 @@
 
 #include "httplib.h"
 
+#include <optional>
+
 #include <System/ContextGroup.h>
 #include <System/Dispatcher.h>
 #include <System/Event.h>

--- a/src/Miner/BlockchainMonitor.h
+++ b/src/Miner/BlockchainMonitor.h
@@ -7,6 +7,8 @@
 
 #include "CryptoTypes.h"
 
+#include "httplib.h"
+
 #include <System/ContextGroup.h>
 #include <System/Dispatcher.h>
 #include <System/Event.h>
@@ -14,19 +16,21 @@
 class BlockchainMonitor
 {
     public:
-        BlockchainMonitor(System::Dispatcher& dispatcher, const std::string& daemonHost, uint16_t daemonPort, size_t pollingInterval);
+        BlockchainMonitor(
+            System::Dispatcher& dispatcher,
+            const size_t pollingInterval,
+            const std::shared_ptr<httplib::Client> httpClient);
 
         void waitBlockchainUpdate();
         void stop();
 
     private:
         System::Dispatcher& m_dispatcher;
-        std::string m_daemonHost;
-        uint16_t m_daemonPort;
         size_t m_pollingInterval;
         bool m_stopped;
-        System::Event m_httpEvent;
         System::ContextGroup m_sleepingContext;
 
-        Crypto::Hash requestLastBlockHash();
+        std::optional<Crypto::Hash> requestLastBlockHash();
+
+        std::shared_ptr<httplib::Client> m_httpClient = nullptr;
 };

--- a/src/Miner/MinerManager.h
+++ b/src/Miner/MinerManager.h
@@ -27,25 +27,28 @@ namespace Miner {
 class MinerManager
 {
     public:
-        MinerManager(System::Dispatcher& dispatcher, const CryptoNote::MiningConfig& config);
+        MinerManager(
+            System::Dispatcher& dispatcher,
+            const CryptoNote::MiningConfig& config,
+            const std::shared_ptr<httplib::Client> httpClient);
 
         void start();
 
     private:
-        System::Dispatcher& m_dispatcher;
         System::ContextGroup m_contextGroup;
         CryptoNote::MiningConfig m_config;
         CryptoNote::Miner m_miner;
         BlockchainMonitor m_blockchainMonitor;
 
         System::Event m_eventOccurred;
-        System::Event m_httpEvent;
         std::queue<MinerEvent> m_events;
         bool isRunning;
 
         CryptoNote::BlockTemplate m_minedBlock;
 
         uint64_t m_lastBlockTimestamp;
+
+        std::shared_ptr<httplib::Client> m_httpClient = nullptr;
 
         void eventLoop();
         MinerEvent waitEvent();
@@ -58,8 +61,8 @@ class MinerManager
         void startBlockchainMonitoring();
         void stopBlockchainMonitoring();
 
-        bool submitBlock(const CryptoNote::BlockTemplate& minedBlock, const std::string& daemonHost, uint16_t daemonPort);
-        CryptoNote::BlockMiningParameters requestMiningParameters(System::Dispatcher& dispatcher, const std::string& daemonHost, uint16_t daemonPort, const std::string& miningAddress);
+        bool submitBlock(const CryptoNote::BlockTemplate& minedBlock);
+        CryptoNote::BlockMiningParameters requestMiningParameters();
 
         void adjustBlockTemplate(CryptoNote::BlockTemplate& blockTemplate) const;
 };

--- a/src/Miner/MiningConfig.cpp
+++ b/src/Miner/MiningConfig.cpp
@@ -144,6 +144,7 @@ void MiningConfig::parse(int argc, char** argv)
 
         std::cout << InformationMsg("What address do you want to mine to?: ");
         std::getline(std::cin, miningAddress);
+        Common::trim(miningAddress);
 
         error = validateAddresses({miningAddress}, integratedAddressesAllowed);
     }

--- a/src/Miner/main.cpp
+++ b/src/Miner/main.cpp
@@ -17,7 +17,12 @@ int main(int argc, char **argv)
         try
         {
             System::Dispatcher dispatcher;
-            Miner::MinerManager app(dispatcher, config);
+
+            auto httpClient = std::make_shared<httplib::Client>(
+                config.daemonHost.c_str(), config.daemonPort, 10 /* 10 second timeout */
+            );
+
+            Miner::MinerManager app(dispatcher, config, httpClient);
 
             app.start();
         }

--- a/src/Rpc/HttpClient.cpp
+++ b/src/Rpc/HttpClient.cpp
@@ -35,6 +35,8 @@ HttpClient::~HttpClient() {
 }
 
 void HttpClient::request(const HttpRequest &req, HttpResponse &res) {
+  std::scoped_lock lock(m_mutex);
+
   if (!m_connected) {
     connect();
   }

--- a/src/Rpc/HttpClient.h
+++ b/src/Rpc/HttpClient.h
@@ -53,6 +53,9 @@ private:
   System::Dispatcher& m_dispatcher;
   System::TcpConnection m_connection;
   std::unique_ptr<System::TcpStreambuf> m_streamBuf;
+  
+  /* Don't send two requests at once */
+  std::mutex m_mutex;
 };
 
 template <typename Request, typename Response>

--- a/src/WalletBackend/SynchronizationStatus.cpp
+++ b/src/WalletBackend/SynchronizationStatus.cpp
@@ -2,12 +2,9 @@
 // 
 // Please see the included LICENSE file for more information.
 
-
 ////////////////////////////////////////////////
 #include <WalletBackend/SynchronizationStatus.h>
 ////////////////////////////////////////////////
-
-#include <crypto/crypto.h>
 
 #include <WalletBackend/Constants.h>
 
@@ -30,7 +27,7 @@ void SynchronizationStatus::storeBlockHash(
         /* Height should be one more than previous height */
         if (height != m_lastKnownBlockHeight + 1)
         {
-            throw std::runtime_error("Blocks were missed in syncing process! Terminating.");
+            throw std::runtime_error("Blocks were missed in syncing process! Possibly malicious daemon. Terminating.");
         }
     }
 

--- a/src/zedwallet++/AddressBook.cpp
+++ b/src/zedwallet++/AddressBook.cpp
@@ -30,7 +30,7 @@ const std::string getAddressBookName(const std::vector<AddressBookEntry> address
 
         std::getline(std::cin, friendlyName);
 
-        ZedUtilities::trim(friendlyName);
+        Common::trim(friendlyName);
 
         const auto it = std::find(addressBook.begin(), addressBook.end(),
                                   AddressBookEntry(friendlyName));
@@ -121,7 +121,7 @@ const std::tuple<bool, AddressBookEntry> getAddressBookEntry(
 
         std::getline(std::cin, friendlyName);
 
-        ZedUtilities::trim(friendlyName);
+        Common::trim(friendlyName);
 
         /* \n == no-op */
         if (friendlyName == "")
@@ -258,7 +258,7 @@ void deleteFromAddressBook()
 
         std::getline(std::cin, friendlyName);
 
-        ZedUtilities::trim(friendlyName);
+        Common::trim(friendlyName);
 
         if (friendlyName == "cancel")
         {

--- a/src/zedwallet++/CommandImplementations.cpp
+++ b/src/zedwallet++/CommandImplementations.cpp
@@ -519,7 +519,7 @@ void createIntegratedAddress()
 
         std::getline(std::cin, address);
 
-        ZedUtilities::trim(address);
+        Common::trim(address);
 
         const bool integratedAddressesAllowed = false;
 
@@ -540,7 +540,7 @@ void createIntegratedAddress()
 
         std::getline(std::cin, paymentID);
 
-        ZedUtilities::trim(paymentID);
+        Common::trim(paymentID);
 
         /* Validate the payment ID */
         if (WalletError error = validatePaymentID(paymentID); error != SUCCESS)

--- a/src/zedwallet++/GetInput.cpp
+++ b/src/zedwallet++/GetInput.cpp
@@ -89,7 +89,7 @@ std::string getInput(
     }
 	
     /* Remove any whitespace */
-    ZedUtilities::trim(command);
+    Common::trim(command);
 
     if (command != "")
     {
@@ -116,7 +116,7 @@ std::string getAddress(
             return "cancel";
         }
 
-        ZedUtilities::trim(address);
+        Common::trim(address);
 
         /* \n == no-op */
         if (address == "")
@@ -160,7 +160,7 @@ std::string getPaymentID(
             return "cancel";
         }
 
-        ZedUtilities::trim(paymentID);
+        Common::trim(paymentID);
 
         if (paymentID == "cancel" && cancelAllowed)
         {
@@ -207,7 +207,7 @@ std::tuple<bool, uint64_t> getAmountToAtomic(
             continue;
         }
 
-        ZedUtilities::trim(amountString);
+        Common::trim(amountString);
 
         /* If the user entered thousand separators, remove them */
         ZedUtilities::removeCharFromString(amountString, ',');
@@ -289,7 +289,7 @@ std::tuple<std::string, uint16_t> getDaemonAddress()
             return {host, port};
         }
 
-        ZedUtilities::trim(address);
+        Common::trim(address);
 
         if (!ZedUtilities::parseDaemonAddressFromString(host, port, address))
         {

--- a/src/zedwallet++/Open.cpp
+++ b/src/zedwallet++/Open.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<WalletBackend> importViewWallet(const Config &config)
 
         std::getline(std::cin, address);
 
-        ZedUtilities::trim(address);
+        Common::trim(address);
 
         const bool integratedAddressesAllowed = false;
 
@@ -148,7 +148,7 @@ std::shared_ptr<WalletBackend> importWalletFromSeed(const Config &config)
 
         std::getline(std::cin, mnemonicSeed);
 
-        ZedUtilities::trim(mnemonicSeed);
+        Common::trim(mnemonicSeed);
         
         /* Just to check if it's valid */
         auto [error, privateSpendKey] = Mnemonics::MnemonicToPrivateKey(mnemonicSeed);
@@ -301,7 +301,7 @@ Crypto::SecretKey getPrivateKey(const std::string outputMsg)
 
         std::getline(std::cin, privateKeyString);
 
-        ZedUtilities::trim(privateKeyString);
+        Common::trim(privateKeyString);
 
         if (privateKeyString.length() != privateKeyLen)
         {


### PR DESCRIPTION
Easy way to verify that the miner/zedwallet-beta are only using one connection to communicate with the daemon:

```
lsof -i -a -p `pidof miner` -r1
```

If you turn on log level 4 in the daemon, you can also see when a new connection is created. This should occur only once.

This also changes the miner to use cpp-httplib.