### PR TITLE
Fix fall-through in BlockchainSynchronizer.cpp

### DIFF
--- a/src/Transfers/BlockchainSynchronizer.cpp
+++ b/src/Transfers/BlockchainSynchronizer.cpp
@@ -539,8 +539,7 @@ void BlockchainSynchronizer::processBlocks(GetBlocksResponse& response) {
         m_logger(DEBUGGING) << "Blockchain updated, resume blockchain synchronization";
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       } 
-        break;
-      }
+      break;
 
     case UpdateConsumersResult::addedNewBlocks:
       setFutureState(State::blockchainSync);

--- a/src/Transfers/BlockchainSynchronizer.cpp
+++ b/src/Transfers/BlockchainSynchronizer.cpp
@@ -538,6 +538,7 @@ void BlockchainSynchronizer::processBlocks(GetBlocksResponse& response) {
       if (m_node.getKnownBlockCount() != m_node.getLocalBlockCount()) {
         m_logger(DEBUGGING) << "Blockchain updated, resume blockchain synchronization";
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        break;
       } else {
         break;
       }

--- a/src/Transfers/BlockchainSynchronizer.cpp
+++ b/src/Transfers/BlockchainSynchronizer.cpp
@@ -538,8 +538,7 @@ void BlockchainSynchronizer::processBlocks(GetBlocksResponse& response) {
       if (m_node.getKnownBlockCount() != m_node.getLocalBlockCount()) {
         m_logger(DEBUGGING) << "Blockchain updated, resume blockchain synchronization";
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        break;
-      } else {
+      } 
         break;
       }
 


### PR DESCRIPTION
If switch case UpdateConsumersResult::nothingChanged is triggered while m_node.getKnownBlockCount() != m_node.getLocalBlockCount, switch processing will fall-through to case UpdateConsumersResult::addedNewBlocks.