### PR TITLE
Fix node fee not getting correctly reset upon swapping node

### DIFF
--- a/src/Nigel/Nigel.cpp
+++ b/src/Nigel/Nigel.cpp
@@ -82,6 +82,8 @@ void Nigel::swapNode(const std::string daemonHost, const uint16_t daemonPort, co
     m_peerCount = 0;
     m_lastKnownHashrate = 0;
     m_isBlockchainCache = false;
+    m_nodeFeeAddress = "";
+    m_nodeFeeAmount = 0;
 
     m_daemonHost = daemonHost;
     m_daemonPort = daemonPort;


### PR DESCRIPTION
Thanks @rashedmyt for discovering.

We call `getNodeFee()` again upon swapping node, but if the address is not valid - for example, if it is empty - then we will not update the node fee results, so the old node fee info will be retained.