### PR TITLE
turtle-service: parameterized init wait timeout

### DIFF
--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -55,12 +55,13 @@ std::error_code interpretResponseStatus(const std::string& status) {
 
 }
 
-NodeRpcProxy::NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort, std::shared_ptr<Logging::ILogger> logger) :
+NodeRpcProxy::NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort, unsigned int initTimeout, std::shared_ptr<Logging::ILogger> logger) :
   m_logger(logger, "NodeRpcProxy"),
   m_rpcTimeout(10000),
   m_pullInterval(5000),
   m_nodeHost(nodeHost),
   m_nodePort(nodePort),
+  m_initTimeout(initTimeout),
   m_connected(true),
   m_peerCount(0),
   m_networkHeight(0),
@@ -69,12 +70,13 @@ NodeRpcProxy::NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort,
   resetInternalState();
 }
 
-NodeRpcProxy::NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort) :
+NodeRpcProxy::NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort, unsigned int initTimeout) :
   m_logger(std::make_shared<Logging::DummyLogger>(), "NodeRpcProxy"),
   m_rpcTimeout(10000),
   m_pullInterval(5000),
   m_nodeHost(nodeHost),
   m_nodePort(nodePort),
+  m_initTimeout(initTimeout),
   m_connected(true),
   m_peerCount(0),
   m_networkHeight(0),
@@ -158,7 +160,7 @@ void NodeRpcProxy::workerThread(const INode::Callback& initialized_callback) {
     });
 
     /* Init succeeded */
-    if (init.wait_for(std::chrono::seconds(10)) == std::future_status::ready) {
+    if (init.wait_for(std::chrono::seconds(m_initTimeout)) == std::future_status::ready) {
         initialized_callback(std::error_code());
     /* Timed out initting */
     } else {

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -35,8 +35,8 @@ public:
 
 class NodeRpcProxy : public CryptoNote::INode {
 public:
-  NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort, std::shared_ptr<Logging::ILogger> logger);
-  NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort);
+  NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort, unsigned int initTimeout, std::shared_ptr<Logging::ILogger> logger);
+  NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort, unsigned int initTimeout);
   virtual ~NodeRpcProxy();
 
   virtual bool addObserver(CryptoNote::INodeObserver* observer) override;
@@ -165,6 +165,7 @@ private:
   const std::string m_nodeHost;
   const unsigned short m_nodePort;
   unsigned int m_rpcTimeout;
+  unsigned int m_initTimeout;
   HttpClient* m_httpClient = nullptr;
   System::Event* m_httpEvent = nullptr;
 

--- a/src/WalletService/NodeFactory.cpp
+++ b/src/WalletService/NodeFactory.cpp
@@ -129,8 +129,8 @@ NodeFactory::NodeFactory() {
 NodeFactory::~NodeFactory() {
 }
 
-CryptoNote::INode* NodeFactory::createNode(const std::string& daemonAddress, uint16_t daemonPort, std::shared_ptr<Logging::ILogger> logger) {
-  std::unique_ptr<CryptoNote::INode> node(new CryptoNote::NodeRpcProxy(daemonAddress, daemonPort, logger));
+CryptoNote::INode* NodeFactory::createNode(const std::string& daemonAddress, uint16_t daemonPort, uint16_t initTimeout, std::shared_ptr<Logging::ILogger> logger) {
+  std::unique_ptr<CryptoNote::INode> node(new CryptoNote::NodeRpcProxy(daemonAddress, daemonPort, initTimeout, logger));
 
   NodeInitObserver initObserver;
   node->init(std::bind(&NodeInitObserver::initCompleted, &initObserver, std::placeholders::_1));

--- a/src/WalletService/NodeFactory.h
+++ b/src/WalletService/NodeFactory.h
@@ -27,7 +27,7 @@ namespace PaymentService {
 
 class NodeFactory {
 public:
-  static CryptoNote::INode* createNode(const std::string& daemonAddress, uint16_t daemonPort, std::shared_ptr<Logging::ILogger> logger);
+  static CryptoNote::INode* createNode(const std::string& daemonAddress, uint16_t daemonPort, uint16_t initTimeout, std::shared_ptr<Logging::ILogger> logger);
   static CryptoNote::INode* createNodeStub();
 private:
   NodeFactory();

--- a/src/WalletService/PaymentGateService.cpp
+++ b/src/WalletService/PaymentGateService.cpp
@@ -128,13 +128,14 @@ void PaymentGateService::stop() {
 }
 
 void PaymentGateService::runRpcProxy(Logging::LoggerRef& log) {
-  log(Logging::INFO) << "Starting Payment Gate with remote node";
+  log(Logging::INFO) << "Starting Payment Gate with remote node, timeout: " << config.serviceConfig.initTimeout;
   CryptoNote::Currency currency = currencyBuilder->currency();
 
   std::unique_ptr<CryptoNote::INode> node(
     PaymentService::NodeFactory::createNode(
       config.serviceConfig.daemonAddress,
       config.serviceConfig.daemonPort,
+      config.serviceConfig.initTimeout,
       log.getLogger()));
 
   runWalletService(currency, *node);

--- a/src/WalletService/WalletServiceConfiguration.cpp
+++ b/src/WalletService/WalletServiceConfiguration.cpp
@@ -34,7 +34,8 @@ namespace PaymentService {
       ("l,log-file", "Specify log <file> location", cxxopts::value<std::string>()->default_value(config.logFile), "<file>")
       ("log-level", "Specify log level", cxxopts::value<int>()->default_value(std::to_string(config.logLevel)), "#")
       ("server-root", "The service will use this <path> as the working directory", cxxopts::value<std::string>(), "<path>")
-      ("save-config", "Save the configuration to the specified <file>", cxxopts::value<std::string>(), "<file>");
+      ("save-config", "Save the configuration to the specified <file>", cxxopts::value<std::string>(), "<file>")
+      ("init-timeout", "Amount of time in seconds to wait for initial connection", cxxopts::value<int>()->default_value("10"), "<seconds>");
 
     options.add_options("Wallet")
       ("address", "Print the wallet addresses and then exit", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
@@ -102,6 +103,11 @@ namespace PaymentService {
       if (cli.count("daemon-port") > 0)
       {
         config.daemonPort = cli["daemon-port"].as<int>();
+      }
+      
+      if (cli.count("init-timeout") > 0)
+      {
+        config.initTimeout = cli["init-timeout"].as<int>();
       }
 
       if (cli.count("log-file") > 0)
@@ -276,6 +282,18 @@ namespace PaymentService {
             throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey );
           }  
         }
+        else if (cfgKey.compare("init-timeout")  == 0)
+        {
+          try
+          {
+            config.initTimeout = std::stoi(cfgValue);
+            updated = true;
+          }
+          catch(std::exception& e)
+          {
+            throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey );
+          }  
+        }
         else if (cfgKey.compare("log-file")  == 0)
         {
           config.logFile = cfgValue;
@@ -393,6 +411,11 @@ namespace PaymentService {
     {
       config.daemonPort = j["daemon-port"].get<int>();
     }
+    
+    if (j.find("init-timeout") != j.end())
+    {
+      config.initTimeout = j["init-timeout"].get<int>();
+    }
 
     if (j.find("log-file") != j.end())
     {
@@ -452,6 +475,7 @@ namespace PaymentService {
       {"daemon-port", config.daemonPort},
       {"log-file", config.logFile},
       {"log-level", config.logLevel},
+      {"init-timeout", config.initTimeout},
       {"container-file", config.containerFile},
       {"container-password", config.containerPassword},
       {"bind-address", config.bindAddress},

--- a/src/WalletService/WalletServiceConfiguration.h
+++ b/src/WalletService/WalletServiceConfiguration.h
@@ -32,6 +32,7 @@ namespace PaymentService {
       unregisterService = false;
       printAddresses = false;
       syncFromZero = false;
+      initTimeout = 10;
     }
 
     std::string daemonAddress;
@@ -46,6 +47,7 @@ namespace PaymentService {
     int daemonPort;
     int bindPort;
     int logLevel;
+    int initTimeout;
 
     bool legacySecurity;
 

--- a/src/zedwallet/ZedWallet.cpp
+++ b/src/zedwallet/ZedWallet.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 
     /* Our connection to turtlecoind */
     std::unique_ptr<CryptoNote::INode> node(
-        new CryptoNote::NodeRpcProxy(config.host, config.port, logManager)
+        new CryptoNote::NodeRpcProxy(config.host, config.port, 10, logManager)
     );
 
     std::promise<std::error_code> errorPromise;


### PR DESCRIPTION
add new (optional) `init-timeout` argument+config key. 
Increasing wait time (at runtime) helps with initial connection to remote node in situation where nodes struggle to respond to rpc (when the network fucked-up/etc)