### PR TITLE
Turns on Static OpenSSL Linkage by Default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ before_build:
 build_script:
   - md build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" ..
+  - cmake -G "Visual Studio 15 2017 Win64" .. -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64
   - MSBuild TurtleCoin.sln /p:CLToolExe=clcache.exe /p:CLToolPath=c:\Python37\Scripts\ /p:Configuration=Release /m
   - src\Release\cryptotest.exe
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: cpp
-cache: ccache
+cache:
+ ccache: true
+ directories:
+    - /home/travis/toolchain
+
 matrix:
   include:
 
@@ -11,8 +15,9 @@ matrix:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-        packages: 
+        packages:
           - libboost1.55-all-dev
+          - libssl-dev
           - g++-8
           - gcc-8
     env:
@@ -28,8 +33,9 @@ matrix:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-        packages: 
+        packages:
           - libboost1.55-all-dev
+          - libssl-dev
           - g++-7
           - gcc-7
     env:
@@ -45,8 +51,9 @@ matrix:
         sources:
         - ubuntu-toolchain-r-test
         - llvm-toolchain-trusty-6.0
-        packages: 
+        packages:
           - libboost1.55-all-dev
+          - libssl-dev
           - clang-6.0
           - libstdc++-7-dev
     env:
@@ -97,8 +104,13 @@ install:
 # Need to uninstall oclint to get newer gcc installed https://github.com/travis-ci/travis-ci/issues/8826
 - if [[ "${LABEL:0:3}" == "osx" ]]; then brew cask uninstall --force oclint || true ; fi
 
-# Need a newer version of llvm to link against to get std::filesystem / std::experimental::filesystem 
+# Need a newer version of llvm to link against to get std::filesystem / std::experimental::filesystem
 - if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew install llvm || travis_retry brew upgrade llvm ; fi
+
+# Need to make sure that we have openssl installed
+- if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew install openssl || travis_retry brew upgrade openssl ; fi
+- if [[ "${LABEL:0:3}" == "osx" ]]; then brew link --force openssl ; fi
+- if [[ "${LABEL:0:3}" == "osx" ]]; then ln -s /usr/local/opt/openssl/include/openssl /usr/local/include ; fi
 
 # Neeed to install ccache
 - if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew install ccache ; fi
@@ -108,27 +120,13 @@ install:
 - if [[ "$LABEL" == "osx-g++-8" ]]; then travis_retry brew install gcc@8 ; fi
 - if [[ "$LABEL" == "osx-g++-7" ]]; then travis_retry brew install gcc@7 ; fi
 
-- if [[ "$LABEL" == "aarch64" ]]; then export BASEDIR=`pwd` ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then cd $HOME ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then mkdir toolchain && cd toolchain ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then tar xfv ../gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz >/dev/null ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then cd gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then tar zxvf ../../boost_1_55_0.tar.gz >/dev/null ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then cd boost_1_55_0 ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then ./bootstrap.sh ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then curl https://raw.githubusercontent.com/turtlecoin/turtlecoin/development/scripts/fix_boost_aarch64.sh | sh ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then ./b2 toolset=gcc-aarch64 --with-system --with-filesystem --with-thread --with-date_time --with-chrono --with-regex --with-serialization --with-program_options >/dev/null; fi
-- if [[ "$LABEL" == "aarch64" ]]; then export CUSTOM_BOOST_ROOT="-DBOOST_ROOT=`pwd`" ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then export CUSTOM_TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=../scripts/cross-aarch64.cmake" ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then export STRIP="$HOME/toolchain/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-strip" ; fi
-- if [[ "$LABEL" == "aarch64" ]]; then cd $BASEDIR ; fi
-
 script:
 - eval $MATRIX_EVAL
+# If we're cross compiling aarch64, make sure our build enivornment is setup
+# we do this in the script stage because this happens after the repo is cloned
+- if [[ "$LABEL" == "aarch64" ]]; then source scripts/prep-aarch64.sh ; fi
 - mkdir build && cd build
-- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true .. ${CUSTOM_TOOLCHAIN} ${CUSTOM_BOOST_ROOT} ${ADDITIONAL_CMAKE_ARGS}
+- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true ..
 - make -j2
 - if [[ "$LABEL" != "aarch64" ]]; then ./src/cryptotest ; fi
 
@@ -137,7 +135,7 @@ before_deploy:
 - cd src
 - TARGETS="TurtleCoind miner zedwallet turtle-service zedwallet-beta cryptotest wallet-api"
 - ${STRIP} ${TARGETS}
-- rm -rf turtlecoin-${TRAVIS_TAG} 
+- rm -rf turtlecoin-${TRAVIS_TAG}
 - mkdir turtlecoin-${TRAVIS_TAG}
 - cp ${TARGETS} turtlecoin-${TRAVIS_TAG}/
 - cp ../../LICENSE turtlecoin-${TRAVIS_TAG}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,6 @@ find_package(Threads)
 
 set(VERSION "0.1")
 
-## This section describes build options for additional support in the project
-set(ENABLE_SSL OFF CACHE STRING "Enable SSL support")
-
 ## This section describes our general CMake setup options
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo Release CACHE TYPE INTERNAL)
@@ -256,19 +253,43 @@ elseif(NOT MSVC)
   set(Boost_LIBRARIES "${Boost_LIBRARIES};rt")
 endif()
 
-## Go get us some OpenSSL libraries if we need to
-if(ENABLE_SSL)
-  set(OPENSSL_USE_STATIC_LIBS OFF)
-  find_package(OpenSSL)
-  if(OPENSSL_FOUND)
-    include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
-    add_definitions(-DCPPHTTPLIB_OPENSSL_SUPPORT)
-    message(STATUS "OpenSSL Found: ${OPENSSL_INCLUDE_DIR}")
-    message(STATUS "OpenSSL Libraries: ${OPENSSL_LIBRARIES}")
-  else()
-    message(STATUS "OpenSSL Found: No... Skipping...")
+## Let's see if we have any OpenSSL static libraries available
+set(OPENSSL_USE_STATIC_LIBS ON)
+## On MSVC, we need to link the RT/MT libraries
+if(MSVC)
+  set(OPENSSL_MSVC_STATIC_RT ON)
+endif()
+
+# We have to look for Homebrew OpenSSL a bit differently
+# Borrowed from https://github.com/tarantool/tarantool/commit/6eab201af1843f53a833c8928dc58fceffa08147
+if(APPLE)
+  find_program(HOMEBREW_EXECUTABLE brew)
+  execute_process(COMMAND ${HOMEBREW_EXECUTABLE} --prefix openssl
+                  OUTPUT_VARIABLE HOMEBREW_OPENSSL
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (DEFINED HOMEBREW_OPENSSL)
+    if (NOT DEFINED OPENSSL_ROOT_DIR)
+        message(STATUS "Setting OpenSSL root to ${HOMEBREW_OPENSSL}")
+        set(OPENSSL_ROOT_DIR "${HOMEBREW_OPENSSL}")
+    endif()
   endif()
-endif(ENABLE_SSL)
+endif()
+
+find_package(OpenSSL)
+
+if(OPENSSL_FOUND)
+  ## On non MSVC build systems, we need to link ldl with the static OpenSSL library
+  if (NOT MSVC)
+    set(OPENSSL_LIBRARIES "${OPENSSL_LIBRARIES};dl")
+  endif()
+
+  include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
+  add_definitions(-DCPPHTTPLIB_OPENSSL_SUPPORT)
+  message(STATUS "OpenSSL Found: ${OPENSSL_INCLUDE_DIR}")
+  message(STATUS "OpenSSL Libraries: ${OPENSSL_LIBRARIES}")
+else()
+  message(STATUS "OpenSSL Found: No... Skipping...")
+endif()
 
 add_subdirectory(external)
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -14,21 +14,11 @@ If you would like to compile yourself, read on.
 
 ### How To Compile
 
-#### OpenSSL Support
-
-Both zedwallet++ (zedwallet-beta) and wallet-api now support connecting to a node using SSL. To enable it during compilation, you will need to pass `-DENABLE_SSL=1` in the any of the CMake commands below.
-
-**Note:** If you compile with SSL support, it will link OpenSSL as a shared library.
-
-If you enable SSL support but OpenSSL is not found on your system, you can tell CMake where it is located with the `-DOPENSSL_ROOT_DIR=<path>` option.
-
-Ex. `-DOPENSSL_ROOT_DIR=/usr/lib/openssl` or `-DOPENSSL_ROOT_DIR=C:/OpenSSL-Win64/include`
-
 #### Linux
 
 ##### Prerequisites
 
-You will need the following packages: boost, cmake (3.8 or higher), make, and git.
+You will need the following packages: [Boost](https://www.boost.org/), [OpenSSL](https://www.openssl.org/), cmake (3.8 or higher), make, and git.
 
 You will also need either GCC/G++, or Clang.
 
@@ -41,7 +31,7 @@ If you are using Clang, you will need Clang 6.0 or higher. You will also need li
 - `sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y`
 - `sudo apt-get update`
 - `sudo apt-get install aptitude -y`
-- `sudo aptitude install -y build-essential g++-8 gcc-8 git libboost-all-dev python-pip`
+- `sudo aptitude install -y build-essential g++-8 gcc-8 git libboost-all-dev python-pip libssl-dev`
 - `sudo pip install cmake`
 - `export CC=gcc-8`
 - `export CXX=g++-8`
@@ -75,7 +65,7 @@ You need to modify the below command for your version of ubuntu - see https://ap
 
 - `sudo apt-get update`
 - `sudo apt-get install aptitude -y`
-- `sudo aptitude install -y -o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals' build-essential clang-6.0 libstdc++-7-dev git libboost-all-dev python-pip`
+- `sudo aptitude install -y -o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals' build-essential clang-6.0 libstdc++-7-dev git libboost-all-dev python-pip libssl-dev`
 - `sudo pip install cmake`
 - `export CC=clang-6.0`
 - `export CXX=clang++-6.0`
@@ -119,7 +109,7 @@ The binaries will be in the `src` folder when you are complete.
 ##### Building
 
 - `which brew || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-- `brew install --force cmake boost llvm gcc@8`
+- `brew install --force cmake boost llvm gcc@8 openssl`
 - `export CC=gcc-8`
 - `export CXX=g++-8`
 - `git clone -b master --single-branch https://github.com/turtlecoin/turtlecoin`
@@ -143,7 +133,7 @@ The binaries will be in the `src` folder when you are complete.
 ##### Building
 
 - `which brew || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-- `brew install --force cmake boost llvm`
+- `brew install --force cmake boost llvm openssl`
 - `export CC=/usr/local/opt/llvm/bin/clang`
 - `export CXX=/usr/local/opt/llvm/bin/clang++`
 - `git clone -b master --single-branch https://github.com/turtlecoin/turtlecoin`
@@ -166,6 +156,7 @@ The binaries will be in the `src` folder when you are complete.
 - Install [Visual Studio 2017 Community Edition](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&page=inlineinstall)
 - When installing Visual Studio, it is **required** that you install **Desktop development with C++**
 - Install the latest version of [Boost](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-64.exe) - Currently Boost 1.68.
+- Install the latest full version of [OpenSSL](https://slproweb.com/download/Win64OpenSSL-1_1_1b.exe) - Currently v1.1.1b
 
 ##### Building
 

--- a/scripts/fix_boost_aarch64.sh
+++ b/scripts/fix_boost_aarch64.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# This file is meant to be ran during the BOOST build process using a 
-# cross-compile toolchain for AARCH64
-
-echo "Setting up user compiler gcc-aarch64: ${HOME}/toolchain/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-g++"
-echo "using gcc : aarch64 : ${HOME}/toolchain/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-g++ ; " >> tools/build/v2/user-config.jam

--- a/scripts/prep-aarch64.sh
+++ b/scripts/prep-aarch64.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright (c) 2019 The TurtleCoin Developers
+#
+# Please see the included LICENSE file for more information.
+
+#
+# This script is used to set up the cross-compilation environment
+# for building aarch64 on x64_64 systems which provides a very
+# fast build experience for the aarch64 platform at this time
+#
+
+# Save our current working location so that we can return here
+# when we are ready
+export BASEDIR=`pwd`
+
+# Set our toolchain folder
+export TOOLCHAIN_DIR=$HOME/toolchain
+
+# Make and change to a toolchain directory for storage of all
+# tools that we will use as part of the build process
+mkdir -p $TOOLCHAIN_DIR && cd $TOOLCHAIN_DIR
+
+# Check to see if we have the aarch64 compiler, if not download
+# the prebuilt binaries from a trusted source
+echo -n "Checking for aarch64-linux-gnu-gcc... "
+if [ ! -f $TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc ]; then
+  echo "Not found... Installing..."
+  wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz
+  tar xfv gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz >/dev/null
+  echo "aarch64-linux-gnu-gcc: Installed"
+else
+  echo "Found"
+fi
+
+# Set our environment variables to use the aarch64 compiler
+export CC=$TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+export CXX=$TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-g++
+export RANLIB=$TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-ranlib
+export LD=$TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-ld
+export MAKEDEPPROG=$TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+export CUSTOM_TOOLCHAIN_FILE=../scripts/cross-aarch64.cmake
+
+# Check to see if we have Boost 1.55 ready in our toolchain, if
+# not we'll download and build it
+echo -n "Checking for Boost 1.55... "
+if [ ! -f $TOOLCHAIN_DIR/boost_1_55_0/stage/lib/libboost_system.a ]; then
+  echo "Not found... Installing..."
+  wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz
+  tar zxvf boost_1_55_0.tar.gz >/dev/null
+  cd boost_1_55_0
+  echo -n "Bootstrapping Boost 1.55 build... "
+  ./bootstrap.sh > /dev/null
+  echo "Complete"
+  echo "using gcc : aarch64 : ${TOOLCHAIN_DIR}/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-g++ ; " >> tools/build/v2/user-config.jam
+  echo -n "Building Boost 1.55... "
+  ./b2 toolset=gcc-aarch64 --with-system --with-filesystem --with-thread --with-date_time --with-chrono --with-regex --with-serialization --with-program_options >/dev/null
+  cd $TOOLCHAIN_DIR
+  echo "Complete"
+else
+  echo "Found"
+fi
+
+# Set our environment variable to use the new Boost root
+export BOOST_ROOT=$TOOLCHAIN_DIR/boost_1_55_0
+
+# Check to see if we have OpenSSL ready in our toolchain, if
+# not we'll download and build it
+echo -n "Checking for OpenSSL 1.0.2r..."
+if [ ! -f $TOOLCHAIN_DIR/openssl/lib/libcrypto.a ]; then
+  echo "Not found... Installing..."
+  wget https://www.openssl.org/source/openssl-1.0.2r.tar.gz
+  tar zxvf openssl-1.0.2r.tar.gz >/dev/null
+  cd openssl-1.0.2r
+  ./Configure linux-aarch64 --prefix=$TOOLCHAIN_DIR/openssl --openssldir=$TOOLCHAIN_DIR/openssl >/dev/null
+  echo -n "Building OpenSSL 1.0.2r... "
+  make PROCESSOR=ARM install >/dev/null
+  echo "Complete"
+else
+  echo "Found"
+fi
+
+# Set our environment variable to use the new OpenSSL root
+export OPENSSL_ROOT_DIR=$TOOLCHAIN_DIR/openssl
+
+# Set an environment variable that contains our custom CMake toolchain
+# commands for our project and other env vars that we'll need
+export STRIP=$TOOLCHAIN_DIR/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-strip
+
+# Return to the path we started at
+cd $BASEDIR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,9 @@ if(MSVC)
     target_link_libraries(System ws2_32)
     target_link_libraries(TurtleCoind Rpcrt4)
     target_link_libraries(service Rpcrt4)
+    target_link_libraries(zedwallet++ ws2_32 advapi32 crypt32 gdi32 user32)
+    target_link_libraries(WalletApi ws2_32 advapi32 crypt32 gdi32 user32)
+    target_link_libraries(miner ws2_32 advapi32 crypt32 gdi32 user32)
 endif ()
 
 # A bit of hackery so we don't have to do the if/else/ for every target that


### PR DESCRIPTION
* OpenSSL now statically linked during build process
* Turns on checking for OpenSSL during all builds
  * If not found, continues to build anyways without SSL features
* Travis & AppVeyor now build with OpenSSL
* Clean up to AARCH64 Travis build process
  * Pulled out the preparation steps into a separate script
* Added AARCH64 built dependencies to the Travis-CI cache
* Updated build directions