### PR TITLE
zedwallet++: ask for spend key first during restore

### DIFF
--- a/src/zedwallet++/CommandImplementations.cpp
+++ b/src/zedwallet++/CommandImplementations.cpp
@@ -65,23 +65,21 @@ void printPrivateKeys(const std::shared_ptr<WalletBackend> walletBackend)
 
     const auto [error, mnemonicSeed] = walletBackend->getMnemonicSeed();
 
+    /* If this isn't a view only wallet, print out the spend key and mnemonic if available */
+    if (!walletBackend->isViewWallet())
+    {
+        std::cout << SuccessMsg("\nPrivate spend key:\n")
+                  << SuccessMsg(privateSpendKey) << "\n";
+
+        if (!error)
+        {
+            std::cout << SuccessMsg("\nMnemonic seed:\n")
+                      << SuccessMsg(mnemonicSeed) << "\n";
+        }
+    }
+
     std::cout << SuccessMsg("Private view key:\n")
               << SuccessMsg(privateViewKey) << "\n";
-
-    /* We've got a private spend, that's it */
-    if (walletBackend->isViewWallet())
-    {
-        return;
-    }
-
-    std::cout << SuccessMsg("\nPrivate spend key:\n")
-              << SuccessMsg(privateSpendKey) << "\n";
-
-    if (!error)
-    {
-        std::cout << SuccessMsg("\nMnemonic seed:\n")
-                  << SuccessMsg(mnemonicSeed) << "\n";
-    }
 }
 
 void balance(const std::shared_ptr<WalletBackend> walletBackend)

--- a/src/zedwallet++/CommandImplementations.cpp
+++ b/src/zedwallet++/CommandImplementations.cpp
@@ -70,16 +70,16 @@ void printPrivateKeys(const std::shared_ptr<WalletBackend> walletBackend)
     {
         std::cout << SuccessMsg("\nPrivate spend key:\n")
                   << SuccessMsg(privateSpendKey) << "\n";
-
-        if (!error)
-        {
-            std::cout << SuccessMsg("\nMnemonic seed:\n")
-                      << SuccessMsg(mnemonicSeed) << "\n";
-        }
     }
 
     std::cout << SuccessMsg("Private view key:\n")
               << SuccessMsg(privateViewKey) << "\n";
+
+    if (!error)
+    {
+        std::cout << SuccessMsg("\nMnemonic seed:\n")
+                  << SuccessMsg(mnemonicSeed) << "\n";
+    }
 }
 
 void balance(const std::shared_ptr<WalletBackend> walletBackend)

--- a/src/zedwallet++/Open.cpp
+++ b/src/zedwallet++/Open.cpp
@@ -103,11 +103,11 @@ std::shared_ptr<WalletBackend> importViewWallet(const Config &config)
 
 std::shared_ptr<WalletBackend> importWalletFromKeys(const Config &config)
 {
-    const Crypto::SecretKey privateSpendKey
-        = getPrivateKey("Enter your private spend key: ");
-
     const Crypto::SecretKey privateViewKey
         = getPrivateKey("Enter your private view key: ");
+
+    const Crypto::SecretKey privateSpendKey
+        = getPrivateKey("Enter your private spend key: ");
 
     const std::string walletFileName = getNewWalletFileName();
 

--- a/src/zedwallet++/Open.cpp
+++ b/src/zedwallet++/Open.cpp
@@ -103,11 +103,11 @@ std::shared_ptr<WalletBackend> importViewWallet(const Config &config)
 
 std::shared_ptr<WalletBackend> importWalletFromKeys(const Config &config)
 {
-    const Crypto::SecretKey privateViewKey
-        = getPrivateKey("Enter your private view key: ");
-
     const Crypto::SecretKey privateSpendKey
         = getPrivateKey("Enter your private spend key: ");
+
+    const Crypto::SecretKey privateViewKey
+        = getPrivateKey("Enter your private view key: ");
 
     const std::string walletFileName = getNewWalletFileName();
 


### PR DESCRIPTION
Small cosmetic change that's been bothering me. When creating a wallet, zedwallet++ displays the view key and then the spend key. When restoring a wallet from keys, it asks for the spend key and then the view key. This changes it to request view key and then spend key.