### PR TITLE
enable 32-bit builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,11 +93,6 @@ if(DEFINED ENV{LABEL})
   message(STATUS "Found LABEL: ${LABEL}")
 endif()
 
-# We do not support 32-bit builds. When and if we do, this can be removed.
-if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-  message(FATAL_ERROR "Targeting a 32-bit architecture is not supported.")
-endif()
-
 ## We only build static binaries -- this is left here for our dependencies
 set(STATIC ON CACHE BOOL FORCE "Link libraries statically? Forced to ON")
 
@@ -188,6 +183,8 @@ if(NOT MSVC)
     set(CRYPTOPP_AARCH64 ON CACHE BOOL FORCE "Tell CryptoPP that we are building for aarch64")
   elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64" AND NOT "${LABEL}" STREQUAL "aarch64")
     set(MAES_FLAG "-maes")
+  else()
+    set(MAES_FLAG "")
   endif()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 ${STATICASSERTC_FLAG} ${WARNINGS} ${C_WARNINGS} ${ARCH_FLAG} ${MAES_FLAG}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ${STATICASSERTCPP_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${ARCH_FLAG} ${MAES_FLAG}")

--- a/README.md
+++ b/README.md
@@ -153,12 +153,14 @@ The binaries will be in the `src` folder when you are complete.
 
 ##### Prerequisites
 
+You can build for 32-bit or 64-bit Windows. **If you're not sure, pick 64-bit.**
+
 - Install [Visual Studio 2017 Community Edition](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&page=inlineinstall)
 - When installing Visual Studio, it is **required** that you install **Desktop development with C++**
-- Install the latest version of Boost (currently Boost 1.68). Select **one or both** of the following:
+- Install the latest version of Boost (currently Boost 1.68). Select the appropriate version for your system:
   - [Boost 64-bit](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-64.exe)
   - [Boost 32-bit](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-32.exe)
-- Install the latest full version of OpenSSL (currently OpenSSL 1.1.1b). Select **one** of the following:
+- Install the latest full version of OpenSSL (currently OpenSSL 1.1.1b). Select the appropriate version for your system:
   - [OpenSSL 64-bit](https://slproweb.com/download/Win64OpenSSL-1_1_1b.exe)
   - [OpenSSL 32-bit](https://slproweb.com/download/Win32OpenSSL-1_1_1b.exe)
 

--- a/README.md
+++ b/README.md
@@ -155,11 +155,16 @@ The binaries will be in the `src` folder when you are complete.
 
 - Install [Visual Studio 2017 Community Edition](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&page=inlineinstall)
 - When installing Visual Studio, it is **required** that you install **Desktop development with C++**
-- Install the latest version of [Boost](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-64.exe) - Currently Boost 1.68.
-- Install the latest full version of [OpenSSL](https://slproweb.com/download/Win64OpenSSL-1_1_1b.exe) - Currently v1.1.1b
+- Install the latest version of Boost (currently Boost 1.68). Select **one or both** of the following:
+  - [Boost 64-bit](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-64.exe)
+  - [Boost 32-bit](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-32.exe)
+- Install the latest full version of OpenSSL (currently OpenSSL 1.1.1b). Select **one** of the following:
+  - [OpenSSL 64-bit](https://slproweb.com/download/Win64OpenSSL-1_1_1b.exe)
+  - [OpenSSL 32-bit](https://slproweb.com/download/Win32OpenSSL-1_1_1b.exe)
 
 ##### Building
 
+For 64-bit:
 - From the start menu, open 'x64 Native Tools Command Prompt for vs2017'.
 - `cd <your_turtlecoin_directory>`
 - `mkdir build`
@@ -168,36 +173,20 @@ The binaries will be in the `src` folder when you are complete.
 - `cmake -G "Visual Studio 15 2017 Win64" .. -DBOOST_ROOT=C:/local/boost_1_68_0`
 - `MSBuild TurtleCoin.sln /p:Configuration=Release /m`
 
+For 32-bit:
+- From the start menu, open 'x86 Native Tools Command Prompt for vs2017'.
+- `cd <your_turtlecoin_directory>`
+- `mkdir build`
+- `cd build`
+- `set PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin";%PATH%`
+- `cmake -G "Visual Studio 15 2017" .. -DBOOST_ROOT=C:/local/boost_1_68_0`
+- `MSBuild TurtleCoin.sln /p:Configuration=Release /p:Platform=Win32 /m`
+
 The binaries will be in the `src/Release` folder when you are complete.
 
 - `cd src`
 - `cd Release`
 - `TurtleCoind.exe --version`
-
-#### Raspberry Pi 3 B+ (AARCH64/ARM64)
-The following images are known to work. Your operation system image **MUST** be 64 bit.
-
-##### Known working images
-
-- https://github.com/Crazyhead90/pi64/releases
-- https://fedoraproject.org/wiki/Architectures/ARM/Raspberry_Pi#aarch64_supported_images_for_Raspberry_Pi_3
-- https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-3
-
-Once you have a 64 bit image installed, setup proceeds the same as any Linux distribution. Ensure you have at least 2GB of ram, or the build is likely to fail. You may need to setup swap space.
-
-##### Building
-
-- `git clone -b master --single-branch https://github.com/turtlecoin/turtlecoin`
-- `cd turtlecoin`
-- `mkdir build`
-- `cd build`
-- `cmake ..`
-- `make`
-
-The binaries will be in the `src` folder when you are complete.
-
-- `cd src`
-- `./TurtleCoind --version`
 
 #### Thanks
 Cryptonote Developers, Bytecoin Developers, Monero Developers, Forknote Project, TurtleCoin Community
@@ -209,7 +198,7 @@ Hi TurtleCoin contributor, thanks for forking and sending back Pull Requests. Ex
 ```
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Monero Project
-// Copyright (c) 2018, The TurtleCoin Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 //
 // Please see the included LICENSE file for more information.
 ```

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -1047,7 +1047,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   RDATA_ALIGN16 uint8_t hp_state[page_size];
 #else
-#warning "ACTIVATING FORCE_USE_HEAP IN aarch64 + crypto in slow-hash.c"
+#pragma message ("warning: ACTIVATING FORCE_USE_HEAP IN aarch64 + crypto in slow-hash.c")
   uint8_t *hp_state = (uint8_t *)aligned_malloc(page_size,16);
 #endif
 
@@ -1284,7 +1284,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   uint8_t long_state[page_size];
 #else
-#warning "ACTIVATING FORCE_USE_HEAP IN aarch64 && !crypto in slow-hash.c"
+#pragma message ("warning: ACTIVATING FORCE_USE_HEAP IN aarch64 && !crypto in slow-hash.c")
   uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 
@@ -1471,7 +1471,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int light, int va
 #ifndef FORCE_USE_HEAP
   uint8_t long_state[page_size];
 #else
-#warning "ACTIVATING FORCE_USE_HEAP IN portable slow-hash.c"
+#pragma message ("warning: ACTIVATING FORCE_USE_HEAP IN portable slow-hash.c")
   uint8_t *long_state = (uint8_t *)malloc(page_size);
 #endif
 


### PR DESCRIPTION
The upgrade to Crypto++ 8.x allows us to support building on 32-bit systems.