### PR TITLE
Activating ccache in build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: cpp
-
+cache: ccache
 matrix:
   include:
 
@@ -100,6 +100,10 @@ install:
 # Need a newer version of llvm to link against to get std::filesystem / std::experimental::filesystem 
 - if [[ "${LABEL:0:3}" == "osx" ]]; then brew install llvm || brew upgrade llvm ; fi
 
+# Neeed to install ccache
+- if [[ "${LABEL:0:3}" == "osx" ]]; then brew install ccache ; fi
+- if [[ "${LABEL:0:3}" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH" ; fi
+
 # Install the correct gcc version
 - if [[ "$LABEL" == "osx-g++-8" ]]; then brew install gcc@8 ; fi
 - if [[ "$LABEL" == "osx-g++-7" ]]; then brew install gcc@7 ; fi
@@ -124,7 +128,8 @@ install:
 script:
 - eval $MATRIX_EVAL
 - mkdir build && cd build
-- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. ${CUSTOM_TOOLCHAIN} ${CUSTOM_BOOST_ROOT} && make -j2
+- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. ${CUSTOM_TOOLCHAIN} ${CUSTOM_BOOST_ROOT}
+- make -j2
 
 before_deploy:
 - if [[ "${TRAVIS_TAG}" == "" ]]; then export TRAVIS_TAG=${TRAVIS_COMMIT} ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 # We need 3.8 for set(CMAKE_CXX_STANDARD 17)
 cmake_minimum_required(VERSION 3.8)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "Found ccache package... Activating...")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project(TurtleCoin)
 
 # Required for finding Threads on ARM
@@ -139,7 +145,7 @@ if(NOT MSVC)
   ## These options generate all those nice warnings we see while building
   set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wvla -Wwrite-strings  -Wno-error=extra -Wno-error=unused-function -Wno-error=sign-compare -Wno-error=strict-aliasing -Wno-error=type-limits -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized -Wno-error=unused-result")
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    set(WARNINGS "${WARNINGS} -Wno-error=mismatched-tags -Wno-error=null-conversion -Wno-overloaded-shift-op-parentheses -Wno-error=shift-count-overflow -Wno-error=tautological-constant-out-of-range-compare -Wno-error=unused-private-field -Wno-error=unneeded-internal-declaration -Wno-error=unused-function -Wno-error=missing-braces")
+    set(WARNINGS "${WARNINGS} -Wno-error=mismatched-tags -Wno-error=null-conversion -Wno-overloaded-shift-op-parentheses -Wno-error=shift-count-overflow -Wno-error=tautological-constant-out-of-range-compare -Wno-error=unused-private-field -Wno-error=unneeded-internal-declaration -Wno-error=unused-function -Wno-error=missing-braces -Wno-error=unused-command-line-argument")
   else()
     set(WARNINGS "${WARNINGS} -Wlogical-op -Wno-error=maybe-uninitialized -Wno-error=clobbered -Wno-error=unused-but-set-variable")
   endif()

--- a/external/cryptopp/CMakeLists.txt
+++ b/external/cryptopp/CMakeLists.txt
@@ -5,6 +5,12 @@
 #   and a number of developer boards used for testing. To test your
 #   changes, please set up a Ubuntu 14.05 LTS system.
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "Found ccache package... Activating...")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 if(NOT DEFINED cryptocpp_DISPLAY_CMAKE_SUPPORT_WARNING)
   set(cryptocpp_DISPLAY_CMAKE_SUPPORT_WARNING 1)
 endif()

--- a/external/miniupnpc/CMakeLists.txt
+++ b/external/miniupnpc/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required (VERSION 2.6)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "Found ccache package... Activating...")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project (miniupnpc C)
 set (MINIUPNPC_VERSION 1.9)
 set (MINIUPNPC_API_VERSION 10)

--- a/external/rocksdb/CMakeLists.txt
+++ b/external/rocksdb/CMakeLists.txt
@@ -33,6 +33,13 @@
 # 4. make -j
 
 cmake_minimum_required(VERSION 2.8.12)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "Found ccache package... Activating...")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project(rocksdb)
 enable_language(CXX)
 enable_language(C)


### PR DESCRIPTION
This activates [ccache](https://ccache.samba.org/manual/latest.html) which is a compiler cache system that allows you to cache compiled code on the system. It further adds it to the Travis-CI cache system so that the cache is pulled in on each build. The `cmake` still runs from scratch so if any files are added/removed, they will still be compiled as normal. Only files that remain unchanged will result in a cache hit (and thus go faster).

As a result, the Travis CI build times are significantly reduced once the cache is populated.

**Note:** the initial merge of this PR will result in the ccache being seeded (initial build) and subsequent PRs based on a branch or merges into the branch with the ccache intact will result in **much** faster CI build times.

Proof:

<img width="1310" alt="capture" src="https://user-images.githubusercontent.com/20562132/50576261-f6bb9c00-0ddb-11e9-8db2-13d2a2d20623.PNG">

https://travis-ci.org/brandonlehmann/turtlecoin/builds/474161287

**The Catch:** [Cache archives are currently set to expire after 28 days for open source projects and 45 days for private projects. This means a specific cache archive will be deleted if it wasn’t changed after its expiration delay.](https://docs.travis-ci.com/user/caching/#caches-expiration) I don't think this will be a problem for us 😄 