### PR TITLE
Support Blockchain cache API in Nigel

### DIFF
--- a/include/CryptoNote.h
+++ b/include/CryptoNote.h
@@ -114,7 +114,10 @@ inline void to_json(nlohmann::json &j, const CryptoNote::KeyInput &k)
 inline void from_json(const nlohmann::json &j, CryptoNote::KeyInput &k)
 {
     k.amount = j.at("amount").get<uint64_t>();
-    k.outputIndexes = j.at("key_offsets").get<std::vector<uint32_t>>();
+    if (j.find("key_offsets") != j.end())
+    {
+        k.outputIndexes = j.at("key_offsets").get<std::vector<uint32_t>>();
+    }
     k.keyImage = j.at("k_image").get<Crypto::KeyImage>();
 }
 

--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2018, The TurtleCoin Developers
-// 
+//
 // Please see the included LICENSE file for more information.
 
 #pragma once
@@ -13,6 +13,7 @@
 
 #include <unordered_map>
 #include <optional>
+#include <sstream>
 
 namespace WalletTypes
 {
@@ -27,8 +28,8 @@ namespace WalletTypes
     };
 
     /* A coinbase transaction (i.e., a miner reward, there is one of these in
-       every block). Coinbase transactions have no inputs. 
-       
+       every block). Coinbase transactions have no inputs.
+
        We call this a raw transaction, because it is simply key images and
        amounts */
     struct RawCoinbaseTransaction
@@ -105,7 +106,7 @@ namespace WalletTypes
 
         /* The transaction key we took from the key outputs */
         Crypto::PublicKey key;
-        
+
         /* If spent, what height did we spend it at. Used to remove spent
            transaction inputs once they are sure to not be removed from a
            forked chain. */
@@ -309,8 +310,8 @@ namespace WalletTypes
             /* A map of public keys to amounts, since one transaction can go to
                multiple addresses. These can be positive or negative, for example
                one address might have sent 10,000 TRTL (-10000) to two recipients
-               (+5000), (+5000) 
-               
+               (+5000), (+5000)
+
                All the public keys in this map, are ones that the wallet container
                owns, it won't store amounts belonging to random people */
             std::unordered_map<Crypto::PublicKey, int64_t> transfers;
@@ -495,7 +496,20 @@ namespace WalletTypes
         r.keyOutputs = j.at("outputs").get<std::vector<KeyOutput>>();
         r.hash = j.at("hash").get<Crypto::Hash>();
         r.transactionPublicKey = j.at("txPublicKey").get<Crypto::PublicKey>();
-        r.unlockTime = j.at("unlockTime").get<uint64_t>();
+
+        /* We need to try to get the unlockTime from an integer in the json
+           however, if that fails because we're talking to a blockchain
+           cache API that encodes unlockTime as a string (due to json
+           integer encoding limits), we need to attempt this as a string */
+        try
+        {
+            r.unlockTime = j.at("unlockTime").get<uint64_t>();
+        }
+        catch (...)
+        {
+            std::istringstream unlockTime(j.at("unlockTime").get<std::string>());
+            unlockTime >> r.unlockTime;
+        }
     }
 
     inline void to_json(nlohmann::json &j, const RawTransaction &r)
@@ -515,7 +529,20 @@ namespace WalletTypes
         r.keyOutputs = j.at("outputs").get<std::vector<KeyOutput>>();
         r.hash = j.at("hash").get<Crypto::Hash>();
         r.transactionPublicKey = j.at("txPublicKey").get<Crypto::PublicKey>();
-        r.unlockTime = j.at("unlockTime").get<uint64_t>();
+
+        /* We need to try to get the unlockTime from an integer in the json
+           however, if that fails because we're talking to a blockchain
+           cache API that encodes unlockTime as a string (due to json
+           integer encoding limits), we need to attempt this as a string */
+        try
+        {
+            r.unlockTime = j.at("unlockTime").get<uint64_t>();
+        }
+        catch (...)
+        {
+            std::istringstream unlockTime(j.at("unlockTime").get<std::string>());
+            unlockTime >> r.unlockTime;
+        }
         r.paymentID = j.at("paymentID").get<std::string>();
         r.keyInputs = j.at("inputs").get<std::vector<CryptoNote::KeyInput>>();
     }
@@ -532,6 +559,15 @@ namespace WalletTypes
     {
         k.key = j.at("key").get<Crypto::PublicKey>();
         k.amount = j.at("amount").get<uint64_t>();
+
+        /* If we're talking to a daemon or blockchain cache
+           that returns the globalIndex as part of the structure
+           of a key output, then we need to load that into the
+           data structure. */
+        if (j.find("globalIndex") != j.end())
+        {
+            k.globalOutputIndex = j.at("globalIndex").get<uint64_t>();
+        }
     }
 
     inline void to_json(nlohmann::json &j, const UnconfirmedInput &u)

--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -13,7 +13,7 @@
 
 #include <unordered_map>
 #include <optional>
-#include <sstream>
+#include <string>
 
 namespace WalletTypes
 {
@@ -505,10 +505,9 @@ namespace WalletTypes
         {
             r.unlockTime = j.at("unlockTime").get<uint64_t>();
         }
-        catch (...)
+        catch (const nlohmann::json::exception &e)
         {
-            std::istringstream unlockTime(j.at("unlockTime").get<std::string>());
-            unlockTime >> r.unlockTime;
+            r.unlockTime = std::stoull(j.at("unlockTime").get<std::string>());
         }
     }
 
@@ -538,10 +537,9 @@ namespace WalletTypes
         {
             r.unlockTime = j.at("unlockTime").get<uint64_t>();
         }
-        catch (...)
+        catch (const nlohmann::json::exception &e)
         {
-            std::istringstream unlockTime(j.at("unlockTime").get<std::string>());
-            unlockTime >> r.unlockTime;
+            r.unlockTime = std::stoull(j.at("unlockTime").get<std::string>());
         }
         r.paymentID = j.at("paymentID").get<std::string>();
         r.keyInputs = j.at("inputs").get<std::vector<CryptoNote::KeyInput>>();

--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -80,6 +80,7 @@ void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort, co
     m_networkBlockCount = 0;
     m_peerCount = 0;
     m_lastKnownHashrate = 0;
+    m_isBlockchainCache = false;
 
     m_daemonHost = daemonHost;
     m_daemonPort = daemonPort;
@@ -203,6 +204,13 @@ bool Nigel::getDaemonInfo()
 
             m_lastKnownHashrate = j.at("difficulty").get<uint64_t>()
                                 / CryptoNote::parameters::DIFFICULTY_TARGET;
+
+            /* Look to see if the isCacheApi property exists in the response
+               and if so, set the internal value to whatever it found */
+            if (j.find("isCacheApi") != j.end())
+            {
+                m_isBlockchainCache = j.at("isCacheApi").get<bool>();
+            }
 
             return true;
         }

--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -108,19 +108,6 @@ std::tuple<bool, std::vector<WalletTypes::WalletBlockInfo>> Nigel::getWalletSync
         {"startTimestamp", startTimestamp}
     };
 
-    /* The blockchain cache does not support sending
-       both the startHeight and startTimestamp properties
-       and will kick a 500 error if we do. So, let's make sure
-       that we're only sending one of them */
-    if (m_isBlockchainCache && startHeight == 0)
-    {
-        j.erase("startHeight");
-    }
-    else if (m_isBlockchainCache && startTimestamp == 0)
-    {
-        j.erase("startTimestamp");
-    }
-
     auto res = m_nodeClient->Post(
         "/getwalletsyncdata", j.dump(), "application/json"
     );

--- a/src/Nigel/Nigel.h
+++ b/src/Nigel/Nigel.h
@@ -127,6 +127,10 @@ class Nigel
         /* The hashrate (based on the last local block the daemon has synced) */
         std::atomic<uint64_t> m_lastKnownHashrate = 0;
 
+        /* Whether the daemon is a blockchain cache API
+           see: https://github.com/TurtlePay/blockchain-cache-api */
+        std::atomic<bool> m_isBlockchainCache = false;
+
         /* The address to send the node fee to (May be "") */
         std::string m_nodeFeeAddress;
 


### PR DESCRIPTION
Resolves #712

To test non-ssl, you can sync against: `node.trtlpay.com:80`
To test SSL (when built with SSL), you can sync against: `blockapi.turtlepay.io:443`

**Bonus:** It auto-detects if it's a blockchain cache so a user doesn't have to do anything special