### PR TITLE
Assume 0 content length if not specified

### DIFF
--- a/external/cpp-httplib/httplib.h
+++ b/external/cpp-httplib/httplib.h
@@ -919,23 +919,24 @@ inline bool read_content_chunked(Stream& strm, std::string& out)
 template <typename T>
 bool read_content(Stream& strm, T& x, Progress progress = Progress())
 {
-    if (has_header(x.headers, "Content-Length")) {
-        auto len = get_header_value_int(x.headers, "Content-Length", 0);
-        if (len == 0) {
-            const auto& encoding = get_header_value(x.headers, "Transfer-Encoding", "");
-            if (!strcasecmp(encoding, "chunked")) {
-                return read_content_chunked(strm, x.body);
-            }
-        }
-        return read_content_with_length(strm, x.body, len, progress);
-    } else {
+    uint64_t bodyLen = 0;
+
+    if (has_header(x.headers, "Content-Length"))
+    {
+        bodyLen = get_header_value_int(x.headers, "Content-Length", 0);
+    }
+
+    if (bodyLen == 0)
+    {
         const auto& encoding = get_header_value(x.headers, "Transfer-Encoding", "");
-        if (!strcasecmp(encoding, "chunked")) {
+
+        if (!strcasecmp(encoding, "chunked"))
+        {
             return read_content_chunked(strm, x.body);
         }
-        return read_content_without_length(strm, x.body);
     }
-    return true;
+
+    return read_content_with_length(strm, x.body, bodyLen, progress);
 }
 
 template <typename T>


### PR DESCRIPTION
Fixes POST without a body timing out and returning a 400 status code