### PR TITLE
some compilers doesn't like it when non-included library is being used

### DIFF
--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -12,6 +12,7 @@
 #include "rapidjson/writer.h"
 
 #include <unordered_map>
+#include <optional>
 
 namespace WalletTypes
 {


### PR DESCRIPTION
Especially Microsoft