### PR TITLE
Wallet Synchronization Back-off Mechanism

### DIFF
--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -76,6 +76,7 @@ void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort, co
 {
     stop();
 
+    m_blockCount = CryptoNote::BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
     m_localDaemonBlockCount = 0;
     m_networkBlockCount = 0;
     m_peerCount = 0;
@@ -89,6 +90,19 @@ void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort, co
     m_nodeClient = getClient(m_daemonHost, m_daemonPort, m_daemonSSL, m_timeout);
 
     init();
+}
+
+void Nigel::decreaseRequestedBlockCount()
+{
+    if (m_blockCount > 1)
+    {
+        m_blockCount = m_blockCount / 2;
+    }
+}
+
+void Nigel::resetRequestedBlockCount()
+{
+    m_blockCount = CryptoNote::BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
 }
 
 std::tuple<bool, std::vector<WalletTypes::WalletBlockInfo>> Nigel::getWalletSyncData(
@@ -105,7 +119,8 @@ std::tuple<bool, std::vector<WalletTypes::WalletBlockInfo>> Nigel::getWalletSync
     json j = {
         {"blockHashCheckpoints", blockHashCheckpoints},
         {"startHeight", startHeight},
-        {"startTimestamp", startTimestamp}
+        {"startTimestamp", startTimestamp},
+        {"blockCount", m_blockCount.load()}
     };
 
     auto res = m_nodeClient->Post(

--- a/src/Nigel/Nigel.h
+++ b/src/Nigel/Nigel.h
@@ -10,6 +10,8 @@
 
 #include <Rpc/CoreRpcServerCommandsDefinitions.h>
 
+#include <config/CryptoNoteConfig.h>
+
 #include <string>
 
 #include <thread>
@@ -46,6 +48,10 @@ class Nigel
         void init();
 
         void swapNode(const std::string daemonHost, const uint16_t daemonPort, const bool daemonSSL);
+
+        void decreaseRequestedBlockCount();
+
+        void resetRequestedBlockCount();
 
         /* Returns whether we've received info from the daemon at some point */
         bool isOnline() const;
@@ -114,6 +120,9 @@ class Nigel
 
         /* If we should stop the background thread */
         std::atomic<bool> m_shouldStop = false;
+
+        /* Stores how many blocks we'll try to sync */
+        std::atomic<uint64_t> m_blockCount = CryptoNote::BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
 
         /* The amount of blocks the daemon we're connected to has */
         std::atomic<uint64_t> m_localDaemonBlockCount = 0;


### PR DESCRIPTION
Implemented a back-off mechanism that cuts the number of blocks requested in half during sync operations if something fails. Once it passes, it moves back up to full power again.