### PR TITLE
WalletBackend (zedwallet++ and wallet-api) support for connecting to SSL daemons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ find_package(Threads)
 
 set(VERSION "0.1")
 
+## This section describes build options for additional support in the project
+set(ENABLE_SSL OFF CACHE STRING "Enable SSL support")
+
 ## This section describes our general CMake setup options
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo Release CACHE TYPE INTERNAL)
@@ -252,6 +255,20 @@ if(APPLE)
 elseif(NOT MSVC)
   set(Boost_LIBRARIES "${Boost_LIBRARIES};rt")
 endif()
+
+## Go get us some OpenSSL libraries if we need to
+if(ENABLE_SSL)
+  set(OPENSSL_USE_STATIC_LIBS OFF)
+  find_package(OpenSSL)
+  if(OPENSSL_FOUND)
+    include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
+    add_definitions(-DCPPHTTPLIB_OPENSSL_SUPPORT)
+    message(STATUS "OpenSSL Found: ${OPENSSL_INCLUDE_DIR}")
+    message(STATUS "OpenSSL Libraries: ${OPENSSL_LIBRARIES}")
+  else()
+    message(STATUS "OpenSSL Found: No... Skipping...")
+  endif()
+endif(ENABLE_SSL)
 
 add_subdirectory(external)
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ If you would like to compile yourself, read on.
 
 ### How To Compile
 
+#### OpenSSL Support
+
+Both zedwallet++ (zedwallet-beta) and wallet-api now support connecting to a node using SSL. To enable it during compilation, you will need to pass `-DENABLE_SSL=1` in the any of the CMake commands below.
+
+**Note:** If you compile with SSL support, it will link OpenSSL as a shared library.
+
+If you enable SSL support but OpenSSL is not found on your system, you can tell CMake where it is located with the `-DOPENSSL_ROOT_DIR=<path>` option.
+
+Ex. `-DOPENSSL_ROOT_DIR=/usr/lib/openssl` or `-DOPENSSL_ROOT_DIR=C:/OpenSSL-Win64/include`
+
 #### Linux
 
 ##### Prerequisites

--- a/external/cpp-httplib/httplib.h
+++ b/external/cpp-httplib/httplib.h
@@ -2,7 +2,7 @@
 //  httplib.h
 //
 //  Copyright (c) 2017 Yuji Hirose. All rights reserved.
-//  Copyright (c) 2018 The TurtleCoin Developers. All rights reserved.
+//  Copyright (c) 2018-2019 The TurtleCoin Developers. All rights reserved.
 //  MIT License
 //
 
@@ -373,7 +373,7 @@ class SSLClient : public Client {
 public:
     SSLClient(
         const char* host,
-        int port = 80,
+        int port = 443,
         time_t timeout_sec = 300);
 
     virtual ~SSLClient();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,12 @@ target_link_libraries(WalletService Mnemonics)
 target_link_libraries(zedwallet Mnemonics Wallet Errors Utilities)
 target_link_libraries(zedwallet++ WalletBackend)
 
+if(OPENSSL_FOUND)
+  target_link_libraries(miner ${OPENSSL_LIBRARIES})
+  target_link_libraries(Nigel ${OPENSSL_LIBRARIES})
+  target_link_libraries(WalletApi ${OPENSSL_LIBRARIES})
+endif()
+
 # Add dependencies means we have to build the latter before we build the former
 # In this case it's because we need to have the current version name rather
 # than a cached one

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,6 +152,7 @@ if(OPENSSL_FOUND)
   target_link_libraries(miner ${OPENSSL_LIBRARIES})
   target_link_libraries(Nigel ${OPENSSL_LIBRARIES})
   target_link_libraries(WalletApi ${OPENSSL_LIBRARIES})
+  target_link_libraries(zedwallet++ ${OPENSSL_LIBRARIES})
 endif()
 
 # Add dependencies means we have to build the latter before we build the former

--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -27,7 +27,7 @@ inline std::shared_ptr<httplib::Client> getClient(const std::string daemonHost, 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     if (daemonSSL)
     {
-        return (std::shared_ptr<httplib::Client>) std::make_shared<httplib::SSLClient>(daemonHost.c_str(), daemonPort, timeout.count());
+        return std::make_shared<httplib::SSLClient>(daemonHost.c_str(), daemonPort, timeout.count());
     }
     else
     {

--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -99,12 +99,14 @@ void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort, co
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     if (m_daemonSSL)
     {
+        m_httpClient = nullptr;
         m_httpsClient = std::make_shared<httplib::SSLClient>(
             daemonHost.c_str(), daemonPort, m_timeout.count()
         );
     }
     else
     {
+        m_httpsClient = nullptr;
 #endif
         m_httpClient = std::make_shared<httplib::Client>(
             daemonHost.c_str(), daemonPort, m_timeout.count()
@@ -371,9 +373,9 @@ std::tuple<uint64_t, std::string> Nigel::nodeFee() const
     return {m_nodeFeeAmount, m_nodeFeeAddress};
 }
 
-std::tuple<std::string, uint16_t> Nigel::nodeAddress() const
+std::tuple<std::string, uint16_t, bool> Nigel::nodeAddress() const
 {
-    return {m_daemonHost, m_daemonPort};
+    return {m_daemonHost, m_daemonPort, m_daemonSSL};
 }
 
 bool Nigel::getTransactionsStatus(

--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -24,24 +24,9 @@ using json = nlohmann::json;
 
 Nigel::Nigel(
     const std::string daemonHost,
-    const uint16_t daemonPort) :
-    Nigel(daemonHost, daemonPort, false, std::chrono::seconds(10))
-{
-}
-
-Nigel::Nigel(
-    const std::string daemonHost,
     const uint16_t daemonPort,
     const bool daemonSSL) :
     Nigel(daemonHost, daemonPort, daemonSSL, std::chrono::seconds(10))
-{
-}
-
-Nigel::Nigel(
-    const std::string daemonHost,
-    const uint16_t daemonPort,
-    const std::chrono::seconds timeout) :
-    Nigel(daemonHost, daemonPort, false, timeout)
 {
 }
 
@@ -77,11 +62,6 @@ Nigel::~Nigel()
 //////////////////////
 /* Member functions */
 //////////////////////
-
-void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort)
-{
-    swapNode(daemonHost, daemonPort, false);
-}
 
 void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort, const bool daemonSSL)
 {

--- a/src/Nigel/Nigel.h
+++ b/src/Nigel/Nigel.h
@@ -28,17 +28,8 @@ class Nigel
 
         Nigel(
             const std::string daemonHost,
-            const uint16_t daemonPort);
-
-        Nigel(
-            const std::string daemonHost,
             const uint16_t daemonPort,
             const bool daemonSSL);
-
-        Nigel(
-            const std::string daemonHost,
-            const uint16_t daemonPort,
-            const std::chrono::seconds timeout);
 
         Nigel(
             const std::string daemonHost,
@@ -53,8 +44,6 @@ class Nigel
         /////////////////////////////
 
         void init();
-
-        void swapNode(const std::string daemonHost, const uint16_t daemonPort);
 
         void swapNode(const std::string daemonHost, const uint16_t daemonPort, const bool daemonSSL);
 

--- a/src/Nigel/Nigel.h
+++ b/src/Nigel/Nigel.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2018, The TurtleCoin Developers
-// 
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -33,6 +33,17 @@ class Nigel
         Nigel(
             const std::string daemonHost,
             const uint16_t daemonPort,
+            const bool daemonSSL);
+
+        Nigel(
+            const std::string daemonHost,
+            const uint16_t daemonPort,
+            const std::chrono::seconds timeout);
+
+        Nigel(
+            const std::string daemonHost,
+            const uint16_t daemonPort,
+            const bool daemonSSL,
             const std::chrono::seconds timeout);
 
         ~Nigel();
@@ -44,6 +55,8 @@ class Nigel
         void init();
 
         void swapNode(const std::string daemonHost, const uint16_t daemonPort);
+
+        void swapNode(const std::string daemonHost, const uint16_t daemonPort, const bool daemonSSL);
 
         /* Returns whether we've received info from the daemon at some point */
         bool isOnline() const;
@@ -103,6 +116,12 @@ class Nigel
         /* Private member variables */
         //////////////////////////////
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+        /* Stores our https client (Don't really care about it launching threads
+           and making our functions non const) */
+        std::shared_ptr<httplib::SSLClient> m_httpsClient = nullptr;
+
+#endif
         /* Stores our http client (Don't really care about it launching threads
            and making our functions non const) */
         std::shared_ptr<httplib::Client> m_httpClient = nullptr;
@@ -115,7 +134,7 @@ class Nigel
 
         /* The amount of blocks the daemon we're connected to has */
         std::atomic<uint64_t> m_localDaemonBlockCount = 0;
-        
+
         /* The amount of blocks the network has */
         std::atomic<uint64_t> m_networkBlockCount = 0;
 
@@ -139,4 +158,7 @@ class Nigel
 
         /* The daemon port */
         uint16_t m_daemonPort;
+
+        /* If the daemon is SSL */
+        bool m_daemonSSL;
 };

--- a/src/Nigel/Nigel.h
+++ b/src/Nigel/Nigel.h
@@ -71,7 +71,7 @@ class Nigel
 
         std::tuple<uint64_t, std::string> nodeFee() const;
 
-        std::tuple<std::string, uint16_t> nodeAddress() const;
+        std::tuple<std::string, uint16_t, bool> nodeAddress() const;
 
         std::tuple<bool, std::vector<WalletTypes::WalletBlockInfo>> getWalletSyncData(
             const std::vector<Crypto::Hash> blockHashCheckpoints,
@@ -160,5 +160,5 @@ class Nigel
         uint16_t m_daemonPort;
 
         /* If the daemon is SSL */
-        bool m_daemonSSL;
+        bool m_daemonSSL = false;
 };

--- a/src/Nigel/Nigel.h
+++ b/src/Nigel/Nigel.h
@@ -105,15 +105,9 @@ class Nigel
         /* Private member variables */
         //////////////////////////////
 
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-        /* Stores our https client (Don't really care about it launching threads
-           and making our functions non const) */
-        std::shared_ptr<httplib::SSLClient> m_httpsClient = nullptr;
-
-#endif
         /* Stores our http client (Don't really care about it launching threads
            and making our functions non const) */
-        std::shared_ptr<httplib::Client> m_httpClient = nullptr;
+        std::shared_ptr<httplib::Client> m_nodeClient = nullptr;
 
         /* Runs a background refresh on height, hashrate, etc */
         std::thread m_backgroundThread;

--- a/src/WalletApi/ApiDispatcher.cpp
+++ b/src/WalletApi/ApiDispatcher.cpp
@@ -1562,7 +1562,7 @@ std::tuple<std::string, uint16_t, bool, std::string, std::string>
 
     if (body.find("daemonSSL") != body.end())
     {
-      daemonSSL = tryGetJsonValue<bool>(body, "daemonSSL");
+        daemonSSL = tryGetJsonValue<bool>(body, "daemonSSL");
     }
 
     return {daemonHost, daemonPort, daemonSSL, filename, password};

--- a/src/WalletApi/ApiDispatcher.cpp
+++ b/src/WalletApi/ApiDispatcher.cpp
@@ -393,14 +393,14 @@ std::tuple<Error, uint16_t> ApiDispatcher::keyImportWallet(
 
     const auto [daemonHost, daemonPort, daemonSSL, filename, password] = getDefaultWalletParams(body);
 
-    const auto privateViewKey = tryGetJsonValue<Crypto::SecretKey>(body, "privateViewKey");
-    const auto privateSpendKey = tryGetJsonValue<Crypto::SecretKey>(body, "privateSpendKey");
+    const auto privateViewKey = getJsonValue<Crypto::SecretKey>(body, "privateViewKey");
+    const auto privateSpendKey = getJsonValue<Crypto::SecretKey>(body, "privateSpendKey");
 
     uint64_t scanHeight = 0;
 
     if (body.find("scanHeight") != body.end())
     {
-        scanHeight = tryGetJsonValue<uint64_t>(body, "scanHeight");
+        scanHeight = getJsonValue<uint64_t>(body, "scanHeight");
     }
 
     Error error;
@@ -422,13 +422,13 @@ std::tuple<Error, uint16_t> ApiDispatcher::seedImportWallet(
 
     const auto [daemonHost, daemonPort, daemonSSL, filename, password] = getDefaultWalletParams(body);
 
-    const std::string mnemonicSeed = tryGetJsonValue<std::string>(body, "mnemonicSeed");
+    const std::string mnemonicSeed = getJsonValue<std::string>(body, "mnemonicSeed");
 
     uint64_t scanHeight = 0;
 
     if (body.find("scanHeight") != body.end())
     {
-        scanHeight = tryGetJsonValue<uint64_t>(body, "scanHeight");
+        scanHeight = getJsonValue<uint64_t>(body, "scanHeight");
     }
 
     Error error;
@@ -449,14 +449,14 @@ std::tuple<Error, uint16_t> ApiDispatcher::importViewWallet(
 
     const auto [daemonHost, daemonPort, daemonSSL, filename, password] = getDefaultWalletParams(body);
 
-    const std::string address = tryGetJsonValue<std::string>(body, "address");
-    const auto privateViewKey = tryGetJsonValue<Crypto::SecretKey>(body, "privateViewKey");
+    const std::string address = getJsonValue<std::string>(body, "address");
+    const auto privateViewKey = getJsonValue<Crypto::SecretKey>(body, "privateViewKey");
 
     uint64_t scanHeight = 0;
 
     if (body.find("scanHeight") != body.end())
     {
-        scanHeight = tryGetJsonValue<uint64_t>(body, "scanHeight");
+        scanHeight = getJsonValue<uint64_t>(body, "scanHeight");
     }
 
     Error error;
@@ -518,10 +518,10 @@ std::tuple<Error, uint16_t> ApiDispatcher::importAddress(
        begin again from zero if none is given */
     if (body.find("scanHeight") != body.end())
     {
-        scanHeight = tryGetJsonValue<uint64_t>(body, "scanHeight");
+        scanHeight = getJsonValue<uint64_t>(body, "scanHeight");
     }
 
-    const auto privateSpendKey = tryGetJsonValue<Crypto::SecretKey>(body, "privateSpendKey");
+    const auto privateSpendKey = getJsonValue<Crypto::SecretKey>(body, "privateSpendKey");
 
     const auto [error, address] = m_walletBackend->importSubWallet(
         privateSpendKey, scanHeight
@@ -552,10 +552,10 @@ std::tuple<Error, uint16_t> ApiDispatcher::importViewAddress(
        begin again from zero if none is given */
     if (body.find("scanHeight") != body.end())
     {
-        scanHeight = tryGetJsonValue<uint64_t>(body, "scanHeight");
+        scanHeight = getJsonValue<uint64_t>(body, "scanHeight");
     }
 
-    const auto publicSpendKey = tryGetJsonValue<Crypto::PublicKey>(body, "publicSpendKey");
+    const auto publicSpendKey = getJsonValue<Crypto::PublicKey>(body, "publicSpendKey");
 
     const auto [error, address] = m_walletBackend->importViewSubWallet(
         publicSpendKey, scanHeight
@@ -580,7 +580,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::validateAddress(
     Response &res,
     const nlohmann::json &body)
 {
-    const std::string address = tryGetJsonValue<std::string>(body, "address");
+    const std::string address = getJsonValue<std::string>(body, "address");
 
     const Error error = validateAddresses({address}, true);
 
@@ -619,15 +619,15 @@ std::tuple<Error, uint16_t> ApiDispatcher::sendBasicTransaction(
     Response &res,
     const nlohmann::json &body)
 {
-    const std::string address = tryGetJsonValue<std::string>(body, "destination");
+    const std::string address = getJsonValue<std::string>(body, "destination");
 
-    const uint64_t amount = tryGetJsonValue<uint64_t>(body, "amount");
+    const uint64_t amount = getJsonValue<uint64_t>(body, "amount");
 
     std::string paymentID;
 
     if (body.find("paymentID") != body.end())
     {
-        paymentID = tryGetJsonValue<std::string>(body, "paymentID");
+        paymentID = getJsonValue<std::string>(body, "paymentID");
     }
 
     auto [error, hash] = m_walletBackend->sendTransactionBasic(
@@ -653,14 +653,14 @@ std::tuple<Error, uint16_t> ApiDispatcher::sendAdvancedTransaction(
     Response &res,
     const nlohmann::json &body)
 {
-    const json destinationsJSON = tryGetJsonValue<json>(body, "destinations");
+    const json destinationsJSON = getJsonValue<json>(body, "destinations");
 
     std::vector<std::pair<std::string, uint64_t>> destinations;
 
     for (const auto destination : destinationsJSON)
     {
-        const std::string address = tryGetJsonValue<std::string>(destination, "address");
-        const uint64_t amount = tryGetJsonValue<uint64_t>(destination, "amount");
+        const std::string address = getJsonValue<std::string>(destination, "address");
+        const uint64_t amount = getJsonValue<uint64_t>(destination, "amount");
         destinations.emplace_back(address, amount);
     }
 
@@ -668,7 +668,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::sendAdvancedTransaction(
 
     if (body.find("mixin") != body.end())
     {
-        mixin = tryGetJsonValue<uint64_t>(body, "mixin");
+        mixin = getJsonValue<uint64_t>(body, "mixin");
     }
     else
     {
@@ -682,35 +682,35 @@ std::tuple<Error, uint16_t> ApiDispatcher::sendAdvancedTransaction(
 
     if (body.find("fee") != body.end())
     {
-        fee = tryGetJsonValue<uint64_t>(body, "fee");
+        fee = getJsonValue<uint64_t>(body, "fee");
     }
 
     std::vector<std::string> subWalletsToTakeFrom = {};
 
     if (body.find("sourceAddresses") != body.end())
     {
-        subWalletsToTakeFrom = tryGetJsonValue<std::vector<std::string>>(body, "sourceAddresses");
+        subWalletsToTakeFrom = getJsonValue<std::vector<std::string>>(body, "sourceAddresses");
     }
 
     std::string paymentID;
 
     if (body.find("paymentID") != body.end())
     {
-        paymentID = tryGetJsonValue<std::string>(body, "paymentID");
+        paymentID = getJsonValue<std::string>(body, "paymentID");
     }
 
     std::string changeAddress;
 
     if (body.find("changeAddress") != body.end())
     {
-        changeAddress = tryGetJsonValue<std::string>(body, "changeAddress");
+        changeAddress = getJsonValue<std::string>(body, "changeAddress");
     }
 
     uint64_t unlockTime = 0;
 
     if (body.find("unlockTime") != body.end())
     {
-        unlockTime = tryGetJsonValue<uint64_t>(body, "unlockTime");
+        unlockTime = getJsonValue<uint64_t>(body, "unlockTime");
     }
 
     auto [error, hash] = m_walletBackend->sendTransactionAdvanced(
@@ -758,13 +758,13 @@ std::tuple<Error, uint16_t> ApiDispatcher::sendAdvancedFusionTransaction(
     Response &res,
     const nlohmann::json &body)
 {
-    const std::string destination = tryGetJsonValue<std::string>(body, "destination");
+    const std::string destination = getJsonValue<std::string>(body, "destination");
 
     uint64_t mixin;
 
     if (body.find("mixin") != body.end())
     {
-        mixin = tryGetJsonValue<uint64_t>(body, "mixin");
+        mixin = getJsonValue<uint64_t>(body, "mixin");
     }
     else
     {
@@ -778,7 +778,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::sendAdvancedFusionTransaction(
 
     if (body.find("sourceAddresses") != body.end())
     {
-        subWalletsToTakeFrom = tryGetJsonValue<std::vector<std::string>>(body, "sourceAddresses");
+        subWalletsToTakeFrom = getJsonValue<std::vector<std::string>>(body, "sourceAddresses");
     }
 
     auto [error, hash] = m_walletBackend->sendFusionTransactionAdvanced(
@@ -866,7 +866,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::resetWallet(
 
     if (body.find("scanHeight") != body.end())
     {
-        scanHeight = tryGetJsonValue<uint64_t>(body, "scanHeight");
+        scanHeight = getJsonValue<uint64_t>(body, "scanHeight");
     }
 
     m_walletBackend->reset(scanHeight, timestamp);
@@ -881,9 +881,22 @@ std::tuple<Error, uint16_t> ApiDispatcher::setNodeInfo(
 {
     std::scoped_lock lock(m_mutex);
 
-    const std::string daemonHost = tryGetJsonValue<std::string>(body, "daemonHost");
-    const uint16_t daemonPort = tryGetJsonValue<uint16_t>(body, "daemonPort");
-    const bool daemonSSL = tryGetJsonValue<bool>(body, "daemonSSL");
+    uint16_t daemonPort = CryptoNote::RPC_DEFAULT_PORT;
+    bool daemonSSL = false;
+
+    /* This parameter is required */
+    const std::string daemonHost = getJsonValue<std::string>(body, "daemonHost");
+
+    /* These parameters are optional */
+    if (body.find("daemonPort") != body.end())
+    {
+        daemonPort = getJsonValue<uint16_t>(body, "daemonPort");
+    }
+
+    if (body.find("daemonSSL") != body.end())
+    {
+        daemonSSL = getJsonValue<bool>(body, "daemonSSL");
+    }
 
     m_walletBackend->swapNode(daemonHost, daemonPort, daemonSSL);
 
@@ -1547,22 +1560,22 @@ std::tuple<std::string, uint16_t, bool, std::string, std::string>
     uint16_t daemonPort = CryptoNote::RPC_DEFAULT_PORT;
     bool daemonSSL = false;
 
-    const std::string filename = tryGetJsonValue<std::string>(body, "filename");
-    const std::string password = tryGetJsonValue<std::string>(body, "password");
+    const std::string filename = getJsonValue<std::string>(body, "filename");
+    const std::string password = getJsonValue<std::string>(body, "password");
 
     if (body.find("daemonHost") != body.end())
     {
-        daemonHost = tryGetJsonValue<std::string>(body, "daemonHost");
+        daemonHost = getJsonValue<std::string>(body, "daemonHost");
     }
 
     if (body.find("daemonPort") != body.end())
     {
-        daemonPort = tryGetJsonValue<uint16_t>(body, "daemonPort");
+        daemonPort = getJsonValue<uint16_t>(body, "daemonPort");
     }
 
     if (body.find("daemonSSL") != body.end())
     {
-        daemonSSL = tryGetJsonValue<bool>(body, "daemonSSL");
+        daemonSSL = getJsonValue<bool>(body, "daemonSSL");
     }
 
     return {daemonHost, daemonPort, daemonSSL, filename, password};

--- a/src/WalletApi/ApiDispatcher.h
+++ b/src/WalletApi/ApiDispatcher.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2018-2019, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -19,7 +19,7 @@ enum WalletState
 
 /* Functions the same as body.at(key).get<T>(), but gives better error messages */
 template<typename T>
-T tryGetJsonValue(const nlohmann::json &body, const std::string key)
+T getJsonValue(const nlohmann::json &body, const std::string key)
 {
     if (body.find(key) == body.end())
     {
@@ -65,7 +65,7 @@ class ApiDispatcher
 
         /* Stops the server */
         void stop();
-        
+
     private:
 
         //////////////////////////////
@@ -93,7 +93,7 @@ class ApiDispatcher
         ///////////////////
         /* POST REQUESTS */
         ///////////////////
-        
+
         /* Opens a wallet */
         std::tuple<Error, uint16_t> openWallet(
             const httplib::Request &req,
@@ -272,7 +272,7 @@ class ApiDispatcher
             const httplib::Request &req,
             httplib::Response &res,
             const nlohmann::json &body) const;
-            
+
         std::tuple<Error, uint16_t> getTransactionsFromHeightToHeight(
             const httplib::Request &req,
             httplib::Response &res,
@@ -282,7 +282,7 @@ class ApiDispatcher
             const httplib::Request &req,
             httplib::Response &res,
             const nlohmann::json &body) const;
-            
+
         std::tuple<Error, uint16_t> getTransactionsFromHeightToHeightWithAddress(
             const httplib::Request &req,
             httplib::Response &res,
@@ -346,7 +346,7 @@ class ApiDispatcher
         void publicKeysToAddresses(nlohmann::json &j) const;
 
         std::string hashPassword(const std::string password) const;
-        
+
         //////////////////////////////
         /* Private member variables */
         //////////////////////////////

--- a/src/WalletApi/ApiDispatcher.h
+++ b/src/WalletApi/ApiDispatcher.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 // 
 // Please see the included LICENSE file for more information.
 
@@ -327,7 +327,7 @@ class ApiDispatcher
         //////////////////////////
 
         /* Extracts {host, port, filename, password}, from body */
-        std::tuple<std::string, uint16_t, std::string, std::string>
+        std::tuple<std::string, uint16_t, bool, std::string, std::string>
             getDefaultWalletParams(const nlohmann::json body) const;
 
         /* Assert the wallet is not a view only wallet */

--- a/src/WalletApi/ApiDispatcher.h
+++ b/src/WalletApi/ApiDispatcher.h
@@ -326,7 +326,7 @@ class ApiDispatcher
         /* END OF API FUNCTIONS */
         //////////////////////////
 
-        /* Extracts {host, port, filename, password}, from body */
+        /* Extracts {host, port, ssl, filename, password}, from body */
         std::tuple<std::string, uint16_t, bool, std::string, std::string>
             getDefaultWalletParams(const nlohmann::json body) const;
 

--- a/src/WalletBackend/WalletBackend.cpp
+++ b/src/WalletBackend/WalletBackend.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2018-2019, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 ////////////////////////////////////////
@@ -99,7 +99,7 @@ Error checkNewWalletFilename(std::string filename)
 
     /* Don't leave random files around if we fail later down the road */
     fs::remove(filename);
-    
+
     return SUCCESS;
 }
 
@@ -114,7 +114,7 @@ WalletBackend::WalletBackend()
 {
     m_eventHandler = std::make_shared<EventHandler>();
 
-    /* Remember to correctly initialize the daemon - 
+    /* Remember to correctly initialize the daemon -
     we can't do it here since we don't have the host/port, and the json
     serialization uses the default constructor */
 }
@@ -139,11 +139,12 @@ WalletBackend::WalletBackend(
     const uint64_t scanHeight,
     const bool newWallet,
     const std::string daemonHost,
-    const uint16_t daemonPort) :
+    const uint16_t daemonPort,
+    const bool daemonSSL) :
 
     m_filename(filename),
     m_password(password),
-    m_daemon(std::make_shared<Nigel>(daemonHost, daemonPort))
+    m_daemon(std::make_shared<Nigel>(daemonHost, daemonPort, daemonSSL))
 {
     /* Generate the address from the two private keys */
     std::string address = Utilities::privateKeysToAddress(
@@ -165,11 +166,12 @@ WalletBackend::WalletBackend(
     const std::string address,
     const uint64_t scanHeight,
     const std::string daemonHost,
-    const uint16_t daemonPort) :
+    const uint16_t daemonPort,
+    const bool daemonSSL) :
 
     m_filename(filename),
     m_password(password),
-    m_daemon(std::make_shared<Nigel>(daemonHost, daemonPort))
+    m_daemon(std::make_shared<Nigel>(daemonHost, daemonPort, daemonSSL))
 {
     bool newWallet = false;
 
@@ -229,12 +231,13 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importWalletFro
     const std::string password,
     const uint64_t scanHeight,
     const std::string daemonHost,
-    const uint16_t daemonPort)
+    const uint16_t daemonPort,
+    const bool daemonSSL)
 {
     /* Check the filename is valid */
     if (Error error = checkNewWalletFilename(filename); error != SUCCESS)
     {
-        return {error, nullptr}; 
+        return {error, nullptr};
     }
 
     /* Convert the mnemonic into a private spend key */
@@ -242,7 +245,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importWalletFro
 
     if (mnemonicError)
     {
-        return {mnemonicError, nullptr}; 
+        return {mnemonicError, nullptr};
     }
 
     Crypto::SecretKey privateViewKey;
@@ -263,7 +266,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importWalletFro
 
     const std::shared_ptr<WalletBackend> wallet(new WalletBackend(
         filename, password, privateSpendKey, privateViewKey,
-        scanHeight, newWallet, daemonHost, daemonPort
+        scanHeight, newWallet, daemonHost, daemonPort, daemonSSL
     ));
 
     wallet->init();
@@ -283,12 +286,13 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importWalletFro
     const std::string password,
     const uint64_t scanHeight,
     const std::string daemonHost,
-    const uint16_t daemonPort)
+    const uint16_t daemonPort,
+    const bool daemonSSL)
 {
     /* Check the filename is valid */
     if (Error error = checkNewWalletFilename(filename); error != SUCCESS)
     {
-        return {error, nullptr}; 
+        return {error, nullptr};
     }
 
     if (Error error = validatePrivateKey(privateViewKey); error != SUCCESS)
@@ -307,7 +311,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importWalletFro
 
     const std::shared_ptr<WalletBackend> wallet(new WalletBackend(
         filename, password, privateSpendKey, privateViewKey, scanHeight,
-        newWallet, daemonHost, daemonPort
+        newWallet, daemonHost, daemonPort, daemonSSL
     ));
 
     wallet->init();
@@ -327,12 +331,13 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importViewWalle
     const std::string password,
     const uint64_t scanHeight,
     const std::string daemonHost,
-    const uint16_t daemonPort)
+    const uint16_t daemonPort,
+    const bool daemonSSL)
 {
     /* Check the filename is valid */
     if (Error error = checkNewWalletFilename(filename); error != SUCCESS)
     {
-        return {error, nullptr}; 
+        return {error, nullptr};
     }
 
     if (Error error = validatePrivateKey(privateViewKey); error != SUCCESS)
@@ -349,7 +354,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::importViewWalle
 
     const std::shared_ptr<WalletBackend> wallet(new WalletBackend(
         filename, password, privateViewKey, address, scanHeight, daemonHost,
-        daemonPort
+        daemonPort, daemonSSL
     ));
 
     wallet->init();
@@ -365,14 +370,15 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::createWallet(
     const std::string filename,
     const std::string password,
     const std::string daemonHost,
-    const uint16_t daemonPort)
+    const uint16_t daemonPort,
+    const bool daemonSSL)
 {
     /* Check the filename is valid */
     if (Error error = checkNewWalletFilename(filename); error != SUCCESS)
     {
         return {error, nullptr};
     }
-	
+
     CryptoNote::KeyPair spendKey;
     Crypto::SecretKey privateViewKey;
     Crypto::PublicKey publicViewKey;
@@ -392,9 +398,9 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::createWallet(
 
     const std::shared_ptr<WalletBackend> wallet(new WalletBackend(
         filename, password, spendKey.secretKey, privateViewKey,
-        scanHeight, newWallet, daemonHost, daemonPort
+        scanHeight, newWallet, daemonHost, daemonPort, daemonSSL
     ));
-	
+
     wallet->init();
 
     /* Save to disk */
@@ -408,7 +414,8 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::openWallet(
     const std::string filename,
     const std::string password,
     const std::string daemonHost,
-    const uint16_t daemonPort)
+    const uint16_t daemonPort,
+    const bool daemonSSL)
 {
     /* Open in binary mode, since we have encrypted data */
     std::ifstream file(filename, std::ios_base::binary);
@@ -416,7 +423,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::openWallet(
     /* Check we successfully opened the file */
     if (!file)
     {
-        return {FILENAME_NON_EXISTENT, nullptr}; 
+        return {FILENAME_NON_EXISTENT, nullptr};
     }
 
     /* Read file into a buffer */
@@ -432,7 +439,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::openWallet(
 
     if (error)
     {
-        return {error, nullptr}; 
+        return {error, nullptr};
     }
 
     using namespace CryptoPP;
@@ -496,7 +503,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::openWallet(
 
     if (error)
     {
-        return {error, nullptr}; 
+        return {error, nullptr};
     }
 
     try
@@ -523,7 +530,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::openWallet(
         /* Initialize it from the json (We could do this in less steps, but it
            requires a move/copy constructor) */
         error = wallet->fromJSON(
-            walletJson, filename, password, daemonHost, daemonPort
+            walletJson, filename, password, daemonHost, daemonPort, daemonSSL
         );
 
         return {error, wallet};
@@ -560,7 +567,7 @@ void WalletBackend::init()
         auto [startHeight, startTimestamp] = m_subWallets->getMinInitialSyncStart();
 
         m_walletSynchronizer = std::make_shared<WalletSynchronizer>(
-            m_daemon, 
+            m_daemon,
             startHeight,
             startTimestamp,
             m_subWallets->getPrivateViewKey(),
@@ -782,7 +789,7 @@ std::tuple<Error, std::string, Crypto::SecretKey> WalletBackend::addSubWallet()
 {
     return m_syncRAIIWrapper->pauseSynchronizerToRunFunction([this]() {
         /* Add the sub wallet */
-        return m_subWallets->addSubWallet(); 
+        return m_subWallets->addSubWallet();
     });
 }
 
@@ -799,7 +806,7 @@ std::tuple<Error, std::string> WalletBackend::importSubWallet(
         /* Add the sub wallet */
         const auto [error, address] = m_subWallets->importSubWallet(
             privateSpendKey, scanHeight
-        ); 
+        );
 
         if (!error)
         {
@@ -835,7 +842,7 @@ std::tuple<Error, std::string> WalletBackend::importViewSubWallet(
         /* Add the sub wallet */
         const auto [error, address] = m_subWallets->importViewSubWallet(
             publicSpendKey, scanHeight
-        ); 
+        );
 
         if (!error)
         {
@@ -1048,16 +1055,16 @@ std::tuple<uint64_t, std::string> WalletBackend::getNodeFee() const
     return m_daemon->nodeFee();
 }
 
-std::tuple<std::string, uint16_t> WalletBackend::getNodeAddress() const
+std::tuple<std::string, uint16_t, bool> WalletBackend::getNodeAddress() const
 {
     return m_daemon->nodeAddress();
 }
 
-void WalletBackend::swapNode(std::string daemonHost, uint16_t daemonPort)
+void WalletBackend::swapNode(std::string daemonHost, uint16_t daemonPort, bool daemonSSL)
 {
     m_syncRAIIWrapper->pauseSynchronizerToRunFunction([&, this]() {
         /* Swap and init the node */
-        m_daemon->swapNode(daemonHost, daemonPort);
+        m_daemon->swapNode(daemonHost, daemonPort, daemonSSL);
 
         /* Give the synchronizer the new daemon */
         m_walletSynchronizer->swapNode(m_daemon);
@@ -1144,7 +1151,8 @@ Error WalletBackend::fromJSON(
     const std::string filename,
     const std::string password,
     const std::string daemonHost,
-    const uint16_t daemonPort)
+    const uint16_t daemonPort,
+    const bool daemonSSL)
 {
     if (Error error = fromJSON(j); error != SUCCESS)
     {
@@ -1154,7 +1162,7 @@ Error WalletBackend::fromJSON(
     m_filename = filename;
     m_password = password;
 
-    m_daemon = std::make_shared<Nigel>(daemonHost, daemonPort);
+    m_daemon = std::make_shared<Nigel>(daemonHost, daemonPort, daemonSSL);
 
     init();
 

--- a/src/WalletBackend/WalletBackend.h
+++ b/src/WalletBackend/WalletBackend.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2018, The TurtleCoin Developers
-// 
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -63,7 +63,8 @@ class WalletBackend
             const std::string password,
             const uint64_t scanHeight,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         /* Imports a wallet from a private spend key and a view key. Returns
            the wallet class, or an error. */
@@ -74,7 +75,8 @@ class WalletBackend
             const std::string password,
             const uint64_t scanHeight,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         /* Imports a view wallet from a private view key and an address.
            Returns the wallet class, or an error. */
@@ -85,21 +87,24 @@ class WalletBackend
             const std::string password,
             const uint64_t scanHeight,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         /* Creates a new wallet with the given filename and password */
         static std::tuple<Error, std::shared_ptr<WalletBackend>> createWallet(
             const std::string filename,
             const std::string password,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         /* Opens a wallet already on disk with the given filename + password */
         static std::tuple<Error, std::shared_ptr<WalletBackend>> openWallet(
             const std::string filename,
             const std::string password,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         /* Create an integrated address from an address + paymentID */
         static std::tuple<Error, std::string> createIntegratedAddress(
@@ -126,8 +131,9 @@ class WalletBackend
             const std::string filename,
             const std::string password,
             const std::string daemonHost,
-            const uint16_t daemonPort);
-        
+            const uint16_t daemonPort,
+            const bool daemonSSL);
+
         /* Send a transaction of amount to destination with paymentID */
         std::tuple<Error, Crypto::Hash> sendTransactionBasic(
             const std::string destination,
@@ -240,10 +246,10 @@ class WalletBackend
         std::tuple<uint64_t, std::string> getNodeFee() const;
 
         /* Returns the node host and port */
-        std::tuple<std::string, uint16_t> getNodeAddress() const;
+        std::tuple<std::string, uint16_t, bool> getNodeAddress() const;
 
         /* Swap to a different daemon node */
-        void swapNode(std::string daemonHost, uint16_t daemonPort);
+        void swapNode(std::string daemonHost, uint16_t daemonPort, bool daemonSSL);
 
         /* Whether we have recieved info from the daemon at some point */
         bool daemonOnline() const;
@@ -255,7 +261,7 @@ class WalletBackend
             const Crypto::Hash txHash) const;
 
         std::vector<std::tuple<std::string, uint64_t, uint64_t>> getBalances() const;
-        
+
         /////////////////////////////
         /* Public member variables */
         /////////////////////////////
@@ -277,7 +283,8 @@ class WalletBackend
             const uint64_t scanHeight,
             const bool newWallet,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         /* View wallet constructor */
         WalletBackend(
@@ -287,7 +294,8 @@ class WalletBackend
             const std::string address,
             const uint64_t scanHeight,
             const std::string daemonHost,
-            const uint16_t daemonPort);
+            const uint16_t daemonPort,
+            const bool daemonSSL);
 
         //////////////////////////////
         /* Private member functions */
@@ -328,7 +336,7 @@ class WalletBackend
            rather than having to throw() or check isInitialized() everywhere.
 
            More info here: https://stackoverflow.com/q/43203869/8737306
-           
+
            PS: I want to die */
         std::shared_ptr<WalletSynchronizer> m_walletSynchronizer;
 

--- a/src/zedwallet++/CommandImplementations.cpp
+++ b/src/zedwallet++/CommandImplementations.cpp
@@ -1,5 +1,4 @@
 // Copyright (c) 2018-2019, The TurtleCoin Developers
-// Copyright (c) 2018-2019, The Catalyst Developers
 // 
 // Please see the included LICENSE file for more information.
 
@@ -8,6 +7,7 @@
 ///////////////////////////////////////////////
 
 #include <config/WalletConfig.h>
+
 #include <config/CryptoNoteConfig.h>
 
 #include <Errors/ValidateParameters.h>
@@ -417,7 +417,7 @@ void printIncomingTransfer(const WalletTypes::Transaction tx)
     {
         stream << "Payment ID: " << tx.paymentID << "\n";
     }
-    
+
     /* Display Unlock time, if applicable; otherwise, don't */
     int64_t difference = tx.unlockTime - tx.blockHeight;
 
@@ -631,11 +631,11 @@ void advanced(const std::shared_ptr<WalletBackend> walletBackend)
 
 void swapNode(const std::shared_ptr<WalletBackend> walletBackend)
 {
-    const auto [host, port] = getDaemonAddress();
+    const auto [host, port, ssl] = getDaemonAddress();
 
     std::cout << InformationMsg("\nSwapping node, this may take some time...\n");
 
-    walletBackend->swapNode(host, port);
+    walletBackend->swapNode(host, port, ssl);
 
     std::cout << SuccessMsg("Node swap complete.\n\n");
 }

--- a/src/zedwallet++/GetInput.h
+++ b/src/zedwallet++/GetInput.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 // 
 // Please see the included LICENSE file for more information.
 
@@ -32,7 +32,7 @@ std::string getInput(
     const std::vector<T> &availableCommands,
     const std::string prompt);
 
-std::tuple<std::string, uint16_t> getDaemonAddress();
+std::tuple<std::string, uint16_t, bool> getDaemonAddress();
 
 std::string getHash(
     const std::string msg,

--- a/src/zedwallet++/Menu.cpp
+++ b/src/zedwallet++/Menu.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 // 
 // Please see the included LICENSE file for more information.
 
@@ -148,11 +148,11 @@ bool checkNodeStatus(const std::shared_ptr<WalletBackend> walletBackend)
         /* User wants to try a different node */
         else if (command == "swap_node")
         {
-            const auto [host, port] = getDaemonAddress();
+            const auto [host, port, ssl] = getDaemonAddress();
 
             std::cout << InformationMsg("\nSwapping node, this may take some time...\n");
 
-            walletBackend->swapNode(host, port);
+            walletBackend->swapNode(host, port, ssl);
 
             std::cout << SuccessMsg("Node swap complete.\n\n");
 

--- a/src/zedwallet++/Open.cpp
+++ b/src/zedwallet++/Open.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 // 
 // Please see the included LICENSE file for more information.
 
@@ -75,7 +75,7 @@ std::shared_ptr<WalletBackend> importViewWallet(const Config &config)
 
     auto [error, walletBackend] = WalletBackend::importViewWallet(
         privateViewKey, address, walletFileName, walletPass, scanHeight,
-        config.host, config.port
+        config.host, config.port, config.ssl
     );
 
     if (error)
@@ -118,7 +118,7 @@ std::shared_ptr<WalletBackend> importWalletFromKeys(const Config &config)
 
     const auto [error, walletBackend] = WalletBackend::importWalletFromKeys(
         privateSpendKey, privateViewKey, walletFileName, walletPass,
-        scanHeight, config.host, config.port
+        scanHeight, config.host, config.port, config.ssl
     );
 
     if (error)
@@ -175,7 +175,7 @@ std::shared_ptr<WalletBackend> importWalletFromSeed(const Config &config)
 
     auto [error, walletBackend] = WalletBackend::importWalletFromSeed(
         mnemonicSeed, walletFileName, walletPass, scanHeight,
-        config.host, config.port
+        config.host, config.port, config.ssl
     );
 
     if (error)
@@ -206,7 +206,7 @@ std::shared_ptr<WalletBackend> createWallet(const Config &config)
     const std::string walletPass = getWalletPassword(verifyPassword, msg);
 
     const auto [error, walletBackend] = WalletBackend::createWallet(
-        walletFileName, walletPass, config.host, config.port
+        walletFileName, walletPass, config.host, config.port, config.ssl
     );
 
     if (error)
@@ -252,7 +252,7 @@ std::shared_ptr<WalletBackend> openWallet(const Config &config)
         }
 
         const auto [error, walletBackend] = WalletBackend::openWallet(
-            walletFileName, walletPass, config.host, config.port
+            walletFileName, walletPass, config.host, config.port, config.ssl
         );
 
         if (error == WRONG_PASSWORD)

--- a/src/zedwallet++/ParseArguments.cpp
+++ b/src/zedwallet++/ParseArguments.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -36,7 +36,12 @@ Config parseArguments(int argc, char **argv)
 
     options.add_options("Daemon")
         ("r,remote-daemon", "The daemon <host:port> combination to use for node operations.",
-          cxxopts::value<std::string>(remoteDaemon)->default_value(defaultRemoteDaemon), "<host:port>");
+          cxxopts::value<std::string>(remoteDaemon)->default_value(defaultRemoteDaemon), "<host:port>")
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+        ("ssl", "Use SSL when connecting to the daemon.",
+          cxxopts::value<bool>(config.ssl)->default_value("false")->implicit_value("true"))
+#endif
+        ;
 
     options.add_options("Wallet")
         ("w,wallet-file", "Open the wallet <file>", cxxopts::value<std::string>(config.walletFile), "<file>")

--- a/src/zedwallet++/ParseArguments.h
+++ b/src/zedwallet++/ParseArguments.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -30,6 +30,9 @@ struct Config
 
     /* Controls what level of messages to log */
     Logger::LogLevel logLevel = Logger::DISABLED;
+    
+    /* Use SSL with daemon */
+    bool ssl = false;
 };
 
 Config parseArguments(int argc, char **argv);


### PR DESCRIPTION
Resolves #713 

Please see the updated build directions on how to enable SSL support. At this time, OpenSSL is linked against as a shared library. As such, I consider it an "advanced user" option as it decreases the portability of the binaries (in my testing at least).

I've done some testing of both zedwallet++ and wallet-api and everything appears to work correctly. Additional testing is appreciated.

The easiest way to enable SSL on a conventional daemon is to pass it through [ngrok](https://ngrok.com/) like so: `ngrok http 11898`

ngrok will then display both http and https (ssl) hostnames and will handle the encryption for you. Just remember that when you're connecting to the ngrok hostname to test SSL that you tell the wallets that the port is `443`.