### PR TITLE
Fix data not getting returned by interleaved stop()

### DIFF
--- a/src/WalletBackend/WalletBackend.h
+++ b/src/WalletBackend/WalletBackend.h
@@ -21,6 +21,7 @@
 #include <SubWallets/SubWallets.h>
 
 #include <WalletBackend/WalletSynchronizer.h>
+#include <WalletBackend/WalletSynchronizerRAIIWrapper.h>
 
 using nlohmann::json;
 
@@ -327,4 +328,6 @@ class WalletBackend
            
            PS: I want to die */
         std::shared_ptr<WalletSynchronizer> m_walletSynchronizer;
+
+        std::shared_ptr<WalletSynchronizerRAIIWrapper> m_syncRAIIWrapper;
 };

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -94,10 +94,6 @@ WalletSynchronizer::~WalletSynchronizer()
    and if we do any inheritance, things don't go awry. */
 void WalletSynchronizer::start()
 {
-    /* Call stop first, so if we reassign any threads, they have been correctly
-       stopped */
-    stop();
-
     /* Reinit any vars which may have changed if we previously called stop() */
     m_shouldStop = false;
 
@@ -151,8 +147,6 @@ void WalletSynchronizer::stop()
 
 void WalletSynchronizer::reset(uint64_t startHeight)
 {
-    stop();
-
     /* Reset start height / timestamp */
     m_startHeight = startHeight;
     m_startTimestamp = 0;

--- a/src/WalletBackend/WalletSynchronizerRAIIWrapper.h
+++ b/src/WalletBackend/WalletSynchronizerRAIIWrapper.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2018, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include <WalletBackend/WalletSynchronizer.h>
+
+class WalletSynchronizerRAIIWrapper
+{
+    public:
+        WalletSynchronizerRAIIWrapper(
+            const std::shared_ptr<WalletSynchronizer> walletSynchronizer) :
+            m_walletSynchronizer(walletSynchronizer) {};
+
+        template<typename T>
+        auto pauseSynchronizerToRunFunction(T func)
+        {
+            /* Can only perform one operation with the synchronizer stopped at
+               once */
+            std::scoped_lock lock(m_mutex);
+
+            /* Stop the synchronizer */
+            if (m_walletSynchronizer != nullptr)
+            {
+                m_walletSynchronizer->stop();
+            }
+
+            /* Run the function, now safe */
+            auto result = func();
+
+            /* Start the synchronizer again */
+            if (m_walletSynchronizer != nullptr)
+            {
+                m_walletSynchronizer->start();
+            }
+
+            /* Return the extracted value */
+            return result;
+        }
+
+    private:
+        std::shared_ptr<WalletSynchronizer> m_walletSynchronizer;
+
+        std::mutex m_mutex;
+};


### PR DESCRIPTION
If we called multiple requests at the same time, which needed the wallet synchronizer to be stopped, this could cause join() to be called on the same thread ID multiple times. This threw an exception, which got caught, but returned an internal server error (500), instead of the data requested. Plus, the operation never completes.

This fixes it by adding a RAII wrapper, which locks a mutex, stops the synchronizer, runs the function, and restarts the synchronizer. It is also a lot easier to not accidentally forget to restart the synchronizer.