### PR TITLE
Cap the size of tx_extra

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1805,7 +1805,9 @@ std::error_code Core::validateSemantic(const Transaction& transaction, uint64_t&
     return error::TransactionValidationError::EMPTY_INPUTS;
   }
 
-  if (blockIndex >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2_HEIGHT)
+  /* Small buffer until enforcing - helps clear out tx pool with old, previously
+     valid transactions */
+  if (blockIndex >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2_HEIGHT + CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW)
   {
       if (transaction.extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
       {

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1805,6 +1805,14 @@ std::error_code Core::validateSemantic(const Transaction& transaction, uint64_t&
     return error::TransactionValidationError::EMPTY_INPUTS;
   }
 
+  if (blockIndex >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2_HEIGHT)
+  {
+      if (transaction.extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
+      {
+          return error::TransactionValidationError::EXTRA_TOO_LARGE;
+      }
+  }
+
   uint64_t summaryOutputAmount = 0;
   for (const auto& output : transaction.outputs) {
     if (output.amount == 0) {

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -191,7 +191,19 @@ private:
 
   uint8_t getBlockMajorVersionForHeight(uint32_t height) const;
   size_t calculateCumulativeBlocksizeLimit(uint32_t height) const;
-  void fillBlockTemplate(BlockTemplate& block, size_t medianSize, size_t maxCumulativeSize, size_t& transactionsSize, uint64_t& fee) const;
+
+  bool validateBlockTemplateTransaction(
+    const CachedTransaction &cachedTransaction,
+    const uint64_t blockHeight) const;
+
+  void fillBlockTemplate(
+    BlockTemplate& block,
+    const size_t medianSize,
+    const size_t maxCumulativeSize,
+    const uint64_t height,
+    size_t& transactionsSize,
+    uint64_t& fee) const;
+
   void deleteAlternativeChains();
   void deleteLeaf(size_t leafIndex);
   void mergeMainChainSegments();

--- a/src/CryptoNoteCore/TransactionValidationErrors.h
+++ b/src/CryptoNoteCore/TransactionValidationErrors.h
@@ -47,7 +47,8 @@ enum class TransactionValidationError {
   OUTPUTS_AMOUNT_OVERFLOW,
   WRONG_AMOUNT,
   WRONG_TRANSACTION_UNLOCK_TIME,
-  INVALID_MIXIN
+  INVALID_MIXIN,
+  EXTRA_TOO_LARGE,
 };
 
 // custom category:
@@ -91,6 +92,7 @@ public:
       case TransactionValidationError::WRONG_AMOUNT: return "Transaction wrong amount";
       case TransactionValidationError::WRONG_TRANSACTION_UNLOCK_TIME: return "Transaction has wrong unlock time";
       case TransactionValidationError::INVALID_MIXIN: return "Mixin too large or too small";
+      case TransactionValidationError::EXTRA_TOO_LARGE: return "Transaction extra too large";
       default: return "Unknown error";
     }
   }

--- a/src/Wallet/WalletErrors.h
+++ b/src/Wallet/WalletErrors.h
@@ -57,7 +57,8 @@ enum WalletErrorCodes {
   BAD_TRANSACTION_EXTRA,
   MIXIN_BELOW_THRESHOLD,
   MIXIN_ABOVE_THRESHOLD,
-  CONFLICTING_PAYMENT_IDS
+  CONFLICTING_PAYMENT_IDS,
+  EXTRA_TOO_LARGE,
 };
 
 // custom category:
@@ -107,6 +108,7 @@ public:
     case MIXIN_BELOW_THRESHOLD:         return "Mixin below minimum allowed threshold";
     case MIXIN_ABOVE_THRESHOLD:         return "Mixin above maximum allowed threshold";
     case CONFLICTING_PAYMENT_IDS:       return "Multiple conflicting payment ID's were specified via the use of integrated addresses";
+    case EXTRA_TOO_LARGE:               return "Transaction extra too large";
     default:                            return "Unknown error";
     }
   }

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -2297,6 +2297,19 @@ size_t WalletGreen::validateSaveAndSendTransaction(const ITransactionReader& tra
     throw std::system_error(make_error_code(error::INTERNAL_WALLET_ERROR), "Failed to deserialize created transaction");
   }
 
+  if (m_node.getLastKnownBlockHeight() > CryptoNote::parameters::MAX_EXTRA_SIZE_V2_HEIGHT)
+  {
+      if (cryptoNoteTransaction.extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
+      {
+          m_logger(ERROR, BRIGHT_RED) << "Transaction extra is too large. Allowed: "
+                                      << CryptoNote::parameters::MAX_EXTRA_SIZE_V2
+                                      << ", actual: " << cryptoNoteTransaction.extra.size()
+                                      << ".";
+
+          throw std::system_error(make_error_code(error::EXTRA_TOO_LARGE), "Transaction extra too large");
+      }
+  }
+
   uint64_t fee = transaction.getInputTotalAmount() - transaction.getOutputTotalAmount();
   size_t transactionId = insertOutgoingTransactionAndPushEvent(transaction.getTransactionHash(), fee, transaction.getExtra(), transaction.getUnlockTime());
   m_logger(DEBUGGING) << "Transaction added to container, ID " << transactionId <<

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -134,6 +134,8 @@ const size_t   MAX_BLOCK_SIZE_INITIAL                        = 100000;
 const uint64_t MAX_BLOCK_SIZE_GROWTH_SPEED_NUMERATOR         = 100 * 1024;
 const uint64_t MAX_BLOCK_SIZE_GROWTH_SPEED_DENOMINATOR       = 365 * 24 * 60 * 60 / DIFFICULTY_TARGET;
 const uint64_t MAX_EXTRA_SIZE                                = 140000;
+const uint64_t MAX_EXTRA_SIZE_V2                             = 1000;
+const uint64_t MAX_EXTRA_SIZE_V2_HEIGHT                      = 1300000;
 
 const uint64_t CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS     = 1;
 const uint64_t CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS    = DIFFICULTY_TARGET * CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS;

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -134,7 +134,7 @@ const size_t   MAX_BLOCK_SIZE_INITIAL                        = 100000;
 const uint64_t MAX_BLOCK_SIZE_GROWTH_SPEED_NUMERATOR         = 100 * 1024;
 const uint64_t MAX_BLOCK_SIZE_GROWTH_SPEED_DENOMINATOR       = 365 * 24 * 60 * 60 / DIFFICULTY_TARGET;
 const uint64_t MAX_EXTRA_SIZE                                = 140000;
-const uint64_t MAX_EXTRA_SIZE_V2                             = 1000;
+const uint64_t MAX_EXTRA_SIZE_V2                             = 1024;
 const uint64_t MAX_EXTRA_SIZE_V2_HEIGHT                      = 1300000;
 
 const uint64_t CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS     = 1;


### PR DESCRIPTION
Currently capped at 1024 bytes, and fork height set for 1.3 million.

You can easily test by altering the fork height to < current height, and you will see the daemon no longer accepts blocks. Furthermore, you should no longer be able to send transactions in turtle-service with a too large extra.