### PR TITLE
Rename PAGE_SIZE parameter

### DIFF
--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -581,22 +581,22 @@ BOOL SetLockPagesPrivilege(HANDLE hProcess, BOOL bEnable)
  * the allocated buffer.
  */
 
-void slow_hash_allocate_state(uint32_t PAGE_SIZE)
+void slow_hash_allocate_state(uint32_t page_size)
 {
     if(hp_state != NULL)
         return;
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
     SetLockPagesPrivilege(GetCurrentProcess(), TRUE);
-    hp_state = (uint8_t *) VirtualAlloc(hp_state, PAGE_SIZE, MEM_LARGE_PAGES |
+    hp_state = (uint8_t *) VirtualAlloc(hp_state, page_size, MEM_LARGE_PAGES |
                                         MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
   defined(__DragonFly__) || defined(__NetBSD__)
-    hp_state = mmap(0, PAGE_SIZE, PROT_READ | PROT_WRITE,
+    hp_state = mmap(0, page_size, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANON, 0, 0);
 #else
-    hp_state = mmap(0, PAGE_SIZE, PROT_READ | PROT_WRITE,
+    hp_state = mmap(0, page_size, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, 0, 0);
 #endif
     if(hp_state == MAP_FAILED)
@@ -606,7 +606,7 @@ void slow_hash_allocate_state(uint32_t PAGE_SIZE)
     if(hp_state == NULL)
     {
         hp_allocated = 0;
-        hp_state = (uint8_t *) malloc(PAGE_SIZE);
+        hp_state = (uint8_t *) malloc(page_size);
     }
 }
 
@@ -614,7 +614,7 @@ void slow_hash_allocate_state(uint32_t PAGE_SIZE)
  *@brief frees the state allocated by slow_hash_allocate_state
  */
 
-void slow_hash_free_state(uint32_t PAGE_SIZE)
+void slow_hash_free_state(uint32_t page_size)
 {
     if(hp_state == NULL)
         return;
@@ -626,7 +626,7 @@ void slow_hash_free_state(uint32_t PAGE_SIZE)
 #if defined(_MSC_VER) || defined(__MINGW32__)
         VirtualFree(hp_state, 0, MEM_RELEASE);
 #else
-        munmap(hp_state, PAGE_SIZE);
+        munmap(hp_state, page_size);
 #endif
     }
 
@@ -664,9 +664,9 @@ void slow_hash_free_state(uint32_t PAGE_SIZE)
  * @param length the length in bytes of the data
  * @param hash a pointer to a buffer in which the final 256 bit hash will be stored
  */
-void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t PAGE_SIZE, uint32_t scratchpad, uint32_t iterations)
+void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t page_size, uint32_t scratchpad, uint32_t iterations)
 {
-  uint32_t TOTALBLOCKS = (PAGE_SIZE / AES_BLOCK_SIZE);
+  uint32_t TOTALBLOCKS = (page_size / AES_BLOCK_SIZE);
   uint32_t init_rounds = (scratchpad / INIT_SIZE_BYTE);
   uint32_t aes_rounds = (iterations / 2);
   size_t lightFlag = (light ? 2: 1);
@@ -691,7 +691,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
       hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein
   };
 
-  slow_hash_allocate_state(PAGE_SIZE);
+  slow_hash_allocate_state(page_size);
 
   /* CryptoNight Step 1:  Use Keccak1600 to initialize the 'state' (and 'text') buffers from the data. */
   if (prehashed) {
@@ -801,7 +801,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
   memcpy(state.init, text, INIT_SIZE_BYTE);
   hash_permutation(&state.hs);
   extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
-  slow_hash_free_state(PAGE_SIZE);
+  slow_hash_free_state(page_size);
 }
 
 #elif !defined NO_AES && (defined(__arm__) || defined(__aarch64__))
@@ -1035,9 +1035,9 @@ STATIC INLINE void aligned_free(void *ptr)
 }
 #endif /* FORCE_USE_HEAP */
 
-void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t PAGE_SIZE, uint32_t scratchpad, uint32_t iterations)
+void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t page_size, uint32_t scratchpad, uint32_t iterations)
 {
-  uint32_t TOTALBLOCKS = (PAGE_SIZE / AES_BLOCK_SIZE);
+  uint32_t TOTALBLOCKS = (page_size / AES_BLOCK_SIZE);
   uint32_t init_rounds = (scratchpad / INIT_SIZE_BYTE);
   uint32_t aes_rounds = (iterations / 2);
   size_t lightFlag = (light ? 2: 1);
@@ -1045,9 +1045,9 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
   RDATA_ALIGN16 uint8_t expandedKey[240];
 
 #ifndef FORCE_USE_HEAP
-  RDATA_ALIGN16 uint8_t hp_state[PAGE_SIZE];
+  RDATA_ALIGN16 uint8_t hp_state[page_size];
 #else
-  uint8_t *hp_state = (uint8_t *)aligned_malloc(PAGE_SIZE,16);
+  uint8_t *hp_state = (uint8_t *)aligned_malloc(page_size,16);
 #endif
 
   uint8_t text[INIT_SIZE_BYTE];
@@ -1255,7 +1255,7 @@ STATIC INLINE void xor_blocks(uint8_t* a, const uint8_t* b)
   U64(a)[1] ^= U64(b)[1];
 }
 
-void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t PAGE_SIZE, uint32_t scratchpad, uint32_t iterations)
+void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t page_size, uint32_t scratchpad, uint32_t iterations)
 {
   uint32_t init_rounds = (scratchpad / INIT_SIZE_BYTE);
   uint32_t aes_rounds = (iterations / 2);
@@ -1281,9 +1281,9 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
   };
 
 #ifndef FORCE_USE_HEAP
-  uint8_t long_state[PAGE_SIZE];
+  uint8_t long_state[page_size];
 #else
-  uint8_t *long_state = (uint8_t *)malloc(PAGE_SIZE);
+  uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 
   if (prehashed) {
@@ -1315,7 +1315,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 
   for(i = 0; i < aes_rounds; i++)
   {
-    #define MASK(div) ((uint32_t)(((PAGE_SIZE / AES_BLOCK_SIZE) / (div) - 1) << 4))
+    #define MASK(div) ((uint32_t)(((page_size / AES_BLOCK_SIZE) / (div) - 1) << 4))
     #define state_index(x,div) ((*(uint32_t *) x) & MASK(div))
 
     // Iteration 1
@@ -1460,16 +1460,16 @@ union cn_slow_hash_state {
 };
 #pragma pack(pop)
 
-void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t PAGE_SIZE, uint32_t scratchpad, uint32_t iterations)
+void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t page_size, uint32_t scratchpad, uint32_t iterations)
 {
   uint32_t init_rounds = (scratchpad / INIT_SIZE_BYTE);
   uint32_t aes_rounds = (iterations / 2);
-  size_t aes_init = (PAGE_SIZE / AES_BLOCK_SIZE);
+  size_t aes_init = (page_size / AES_BLOCK_SIZE);
 
 #ifndef FORCE_USE_HEAP
-  uint8_t long_state[PAGE_SIZE];
+  uint8_t long_state[page_size];
 #else
-  uint8_t *long_state = (uint8_t *)malloc(PAGE_SIZE);
+  uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 
   union cn_slow_hash_state state;


### PR DESCRIPTION
This fixes an error when building in Alpine. musl has a PAGE_SIZE macro defined in limits.h and so it conflicts with the parameter used in slow-hash.c when building.