### PR TITLE
Expose preprocessor definition FORCE_USE_HEAP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ matrix:
     - LABEL="aarch64"
     - _DEPLOYABLE="true"
     - STRIP="aarch64-linux-gnu-strip"
-    - ADDITIONAL_CMAKE_ARGS="-DFORCE_USE_HEAP=1"
 
 before_install:
 - eval $MATRIX_EVAL

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ matrix:
     - LABEL="aarch64"
     - _DEPLOYABLE="true"
     - STRIP="aarch64-linux-gnu-strip"
+    - ADDITIONAL_CMAKE_ARGS="-DFORCE_USE_HEAP=1"
 
 before_install:
 - eval $MATRIX_EVAL
@@ -128,7 +129,7 @@ install:
 script:
 - eval $MATRIX_EVAL
 - mkdir build && cd build
-- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. ${CUSTOM_TOOLCHAIN} ${CUSTOM_BOOST_ROOT}
+- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. ${CUSTOM_TOOLCHAIN} ${CUSTOM_BOOST_ROOT} ${ADDITIONAL_CMAKE_ARGS}
 - make -j2
 - if [[ "$LABEL" != "aarch64" ]]; then ./src/cryptotest ; fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,32 @@ set(ENABLE_PTHREAD_MUTEX_ADAPTIVE_NP OFF CACHE STRING "Enable RocksDB PTHREAD_MU
 set(ENABLE_MALLOC_USABLE_SIZE OFF CACHE STRING "Enable RocksDB MALLOC_USABLE_SIZE support detection? Defaults to OFF")
 set(ENABLE_SCHED_GETCPU OFF CACHE STRING "Enable RocksDB SCHED_GETCPU support detection? Defaults to OFF")
 
+## This section is for settings found in the slow-hash routine(s) that may benefit some systems (mostly ARM)
+set(FORCE_USE_HEAP OFF CACHE BOOL "Force the use of heap memory allocation")
+set(NO_AES OFF CACHE BOOL "Turn off Hardware AES instructions?")
+set(NO_OPTIMIZED_MULTIPLY_ON_ARM OFF CACHE BOOL "Turn off Optimized Multiplication on ARM?")
+
+if(FORCE_USE_HEAP)
+  add_definitions(-DFORCE_USE_HEAP)
+  message(STATUS "FORCE_USE_HEAP: ENABLED")
+else()
+  message(STATUS "FORCE_USE_HEAP: DISABLED")
+endif()
+
+if(NO_AES)
+  add_definitions(-DNO_AES)
+  message(STATUS "HW AES: DISABLED")
+else()
+  message(STATUS "HW AES: ENABLED")
+endif()
+
+if(NO_OPTIMIZED_MULTIPLY_ON_ARM)
+  add_definitions(-DNO_OPTIMIZED_MULTIPLY_ON_ARM)
+  message(STATUS "OPTIMIZED_ARM_MULTIPLICATION: DISABLED")
+else()
+  message(STATUS "OPTIMIZED_ARM_MULTIPLICATION: ENABLED")
+endif()
+
 # We need to set the label and import it into CMake if it exists
 set(LABEL "")
 if(DEFINED ENV{LABEL})
@@ -75,9 +101,6 @@ endif()
 
 ## We only build static binaries -- this is left here for our dependencies
 set(STATIC ON CACHE BOOL FORCE "Link libraries statically? Forced to ON")
-
-# This section helps us set up RocksDB for maximum portability
-set(ENABLE_AVX OFF CACHE STRING "Enable RocksDB AVX/AVX2 support detection? Defaults to OFF")
 
 ## This section helps us tag our builds with the git commit information
 set(COMMIT_ID_IN_VERSION ON CACHE BOOL "Include commit ID in version")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(ENABLE_MALLOC_USABLE_SIZE OFF CACHE STRING "Enable RocksDB MALLOC_USABLE_SIZ
 set(ENABLE_SCHED_GETCPU OFF CACHE STRING "Enable RocksDB SCHED_GETCPU support detection? Defaults to OFF")
 
 ## This section is for settings found in the slow-hash routine(s) that may benefit some systems (mostly ARM)
-set(FORCE_USE_HEAP OFF CACHE BOOL "Force the use of heap memory allocation")
+set(FORCE_USE_HEAP ON CACHE BOOL "Force the use of heap memory allocation")
 set(NO_AES OFF CACHE BOOL "Turn off Hardware AES instructions?")
 set(NO_OPTIMIZED_MULTIPLY_ON_ARM OFF CACHE BOOL "Turn off Optimized Multiplication on ARM?")
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Once you have a 64 bit image installed, setup proceeds the same as any Linux dis
 - `cd turtlecoin`
 - `mkdir build`
 - `cd build`
-- `cmake .. -DFORCE_USE_HEAP=1`
+- `cmake ..`
 - `make`
 
 The binaries will be in the `src` folder when you are complete.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The binaries will be in the `src/Release` folder when you are complete.
 - `cd Release`
 - `TurtleCoind.exe --version`
 
-#### Raspberry Pi 3 B+
+#### Raspberry Pi 3 B+ (AARCH64/ARM64)
 The following images are known to work. Your operation system image **MUST** be 64 bit.
 
 ##### Known working images
@@ -193,7 +193,7 @@ Once you have a 64 bit image installed, setup proceeds the same as any Linux dis
 - `cd turtlecoin`
 - `mkdir build`
 - `cd build`
-- `cmake ..`
+- `cmake .. -DFORCE_USE_HEAP=1`
 - `make`
 
 The binaries will be in the `src` folder when you are complete.
@@ -212,6 +212,6 @@ Hi TurtleCoin contributor, thanks for forking and sending back Pull Requests. Ex
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 ```

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -1047,6 +1047,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   RDATA_ALIGN16 uint8_t hp_state[page_size];
 #else
+#message "ACTIVATING FORCE_USE_HEAP IN aarch64 + crypto in slow-hash.c"
   uint8_t *hp_state = (uint8_t *)aligned_malloc(page_size,16);
 #endif
 
@@ -1283,6 +1284,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   uint8_t long_state[page_size];
 #else
+#message "ACTIVATING FORCE_USE_HEAP IN aarch64 && !crypto in slow-hash.c"
   uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 
@@ -1469,6 +1471,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   uint8_t long_state[page_size];
 #else
+#message "ACTIVATING FORCE_USE_HEAP IN portable slow-hash.c"
   uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -1047,7 +1047,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   RDATA_ALIGN16 uint8_t hp_state[page_size];
 #else
-#message "ACTIVATING FORCE_USE_HEAP IN aarch64 + crypto in slow-hash.c"
+#warning "ACTIVATING FORCE_USE_HEAP IN aarch64 + crypto in slow-hash.c"
   uint8_t *hp_state = (uint8_t *)aligned_malloc(page_size,16);
 #endif
 
@@ -1284,7 +1284,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   uint8_t long_state[page_size];
 #else
-#message "ACTIVATING FORCE_USE_HEAP IN aarch64 && !crypto in slow-hash.c"
+#warning "ACTIVATING FORCE_USE_HEAP IN aarch64 && !crypto in slow-hash.c"
   uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 
@@ -1471,7 +1471,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   uint8_t long_state[page_size];
 #else
-#message "ACTIVATING FORCE_USE_HEAP IN portable slow-hash.c"
+#warning "ACTIVATING FORCE_USE_HEAP IN portable slow-hash.c"
   uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 


### PR DESCRIPTION
This exposes a few of the preprocessor directives in `slow-hash.c` so that they can be specified easily during the build process via Cmake.

One of the most notable is the FORCE_USE_HEAP (via `-DFORCE_USE_HEAP=1` that is required on CPUs with a smaller L2 cache (ARM). Doing this allows the slow-hash routines to function properly thereby allowing the daemon/node to run on a number of ARM processors.

Special thanks that @thinkpol2 and @LeoStehlik for chasing this issue down and beating it into submission. Both have confirmed proper operation of the daemon on ARM boards. I believe @ExtraHash even has a daemon running on a mobile device in termux 

Resolves #640 