### PR TITLE
Remove artifact from when we used a boost httplib

### DIFF
--- a/src/WalletApi/WalletApi.cpp
+++ b/src/WalletApi/WalletApi.cpp
@@ -67,13 +67,6 @@ int main(int argc, char **argv)
                   << "\nPlease report this error, and what you were doing to "
                      "cause it.\n";
     }
-    catch (const boost::exception &e)
-    {
-        std::cout << "Unexpected error: "
-                  << dynamic_cast<std::exception const&>(e).what()
-                  << "\nPlease report this error, and what you were doing to "
-                     "cause it.\n";
-    }
 
     std::cout << ("\nSaving and shutting down...\n");
 


### PR DESCRIPTION
When we were using cpprestsdk it sometimes threw boost errors.