### PR TITLE
Speed up mnemonics lib compilation

### DIFF
--- a/src/Mnemonics/WordList.h
+++ b/src/Mnemonics/WordList.h
@@ -8,7 +8,7 @@ namespace Mnemonics
 {
     namespace WordList
     {
-        const std::vector<std::string> English =
+        const static std::vector<const char *> English =
         {
             "abbey",
             "abducts",


### PR DESCRIPTION
To compile the mnemonics lib before:

```
real	2m0.206s
user	2m1.771s
sys	0m3.910s
```

After:

```
real	0m10.551s
user	0m15.931s
sys	0m2.576s
```