### PR TITLE
Fix strange console locking issue in Windows under non english locale...

### DIFF
--- a/src/Platform/Windows/System/ErrorMessage.cpp
+++ b/src/Platform/Windows/System/ErrorMessage.cpp
@@ -42,7 +42,7 @@ std::string errorMessage(int error) {
   } buffer;
 
   auto size = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER, nullptr, error,
-                            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<LPTSTR>(&buffer.pointer), 0, nullptr);
+                            MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), reinterpret_cast<LPTSTR>(&buffer.pointer), 0, nullptr);
   return "result=" + std::to_string(error) + ", " + std::string(buffer.pointer, size);
 }
 


### PR DESCRIPTION
When the turtlecoind's logging system is >=3, it will output debug messages including socket error messages. However, under certain locale (mine is ja_JP) errorMessage(int) will produce output in native system language and cause the console to be locked.

Fix:
Modified FormatMessage call to use en_US locale regardless of user native language.

Hope it solves the problem