### PR TITLE
WalletBackend Scan Height Allowance

### DIFF
--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -208,19 +208,30 @@ std::vector<WalletTypes::WalletBlockInfo> WalletSynchronizer::downloadBlocks()
     /* If checkpoints are empty, this is the first sync request. */
     if (blockCheckpoints.empty())
     {
-        const uint64_t actualHeight = blocks.front().blockHeight;
-
         /* Only check if a timestamp isn't given */
         if (m_startTimestamp == 0)
         {
-            /* The height we expect to get back from the daemon */
-            if (actualHeight != m_startHeight)
+            bool startHeightFoundInRange = false;
+
+            /* Loop through the blocks we got back and make sure that
+               we were given data for the start block we were looking for */
+            for (const auto &block : blocks)
+            {
+              if (block.blockHeight == m_startHeight)
+              {
+                startHeightFoundInRange = true;
+              }
+            }
+
+            /* If we weren't given a block with the startHeight we were
+               looking for then we don't need to store this data */
+            if (!startHeightFoundInRange)
             {
                 std::stringstream stream;
 
                 stream << "Received unexpected block height from daemon. "
-                       << "Expected " << m_startHeight << ", got "
-                       << actualHeight << ". Not returning any blocks.";
+                       << "Expected " << m_startHeight << ", but did not "
+                       "receive that block. Not returning any blocks.";
 
                 Logger::logger.log(
                     stream.str(),

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -211,21 +211,15 @@ std::vector<WalletTypes::WalletBlockInfo> WalletSynchronizer::downloadBlocks()
         /* Only check if a timestamp isn't given */
         if (m_startTimestamp == 0)
         {
-            bool startHeightFoundInRange = false;
-
             /* Loop through the blocks we got back and make sure that
                we were given data for the start block we were looking for */
-            for (const auto &block : blocks)
-            {
-              if (block.blockHeight == m_startHeight)
-              {
-                startHeightFoundInRange = true;
-              }
-            }
+            const auto it = std::find_if(blocks.begin(), blocks.end(), [this](const auto &block) {
+                return block.blockHeight == m_startHeight;
+            });
 
             /* If we weren't given a block with the startHeight we were
                looking for then we don't need to store this data */
-            if (!startHeightFoundInRange)
+            if (it == blocks.end())
             {
                 std::stringstream stream;
 


### PR DESCRIPTION
Allow the daemon/cache to return blocks prior to the one requested as long as the response contains the block we're looking for