### PR TITLE
daemon add --p2p-reset-peerstate option

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The Karai Developers
 // Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -312,7 +313,7 @@ int main(int argc, char* argv[])
     netNodeConfig.init(config.p2pInterface, config.p2pPort, config.p2pExternalPort, config.localIp,
       config.hideMyPort, config.dataDirectory, config.peers,
       config.exclusiveNodes, config.priorityNodes,
-      config.seedNodes);
+      config.seedNodes, config.p2pResetPeerstate);
 
     if (!Tools::create_directories_if_necessary(dbConfig.getDataDir()))
     {

--- a/src/Daemon/DaemonConfiguration.cpp
+++ b/src/Daemon/DaemonConfiguration.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -71,6 +72,7 @@ namespace DaemonConfig{
       ("p2p-bind-ip", "Interface IP address for the P2P service", cxxopts::value<std::string>()->default_value(config.p2pInterface), "<ip>")
       ("p2p-bind-port", "TCP port for the P2P service", cxxopts::value<int>()->default_value(std::to_string(config.p2pPort)), "#")
       ("p2p-external-port", "External TCP port for the P2P service (NAT port forward)", cxxopts::value<int>()->default_value("0"), "#")
+      ("p2p-reset-peerstate", "Generate a new peer ID and remove known peers saved previously", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
       ("rpc-bind-ip", "Interface IP address for the RPC service", cxxopts::value<std::string>()->default_value(config.rpcInterface), "<ip>")
       ("rpc-bind-port", "TCP port for the RPC service", cxxopts::value<int>()->default_value(std::to_string(config.rpcPort)), "#");
 
@@ -229,6 +231,11 @@ namespace DaemonConfig{
       if (cli.count("p2p-external-port") > 0)
       {
         config.p2pExternalPort = cli["p2p-external-port"].as<int>();
+      }
+
+      if (cli.count("p2p-reset-peerstate") > 0)
+      {
+        config.p2pResetPeerstate = cli["p2p-reset-peerstate"].as<bool>();
       }
 
       if (cli.count("rpc-bind-ip") > 0)
@@ -494,6 +501,11 @@ namespace DaemonConfig{
             throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey );
           }
         }
+        else if (cfgKey.compare("p2p-reset-peerstate") == 0)
+        {
+          config.p2pResetPeerstate =  cfgValue.at(0) == '1' ? true : false;
+          updated = true;
+        }
         else if (cfgKey.compare("add-exclusive-node") == 0)
         {
 
@@ -678,6 +690,11 @@ namespace DaemonConfig{
       config.p2pExternalPort = j["p2p-external-port"].GetInt();
     }
 
+    if (j.HasMember("p2p-reset-peerstate"))
+    {
+      config.p2pResetPeerstate = j["p2p-reset-peerstate"].GetBool();
+    }
+    
     if (j.HasMember("rpc-bind-ip"))
     {
       config.rpcInterface = j["rpc-bind-ip"].GetString();
@@ -772,6 +789,7 @@ namespace DaemonConfig{
     j.AddMember("p2p-bind-ip", config.p2pInterface, alloc);
     j.AddMember("p2p-bind-port", config.p2pPort, alloc);
     j.AddMember("p2p-external-port", config.p2pExternalPort, alloc);
+    j.AddMember("p2p-reset-peerstate", config.p2pResetPeerstate, alloc);
     j.AddMember("rpc-bind-ip", config.rpcInterface, alloc);
     j.AddMember("rpc-bind-port", config.rpcPort, alloc);
 

--- a/src/Daemon/DaemonConfiguration.h
+++ b/src/Daemon/DaemonConfiguration.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -38,6 +39,7 @@ namespace DaemonConfig {
       enableBlockExplorer = false;
       localIp = false;
       hideMyPort = false;
+      p2pResetPeerstate = false;
       help = false;
       version = false;
       osVersion = false;
@@ -79,6 +81,7 @@ namespace DaemonConfig {
     bool localIp;
     bool hideMyPort;
     bool resync;
+    bool p2pResetPeerstate;
 
     std::string configFile;
     std::string outputFile;

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
 // Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -249,7 +250,14 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
 
       try {
         std::ifstream p2p_data;
-        p2p_data.open(state_file_path, std::ios_base::binary | std::ios_base::in);
+
+        std::ios_base::openmode open_mode = std::ios_base::binary | std::ios_base::in;
+        /* --p2p-reset-peerstate daemon option 
+          Truncates the file if want the peer state reset */
+        if(m_p2p_state_reset) {
+          open_mode |= std::ios_base::trunc;
+        }
+        p2p_data.open(state_file_path, open_mode);
 
         if (!p2p_data.fail()) {
           StdInputStream inputStream(p2p_data);
@@ -386,6 +394,7 @@ std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
     }
     m_config_folder = config.getConfigFolder();
     m_p2p_state_filename = config.getP2pStateFilename();
+    m_p2p_state_reset = config.getP2pStateReset();
 
     if (!init_config()) {
       logger(ERROR, BRIGHT_RED) << "Failed to init config.";

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -223,6 +224,7 @@ namespace CryptoNote
     bool m_allow_local_ip;
     bool m_hide_my_port;
     std::string m_p2p_state_filename;
+    bool m_p2p_state_reset;
 
     System::Dispatcher& m_dispatcher;
     System::ContextGroup m_workingContextGroup;

--- a/src/P2p/NetNodeConfig.cpp
+++ b/src/P2p/NetNodeConfig.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -57,12 +58,13 @@ NetNodeConfig::NetNodeConfig() {
   hideMyPort = false;
   configFolder = Tools::getDefaultDataDirectory();
   testnet = false;
+  p2pStateReset = false;
 }
 
 bool NetNodeConfig::init(const std::string interface, const int port, const int external, const bool localIp,
                           const bool hidePort, const std::string dataDir, const std::vector<std::string> addPeers,
                           const std::vector<std::string> addExclusiveNodes, const std::vector<std::string> addPriorityNodes,
-                          const std::vector<std::string> addSeedNodes)
+                          const std::vector<std::string> addSeedNodes, const bool p2pResetPeerState)
 {
   bindIp = interface;
   bindPort = port;
@@ -71,6 +73,7 @@ bool NetNodeConfig::init(const std::string interface, const int port, const int 
   hideMyPort = hidePort;
   configFolder = dataDir;
   p2pStateFilename = CryptoNote::parameters::P2P_NET_DATA_FILENAME;
+  p2pStateReset = p2pResetPeerState;
 
   if (!addPeers.empty())
   {
@@ -117,6 +120,10 @@ std::string NetNodeConfig::getP2pStateFilename() const {
 
 bool NetNodeConfig::getTestnet() const {
   return testnet;
+}
+
+bool NetNodeConfig::getP2pStateReset() const {
+  return p2pStateReset;
 }
 
 std::string NetNodeConfig::getBindIp() const {

--- a/src/P2p/NetNodeConfig.h
+++ b/src/P2p/NetNodeConfig.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2019, The CyprusCoin Developers
 //
 // Please see the included LICENSE file for more information.
 
@@ -19,10 +20,11 @@ public:
   bool init(const std::string interface, const int port, const int external, const bool localIp,
               const bool hidePort, const std::string dataDir, const std::vector<std::string> addPeers,
               const std::vector<std::string> addExclusiveNodes, const std::vector<std::string> addPriorityNodes,
-              const std::vector<std::string> addSeedNodes);
+              const std::vector<std::string> addSeedNodes, const bool p2pResetPeerState);
 
   std::string getP2pStateFilename() const;
   bool getTestnet() const;
+  bool getP2pStateReset() const;
   std::string getBindIp() const;
   uint16_t getBindPort() const;
   uint16_t getExternalPort() const;
@@ -47,6 +49,7 @@ private:
   std::string configFolder;
   std::string p2pStateFilename;
   bool testnet;
+  bool p2pStateReset;
 };
 
 } //namespace nodetool


### PR DESCRIPTION
able to control clearing p2p state via config.
saves having to figure out a script to remove 
the p2pstate.bin file before starting daemon.
needed for clean container images