### PR TITLE
WalletBackend block cache + prefetch

### DIFF
--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -49,6 +49,14 @@ namespace WalletTypes
            CRYPTONOTE_MAX_BLOCK_NUMBER (In cryptonoteconfig) it is treated
            as a unix timestamp, else it is treated as a block height. */
         uint64_t unlockTime;
+
+        size_t memoryUsage() const
+        {
+            return keyOutputs.size() * sizeof(KeyOutput) + sizeof(keyOutputs) +
+                   sizeof(hash) +
+                   sizeof(transactionPublicKey) +
+                   sizeof(unlockTime);
+        }
     };
 
     /* A raw transaction, simply key images and amounts */
@@ -60,6 +68,13 @@ namespace WalletTypes
         /* The inputs used for a transaction, can be used to track outgoing
            transactions */
         std::vector<CryptoNote::KeyInput> keyInputs;
+
+        size_t memoryUsage() const
+        {
+            return paymentID.size() * sizeof(char) + sizeof(paymentID) +
+                   keyInputs.size() * sizeof(CryptoNote::KeyInput) + sizeof(keyInputs) +
+                   RawCoinbaseTransaction::memoryUsage();
+        }
     };
 
     /* A 'block' with the very basics needed to sync the transactions */
@@ -79,6 +94,24 @@ namespace WalletTypes
 
         /* The timestamp of the block */
         uint64_t blockTimestamp;
+
+        size_t memoryUsage() const
+        {
+            const size_t txUsage = std::accumulate(
+                transactions.begin(),
+                transactions.end(),
+                sizeof(transactions),
+                [](const auto acc, const auto item) {
+
+                return acc + item.memoryUsage();
+            });
+            
+            return coinbaseTransaction.memoryUsage() +
+                   txUsage +
+                   sizeof(blockHeight) +
+                   sizeof(blockHash) +
+                   sizeof(blockTimestamp);
+        }
     };
 
     struct TransactionInput

--- a/src/SubWallets/SubWallet.cpp
+++ b/src/SubWallets/SubWallet.cpp
@@ -6,6 +6,8 @@
 #include <SubWallets/SubWallet.h>
 /////////////////////////////////
 
+#include <config/Constants.h>
+
 #include <Logger/Logger.h>
 
 #include <Utilities/Utilities.h>
@@ -28,7 +30,7 @@ SubWallet::SubWallet(
     m_address(address),
     m_syncStartHeight(scanHeight),
     m_syncStartTimestamp(scanTimestamp),
-    m_privateSpendKey(Constants::BLANK_SECRET_KEY),
+    m_privateSpendKey(Constants::NULL_SECRET_KEY),
     m_isPrimaryAddress(isPrimaryAddress)
 {
 }

--- a/src/Utilities/ThreadSafeDeque.h
+++ b/src/Utilities/ThreadSafeDeque.h
@@ -1,0 +1,212 @@
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include <condition_variable>
+
+#include <mutex>
+
+#include <queue>
+
+template <typename T>
+class ThreadSafeDeque
+{
+    public:
+        ThreadSafeDeque() :
+            m_shouldStop(false)
+        {
+        }
+
+        ThreadSafeDeque(bool startStopped) :
+            m_shouldStop(startStopped)
+        {
+        }
+
+        bool push_back(T item)
+        {
+            /* Aquire the lock */
+            std::unique_lock<std::mutex> lock(m_mutex);
+			
+            /* Stopping, don't push data */
+            if (m_shouldStop)
+            {
+                return false;
+            }
+
+            /* Add the item to the front of the queue */
+            m_deque.push_back(item);
+
+            /* Unlock the mutex before notifying, so it doesn't block after
+               waking up */
+            lock.unlock();
+
+            /* Notify the consumer that we have some data */
+            m_haveData.notify_all();
+
+            return true;
+        }
+
+        /* Delete the front item from the queue */
+        void pop_front()
+        {
+            /* Aquire the lock */
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            /* Whilst we could allow deleting from an empty queue, i.e, waiting
+               for an item, then removing it, this could cause us to be stuck
+               waiting on data to arrive when the queue is empty. We can't
+               really return without removing the item. We could return a bool
+               saying if we completed it, but then the user has no real way to
+               force a removal short of running it in a while loop.
+               Instead, if we just force the queue to have to have data in,
+               we can make sure a removal always suceeds. */
+            if (m_deque.empty())
+            {
+                throw std::runtime_error("Cannot remove from an empty queue!");
+            }
+
+            /* Remove the first item from the queue */
+            m_deque.pop_front();
+
+            /* Unlock the mutex before notifying, so it doesn't block after
+               waking up */
+            lock.unlock();
+
+            m_consumedData.notify_all();
+        }
+
+        /* Take an item from the front of the queue, and do NOT remove it */
+        T front()
+        {
+            return getFirstItem(false);
+        }
+
+        /* Take and remove an item from the front of the queue */
+        T front_and_remove()
+        {
+            return getFirstItem(true);
+        }
+
+        /* Stop the queue if something is waiting on it, so we don't block
+           whilst closing */
+        void stop()
+        {
+            /* Make sure the queue knows to return */
+            m_shouldStop = true;
+
+            /* Wake up anything waiting on data */
+            m_haveData.notify_all();
+
+            /* Make sure not to call .unlock() on the mutex here - it's
+               undefined behaviour if it isn't locked. */
+
+            m_consumedData.notify_all();
+        }
+
+        void start()
+        {
+            m_shouldStop = false;
+        }
+
+        size_t size()
+        {
+            /* Aquire the lock (I'm not sure if this is actually needed here,
+               but hey) */
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            return m_deque.size();
+        }
+
+        /* Takes n elements, if available, starting at the head of the queue.
+           Otherwise returns max available. Does not remove items from the queue. */
+        std::vector<T> pop_front_n(const size_t numElements)
+        {
+            /* Aquire the lock */
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            std::vector<T> results;
+
+            if (m_deque.size() <= numElements)
+            {
+                results.resize(m_deque.size());
+                std::copy(m_deque.begin(), m_deque.end(), results.begin());
+            }
+            else
+            {
+                results.resize(numElements);
+                std::copy(m_deque.begin(), m_deque.begin() + numElements, results.begin());
+            }
+
+            return results;
+        }
+
+    private:
+        T getFirstItem(bool removeFromQueue)
+        {
+            /* Aquire the lock */
+            std::unique_lock<std::mutex> lock(m_mutex);
+			
+            T item;
+
+            /* Stopping, don't return data */
+            if (m_shouldStop)
+            {
+                return item;
+            }
+                
+            /* Wait for data to become available (releases the lock whilst
+               it's not, so we don't block the producer) */
+            m_haveData.wait(lock, [&]
+            { 
+                /* Stopping, don't block */
+                if (m_shouldStop)
+                {
+                    return true;
+                }
+
+                return !m_deque.empty();
+            });
+
+            /* Stopping, don't return data */
+            if (m_shouldStop)
+            {
+                return item;
+            }
+
+            /* Get the first item in the queue */
+            item = m_deque.front();
+
+            /* Remove the first item from the queue */
+            if (removeFromQueue)
+            {
+                m_deque.pop_front();
+            }
+
+            /* Unlock the mutex before notifying, so it doesn't block after
+               waking up */
+            lock.unlock();
+
+            m_consumedData.notify_all();
+			
+            /* Return the item */
+            return item;
+        }
+        
+    private:
+        /* The deque data structure */
+        std::vector<T> m_deque;
+
+        /* The mutex, to ensure we have atomic access to the queue */
+        std::mutex m_mutex;
+
+        /* Whether we have data or not */
+        std::condition_variable m_haveData;
+
+        /* Triggered when data is consumed */
+        std::condition_variable m_consumedData;
+
+        /* Whether we're stopping */
+        std::atomic<bool> m_shouldStop;
+};

--- a/src/Utilities/ThreadSafeDeque.h
+++ b/src/Utilities/ThreadSafeDeque.h
@@ -32,6 +32,22 @@ class ThreadSafeDeque
         {
         }
 
+        /* Move constructor */
+        ThreadSafeDeque(ThreadSafeDeque && old)
+        {
+            *this = std::move(old);
+        }
+
+        ThreadSafeDeque& operator=(ThreadSafeDeque && old)
+        {
+            /* Stop anything running */
+            stop();
+
+            m_deque = std::move(old.m_deque);
+
+            return *this;
+        }
+
         /* Add the items to the end of the queue. They are added in the order
            of the iterators passed in, so once the operation has completed,
            the item pointed to by end will be at the end of the queue. */
@@ -241,7 +257,9 @@ class ThreadSafeDeque
 
             return results;
         }
-
+        
+        /* Recommended to implement a .memoryUsage() method for your type, if not using
+           a simple type. Otherwise, sizeof() is unlikely to be accurate. */
         size_t memoryUsage() const
         {
             if constexpr (CanMemoryUsage<T>)

--- a/src/WalletBackend/BlockDownloader.cpp
+++ b/src/WalletBackend/BlockDownloader.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2019, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
+
+//////////////////////////////////////////
+#include <WalletBackend/BlockDownloader.h>
+//////////////////////////////////////////
+
+#include <Logger/Logger.h>
+
+std::vector<WalletTypes::WalletBlockInfo> BlockDownloader::fetchBlocks(const size_t blockCount) const
+{
+    return m_storedBlocks.front_n(blockCount);
+}
+
+uint64_t BlockDownloader::getHeight() const
+{
+    return 0; /* TODO */
+}
+
+std::vector<Crypto::Hash> BlockDownloader::getStoredBlockCheckpoints() const
+{
+    const auto blocks = m_storedBlocks.front_n(Constants::LAST_KNOWN_BLOCK_HASHES_SIZE);
+
+    std::vector<Crypto::Hash> result;
+
+    result.resize(blocks.size());
+
+    std::transform(blocks.rbegin(), blocks.rend(), result.begin(), [](const auto block) { return block.blockHash; });
+
+    return result;
+}
+
+std::vector<Crypto::Hash> BlockDownloader::getBlockCheckpoints() const
+{
+    /* Note that these are in the wrong order - they are oldest to newest,
+       when we want the inverse. Skipping an inverse in getStoredBlockCheckpoints
+       since we need to concat these anyway which requires another iteration (?) */
+    /* Hashes of blocks we have downloaded but not processed */
+    const auto unprocessedBlockHashes = getStoredBlockCheckpoints();
+
+    /* Hashes of blocks we have processed in the wallet */
+    const auto recentProcessedBlockHashes = m_synchronizationStatus->getRecentBlockHashes();
+
+    std::vector<Crypto::Hash> result;
+
+    /* Add in reverse order for reasons mentioned previously */
+    std::copy(unprocessedBlockHashes.rbegin(), unprocessedBlockHashes.rend(), std::back_inserter(result));
+
+    /* If we don't have the desired 50 blocks, add on the recently processed
+       block checkpoints. This fixes us not passing the right data when
+       we are fully synced or have no store built up yet */
+    if (result.size() < Constants::LAST_KNOWN_BLOCK_HASHES_SIZE)
+    {
+        /* Copy the amount of hashes available, or the amount needed to make
+           up the difference, whichever is less */
+        const size_t numToCopy = std::min(
+            recentProcessedBlockHashes.size(),
+            Constants::LAST_KNOWN_BLOCK_HASHES_SIZE - result.size()
+        );
+
+        std::copy(recentProcessedBlockHashes.begin(), recentProcessedBlockHashes.begin() + numToCopy, std::back_inserter(result));
+    }
+
+    /* Infrequent checkpoints to handle deep forks */
+    const auto blockHashCheckpoints = m_synchronizationStatus->getBlockCheckpoints();
+
+    std::copy(blockHashCheckpoints.begin(), blockHashCheckpoints.end(), std::back_inserter(result));
+
+    return result;
+}
+
+void BlockDownloader::downloadBlocks()
+{
+    std::scoped_lock lock(m_mutex);
+
+    const uint64_t localDaemonBlockCount = m_daemon->localDaemonBlockCount();
+
+    const uint64_t walletBlockCount = getHeight();
+
+    if (localDaemonBlockCount < walletBlockCount)
+    {
+        return;
+    }
+
+    const auto blockCheckpoints = getBlockCheckpoints();
+
+    const auto [success, blocks] = m_daemon->getWalletSyncData(
+        blockCheckpoints, m_startHeight, m_startTimestamp
+    );
+
+    /* If we get no blocks, we are fully synced.
+       (Or timed out/failed to get blocks)
+       Sleep a bit so we don't spam the daemon. */
+    if (!success || blocks.empty())
+    {
+        /* We may have also failed because we requested
+           more data than could be returned in a reasonable
+           amount of time, so we'll back off a little bit */
+        m_daemon->decreaseRequestedBlockCount();
+
+        Logger::logger.log(
+            "Zero blocks received from daemon, possibly fully synced",
+            Logger::DEBUG,
+            {Logger::SYNC}
+        );
+
+        return;
+    }
+
+    /* If we received data back, we'll make sure we're back
+       to running at full speed in case we backed off a little
+       bit before */
+    m_daemon->resetRequestedBlockCount();
+
+    /* Timestamp is transient and can change - block height is constant. */
+    if (m_startTimestamp != 0)
+    {
+        m_startTimestamp = 0;
+        m_startHeight = blocks.front().blockHeight;
+
+        m_subWallets->convertSyncTimestampToHeight(m_startTimestamp, m_startHeight);
+    }
+
+    /* If checkpoints are empty, this is the first sync request. */
+    if (blockCheckpoints.empty())
+    {
+        /* Only check if a timestamp isn't given */
+        if (m_startTimestamp == 0)
+        {
+            /* Loop through the blocks we got back and make sure that
+               we were given data for the start block we were looking for */
+            const auto it = std::find_if(blocks.begin(), blocks.end(), [this](const auto &block) {
+                return block.blockHeight == m_startHeight;
+            });
+
+            /* If we weren't given a block with the startHeight we were
+               looking for then we don't need to store this data */
+            if (it == blocks.end())
+            {
+                std::stringstream stream;
+
+                stream << "Received unexpected block height from daemon. "
+                       << "Expected " << m_startHeight << ", but did not "
+                       << "receive that block. Not storing any blocks.";
+
+                Logger::logger.log(
+                    stream.str(),
+                    Logger::WARNING,
+                    {Logger::SYNC, Logger::DAEMON}
+                );
+
+                return;
+            }
+        }
+    }
+
+    m_storedBlocks.push_back_n(blocks.begin(), blocks.end());
+}

--- a/src/WalletBackend/BlockDownloader.h
+++ b/src/WalletBackend/BlockDownloader.h
@@ -33,7 +33,7 @@ class BlockDownloader
         /* Retrieve blockCount blocks from the internal store. does not remove
            them. Returns as many as possible if the amount requested is not
            available. May be empty (this is the norm when synced.) */
-        std::vector<WalletTypes::WalletBlockInfo> fetchBlocks(const size_t blockCount) const;
+        std::vector<WalletTypes::WalletBlockInfo> fetchBlocks(const size_t blockCount);
 
         /* Drops the oldest block from the internal queue */
         void dropBlock();

--- a/src/WalletBackend/BlockDownloader.h
+++ b/src/WalletBackend/BlockDownloader.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2019, The TurtleCoin Developers
+// 
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include <atomic>
+
+#include <config/Constants.h>
+
+#include <Nigel/Nigel.h>
+
+#include <SubWallets/SubWallets.h>
+
+#include <Utilities/ThreadSafeDeque.h>
+
+#include <vector>
+
+#include <WalletBackend/SynchronizationStatus.h>
+
+#include <WalletTypes.h>
+
+class BlockDownloader
+{
+    public:
+
+        /////////////////////////////
+        /* Public member functions */
+        /////////////////////////////
+
+        /* Retrieve blockCount blocks from the internal store. does not remove
+           them. Returns as many as possible if the amount requested is not
+           available. May be empty (this is the norm when synced.) */
+        std::vector<WalletTypes::WalletBlockInfo> fetchBlocks(const size_t blockCount) const;
+
+    private:
+
+        //////////////////////////////
+        /* Private member functions */
+        //////////////////////////////
+
+        uint64_t getHeight() const;
+
+        std::vector<Crypto::Hash> getStoredBlockCheckpoints() const;
+
+        std::vector<Crypto::Hash> getBlockCheckpoints() const;
+
+        void downloadBlocks();
+
+        //////////////////////////////
+        /* Private member variables */
+        //////////////////////////////
+
+        /* Cached blocks */
+        ThreadSafeDeque<WalletTypes::WalletBlockInfo> m_storedBlocks;
+
+        /* The daemon connection */
+        std::shared_ptr<Nigel> m_daemon;
+
+        /* Ensure we're only making one request at once */
+        std::mutex m_mutex;
+
+        /* Timestamp to begin syncing at */
+        uint64_t m_startTimestamp;
+
+        /* Height to begin syncing at */
+        uint64_t m_startHeight;
+
+        /* Sync progress */
+        std::shared_ptr<SynchronizationStatus> m_synchronizationStatus;
+
+        std::shared_ptr<SubWallets> m_subWallets;
+};

--- a/src/WalletBackend/Constants.h
+++ b/src/WalletBackend/Constants.h
@@ -41,7 +41,7 @@ namespace Constants
     const uint16_t WALLET_FILE_FORMAT_VERSION = 0;
 
     /* How large should the m_lastKnownBlockHashes container be */
-    const uint32_t LAST_KNOWN_BLOCK_HASHES_SIZE = 100;
+    const size_t LAST_KNOWN_BLOCK_HASHES_SIZE = 50;
 
     /* Save a block hash checkpoint every BLOCK_HASH_CHECKPOINTS_INTERVAL
        blocks */
@@ -61,17 +61,9 @@ namespace Constants
        This value determines how many blocks to take from. */
     const uint64_t GLOBAL_INDEXES_OBSCURITY = 10;
 
-    /* The maximum amount of blocks we can have waiting to be processed in
-       the queue. If we exceed this, we will wait till it drops below this
-       amount. */
-    const uint32_t MAXIMUM_SYNC_QUEUE_SIZE = 1000;
-
-    /* Handy if we don't want to use a secret key (for example, for view wallets)
-       and want to make it explicit that this is uninitialized. */
-    const Crypto::SecretKey BLANK_SECRET_KEY = Crypto::SecretKey({
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-    });
+    /* Amount of blocks to take in one chunk from the block downloader, and
+       then split into threads and process. Too large will result in large
+       jumps in the sync height, but should offer better performance from a
+       decrease in locking of data structures. */
+    const uint64_t BLOCK_PROCESSING_CHUNK = 200;
 }

--- a/src/WalletBackend/SynchronizationStatus.cpp
+++ b/src/WalletBackend/SynchronizationStatus.cpp
@@ -56,40 +56,6 @@ void SynchronizationStatus::storeBlockHash(
     }
 }
 
-/* This returns a vector of hashes, used to be passed to queryBlocks(), to
-   determine where to begin syncing from. We could just pass in the last known
-   block hash, but if this block was on a forked chain, we would have to
-   discard all our progress, and begin again from the genesis block.
-
-   Instead, we store the last 100 block hashes we know about (since forks
-   are most likely going to be quite shallow forks, usually 1 or 2 blocks max),
-   and then we store one hash every 5000 blocks, in case we have a very
-   deep fork.
-   
-   Note that the first items in this vector are the latest block. On the
-   daemon side, it loops through the vector, looking for the hash in its
-   database, then returns the height it found. So, if you put your earliest
-   block at the start of the vector, you're just going to start syncing from
-   that block every time. */
-/* TODO: Remove */
-std::vector<Crypto::Hash> SynchronizationStatus::getBlockHashCheckpoints() const
-{
-    std::vector<Crypto::Hash> results;
-
-    /* Copy the contents of m_lastKnownBlockHashes to result, these are the
-       last 100 known block hashes we have synced. For example, if the top
-       block we know about is 110, this contains [110, 109, 108.. 10]. */
-    std::copy(m_lastKnownBlockHashes.begin(), m_lastKnownBlockHashes.end(),
-              back_inserter(results));
-
-    /* Append the contents of m_blockHashCheckpoints to result, these are the
-       checkpoints we make every 5k blocks in case of deep forks */
-    std::copy(m_blockHashCheckpoints.begin(), m_blockHashCheckpoints.end(),
-              back_inserter(results));
-
-    return results;
-}
-
 std::deque<Crypto::Hash> SynchronizationStatus::getBlockCheckpoints() const
 {
     return m_blockHashCheckpoints;

--- a/src/WalletBackend/SynchronizationStatus.cpp
+++ b/src/WalletBackend/SynchronizationStatus.cpp
@@ -33,6 +33,7 @@ void SynchronizationStatus::storeBlockHash(
                    << m_lastKnownBlockHeight + 1 << ", Received: "
                    << height << ".\nPossibly malicious daemon. Terminating.";
 
+            /* TODO: Convert to log message */
             throw std::runtime_error(stream.str());
         }
     }
@@ -70,6 +71,7 @@ void SynchronizationStatus::storeBlockHash(
    database, then returns the height it found. So, if you put your earliest
    block at the start of the vector, you're just going to start syncing from
    that block every time. */
+/* TODO: Remove */
 std::vector<Crypto::Hash> SynchronizationStatus::getBlockHashCheckpoints() const
 {
     std::vector<Crypto::Hash> results;
@@ -86,6 +88,16 @@ std::vector<Crypto::Hash> SynchronizationStatus::getBlockHashCheckpoints() const
               back_inserter(results));
 
     return results;
+}
+
+std::deque<Crypto::Hash> SynchronizationStatus::getBlockCheckpoints() const
+{
+    return m_blockHashCheckpoints;
+}
+
+std::deque<Crypto::Hash> SynchronizationStatus::getRecentBlockHashes() const
+{
+    return m_lastKnownBlockHashes;
 }
 
 void SynchronizationStatus::fromJSON(const JSONObject &j)

--- a/src/WalletBackend/SynchronizationStatus.h
+++ b/src/WalletBackend/SynchronizationStatus.h
@@ -30,6 +30,10 @@ class SynchronizationStatus
 
         std::vector<Crypto::Hash> getBlockHashCheckpoints() const;
 
+        std::deque<Crypto::Hash> getBlockCheckpoints() const;
+
+        std::deque<Crypto::Hash> getRecentBlockHashes() const;
+
         /* Converts the class to a json object */
         void toJSON(rapidjson::Writer<rapidjson::StringBuffer> &writer) const;
 

--- a/src/WalletBackend/WalletBackend.cpp
+++ b/src/WalletBackend/WalletBackend.cpp
@@ -540,7 +540,7 @@ void WalletBackend::init()
         m_walletSynchronizer->initializeAfterLoad(m_daemon, m_eventHandler);
     }
 
-    m_walletSynchronizer->m_subWallets = m_subWallets;
+    m_walletSynchronizer->setSubWallets(m_subWallets);
 
     /* Launch the wallet sync process in a background thread */
     m_walletSynchronizer->start();

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -18,6 +18,8 @@
 
 #include <Logger/Logger.h>
 
+#include <Utilities/ThreadSafeQueue.h>
+#include <Utilities/ThreadSafeDeque.h>
 #include <Utilities/Utilities.h>
 
 #include <WalletBackend/Constants.h>
@@ -96,7 +98,7 @@ void WalletSynchronizer::mainLoop()
     {
         const auto blocks = downloadBlocks();
 
-        for (const auto block : blocks)
+        for (const auto &block : blocks)
         {
             if (m_shouldStop)
             {

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -49,7 +49,8 @@ WalletSynchronizer::WalletSynchronizer(
     m_startHeight(startHeight),
     m_startTimestamp(startTimestamp),
     m_privateViewKey(privateViewKey),
-    m_eventHandler(eventHandler)
+    m_eventHandler(eventHandler),
+    m_blockDownloader(daemon, nullptr, startHeight, startTimestamp)
 {
 }
 
@@ -68,8 +69,6 @@ WalletSynchronizer & WalletSynchronizer::operator=(WalletSynchronizer && old)
 
     m_syncThread = std::move(old.m_syncThread);
 
-    m_syncStatus = std::move(old.m_syncStatus);
-
     m_startTimestamp = std::move(old.m_startTimestamp);
     m_startHeight = std::move(old.m_startHeight);
 
@@ -78,6 +77,8 @@ WalletSynchronizer & WalletSynchronizer::operator=(WalletSynchronizer && old)
     m_eventHandler = std::move(old.m_eventHandler);
 
     m_daemon = std::move(old.m_daemon);
+
+    m_blockDownloader = std::move(old.m_blockDownloader);
 
     return *this;
 }
@@ -94,9 +95,11 @@ WalletSynchronizer::~WalletSynchronizer()
 
 void WalletSynchronizer::mainLoop()
 {
+    auto lastCheckedLockedTransactions = std::chrono::system_clock::now();
+
     while (!m_shouldStop)
     {
-        const auto blocks = downloadBlocks();
+        const auto blocks = m_blockDownloader.fetchBlocks(Constants::BLOCK_PROCESSING_CHUNK);
 
         for (const auto &block : blocks)
         {
@@ -108,139 +111,22 @@ void WalletSynchronizer::mainLoop()
             processBlock(block);
         }
 
-        if (blocks.empty() && !m_shouldStop)
+        /* If we're synced, check any transactions that may be in the pool */
+        if (getCurrentScanHeight() >= m_daemon->localDaemonBlockCount() && !m_shouldStop)
         {
-            /* If we're synced, check any transactions that may be in the pool */
-            if (getCurrentScanHeight() >= m_daemon->localDaemonBlockCount() &&
-                !m_subWallets->isViewWallet())
+            const auto now = std::chrono::system_clock::now();
+            const auto timeDiff = now - lastCheckedLockedTransactions;
+
+            /* Not a viewwallet and haven't checked transactions in last 15 secs */
+            if (!m_subWallets->isViewWallet() && timeDiff > std::chrono::seconds(15))
             {
                 checkLockedTransactions();
+                lastCheckedLockedTransactions = now;
             }
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
-
-            continue;
         }
     }
-}
-
-std::vector<WalletTypes::WalletBlockInfo> WalletSynchronizer::downloadBlocks()
-{
-    const uint64_t localDaemonBlockCount = m_daemon->localDaemonBlockCount();
-
-    const uint64_t walletBlockCount = getCurrentScanHeight();
-
-    /* Local daemon has less blocks than the wallet:
-
-    With the get wallet sync data call, we give a height or a timestamp to
-    start at, and an array of block hashes of the last known blocks we
-    know about.
-
-    If the daemon can find the hashes, it returns the next one it knows
-    about, so if we give a start height of 200,000, and a hash of
-    block 300,000, it will return block 300,001 and above.
-
-    This works well, since if the chain forks at 300,000, it won't have the
-    hash of 300,000, so it will return the next hash we gave it,
-    in this case probably 299,999.
-
-    On the wallet side, we'll detect a block lower than our last known
-    block, and handle the fork.
-
-    However, if we're syncing our wallet with an unsynced daemon,
-    lets say our wallet is at height 600,000, and the daemon is at 300,000.
-    If our start height was at 200,000, then since it won't have any block
-    hashes around 600,000, it will start returning blocks from
-    200,000 and up, discarding our current progress.
-
-    Therefore, we should wait until the local daemon has more blocks than
-    us to prevent discarding sync data. */
-    if (localDaemonBlockCount < walletBlockCount)
-    {
-        Logger::logger.log(
-            "Wallet already synced, not fetching blocks",
-            Logger::DEBUG,
-            {Logger::SYNC}
-        );
-
-        return {};
-    }
-
-    /* The block hashes to try begin syncing from */
-    const auto blockCheckpoints = m_syncStatus.getBlockHashCheckpoints();
-
-    /* Blocks the thread for up to 10 secs */
-    const auto [success, blocks] = m_daemon->getWalletSyncData(
-        blockCheckpoints, m_startHeight, m_startTimestamp
-    );
-
-    /* If we get no blocks, we are fully synced.
-       (Or timed out/failed to get blocks)
-       Sleep a bit so we don't spam the daemon. */
-    if (!success || blocks.empty())
-    {
-        /* We may have also failed because we requested
-           more data than could be returned in a reasonable
-           amount of time, so we'll back off a little bit */
-        m_daemon->decreaseRequestedBlockCount();
-
-        Logger::logger.log(
-            "Zero blocks received from daemon, possibly fully synced",
-            Logger::DEBUG,
-            {Logger::SYNC}
-        );
-
-        return {};
-    }
-
-    /* If we received data back, we'll make sure we're back
-       to running at full speed in case we backed off a little
-       bit before */
-    m_daemon->resetRequestedBlockCount();
-
-    /* Timestamp is transient and can change - block height is constant. */
-    if (m_startTimestamp != 0)
-    {
-        m_startTimestamp = 0;
-        m_startHeight = blocks.front().blockHeight;
-
-        m_subWallets->convertSyncTimestampToHeight(m_startTimestamp, m_startHeight);
-    }
-
-    /* If checkpoints are empty, this is the first sync request. */
-    if (blockCheckpoints.empty())
-    {
-        /* Only check if a timestamp isn't given */
-        if (m_startTimestamp == 0)
-        {
-            /* Loop through the blocks we got back and make sure that
-               we were given data for the start block we were looking for */
-            const auto it = std::find_if(blocks.begin(), blocks.end(), [this](const auto &block) {
-                return block.blockHeight == m_startHeight;
-            });
-
-            /* If we weren't given a block with the startHeight we were
-               looking for then we don't need to store this data */
-            if (it == blocks.end())
-            {
-                std::stringstream stream;
-
-                stream << "Received unexpected block height from daemon. "
-                       << "Expected " << m_startHeight << ", but did not "
-                       "receive that block. Not returning any blocks.";
-
-                Logger::logger.log(
-                    stream.str(),
-                    Logger::WARNING,
-                    {Logger::SYNC, Logger::DAEMON}
-                );
-
-                return {};
-            }
-        }
-    }
-
-    return blocks;
 }
 
 std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> WalletSynchronizer::processBlockOutputs(
@@ -276,7 +162,7 @@ void WalletSynchronizer::processBlock(const WalletTypes::WalletBlockInfo &block)
     );
 
     /* Chain forked, invalidate previous transactions */
-    if (m_syncStatus.getHeight() >= block.blockHeight)
+    if (m_blockDownloader.getHeight() >= block.blockHeight)
     {
         Logger::logger.log(
             "Blockchain forked, resolving...",
@@ -386,7 +272,7 @@ void WalletSynchronizer::processBlock(const WalletTypes::WalletBlockInfo &block)
     /* Make sure to do this at the end, once the transactions are fully
        processed! Otherwise, we could miss a transaction depending upon
        when we save */
-    m_syncStatus.storeBlockHash(block.blockHash, block.blockHeight);
+    m_blockDownloader.dropBlock(block.blockHeight, block.blockHash);
 
     if (block.blockHeight >= m_daemon->networkBlockCount())
     {
@@ -685,6 +571,8 @@ void WalletSynchronizer::start()
         throw std::runtime_error("Daemon has not been initialized!");
     }
 
+    m_blockDownloader.start();
+
     m_syncThread = std::thread(&WalletSynchronizer::mainLoop, this);
 }
 
@@ -699,6 +587,9 @@ void WalletSynchronizer::stop()
     /* Tell the threads to stop */
     m_shouldStop = true;
 
+    /* Tell the block downloader to stop and wait for it */
+    m_blockDownloader.stop();
+
     /* Wait for the block downloader thread to finish (if applicable) */
     if (m_syncThread.joinable())
     {
@@ -712,8 +603,8 @@ void WalletSynchronizer::reset(uint64_t startHeight)
     m_startHeight = startHeight;
     m_startTimestamp = 0;
 
-    /* Discard sync progress */
-    m_syncStatus = SynchronizationStatus();
+    /* Discard downloaded blocks and sync status */
+    m_blockDownloader = BlockDownloader(m_daemon, m_subWallets, m_startHeight, m_startTimestamp);
 
     /* Need to call start in your calling code - We don't call it here so
        you can schedule the start correctly */
@@ -732,11 +623,12 @@ void WalletSynchronizer::initializeAfterLoad(
 {
     m_daemon = daemon;
     m_eventHandler = eventHandler;
+    m_blockDownloader.initializeAfterLoad(m_daemon);
 }
 
 uint64_t WalletSynchronizer::getCurrentScanHeight() const
 {
-    return m_syncStatus.getHeight();
+    return m_blockDownloader.getHeight();
 }
 
 void WalletSynchronizer::swapNode(const std::shared_ptr<Nigel> daemon)
@@ -746,10 +638,15 @@ void WalletSynchronizer::swapNode(const std::shared_ptr<Nigel> daemon)
 
 void WalletSynchronizer::fromJSON(const JSONObject &j)
 {
-    m_syncStatus.fromJSON(getObjectFromJSON(j, "transactionSynchronizerStatus"));
     m_startTimestamp = getUint64FromJSON(j, "startTimestamp");
     m_startHeight = getUint64FromJSON(j, "startHeight");
     m_privateViewKey.fromString(getStringFromJSON(j, "privateViewKey"));
+
+    m_blockDownloader.fromJSON(
+        getObjectFromJSON(j, "transactionSynchronizerStatus"),
+        m_startHeight,
+        m_startTimestamp
+    );
 }
 
 void WalletSynchronizer::toJSON(rapidjson::Writer<rapidjson::StringBuffer> &writer) const
@@ -757,7 +654,7 @@ void WalletSynchronizer::toJSON(rapidjson::Writer<rapidjson::StringBuffer> &writ
     writer.StartObject();
 
     writer.Key("transactionSynchronizerStatus");
-    m_syncStatus.toJSON(writer);
+    m_blockDownloader.toJSON(writer);
 
     writer.Key("startTimestamp");
     writer.Uint64(m_startTimestamp);
@@ -769,4 +666,10 @@ void WalletSynchronizer::toJSON(rapidjson::Writer<rapidjson::StringBuffer> &writ
     m_privateViewKey.toJSON(writer);
 
     writer.EndObject();
+}
+
+void WalletSynchronizer::setSubWallets(const std::shared_ptr<SubWallets> subWallets)
+{
+    m_subWallets = subWallets;
+    m_blockDownloader.setSubWallets(m_subWallets);
 }

--- a/src/WalletBackend/WalletSynchronizer.h
+++ b/src/WalletBackend/WalletSynchronizer.h
@@ -10,6 +10,7 @@
 
 #include <SubWallets/SubWallets.h>
 
+#include <WalletBackend/BlockDownloader.h>
 #include <WalletBackend/EventHandler.h>
 #include <WalletBackend/SynchronizationStatus.h>
 
@@ -90,13 +91,8 @@ class WalletSynchronizer
 
         void setSyncStart(const uint64_t startTimestamp, const uint64_t startHeight);
 
-        /////////////////////////////
-        /* Public member variables */
-        /////////////////////////////
-
-        /* The sub wallets (shared with the main class) */
-        std::shared_ptr<SubWallets> m_subWallets;
-
+        void setSubWallets(const std::shared_ptr<SubWallets> subWallets);
+        
     private:
 
         //////////////////////////////
@@ -104,8 +100,6 @@ class WalletSynchronizer
         //////////////////////////////
 
         void mainLoop();
-
-        std::vector<WalletTypes::WalletBlockInfo> downloadBlocks();
 
         std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> processBlockOutputs(
             const WalletTypes::WalletBlockInfo &block) const;
@@ -146,8 +140,6 @@ class WalletSynchronizer
         /* An atomic bool to signal if we should stop the sync thread */
         std::atomic<bool> m_shouldStop;
 
-        SynchronizationStatus m_syncStatus;
-
         /* The timestamp to start scanning downloading block data from */
         uint64_t m_startTimestamp;
 
@@ -162,4 +154,9 @@ class WalletSynchronizer
 
         /* The daemon connection */
         std::shared_ptr<Nigel> m_daemon;
+
+        BlockDownloader m_blockDownloader;
+
+        /* The sub wallets (shared with the main class) */
+        std::shared_ptr<SubWallets> m_subWallets;
 };

--- a/src/WalletBackend/WalletSynchronizer.h
+++ b/src/WalletBackend/WalletSynchronizer.h
@@ -11,7 +11,6 @@
 #include <SubWallets/SubWallets.h>
 
 #include <WalletBackend/EventHandler.h>
-#include <WalletBackend/ThreadSafeQueue.h>
 #include <WalletBackend/SynchronizationStatus.h>
 
 #include <WalletTypes.h>

--- a/src/config/Constants.h
+++ b/src/config/Constants.h
@@ -8,6 +8,8 @@
 
 #include <vector>
 
+/* You can change things in this file, but you probably shouldn't. Leastways,
+   without knowing what you're doing. */
 namespace Constants
 {
     /* Amounts we make outputs into (Not mandatory, but a good idea) */

--- a/src/config/Constants.h
+++ b/src/config/Constants.h
@@ -64,4 +64,7 @@ namespace Constants
         0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0,
     });
+
+    /* Amount of hashes to provide to daemon in /getWalletSyncData call, */
+    const size_t LAST_KNOWN_BLOCK_HASHES_SIZE = 50;
 }

--- a/src/config/Constants.h
+++ b/src/config/Constants.h
@@ -66,7 +66,4 @@ namespace Constants
         0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0,
     });
-
-    /* Amount of hashes to provide to daemon in /getWalletSyncData call, */
-    const size_t LAST_KNOWN_BLOCK_HASHES_SIZE = 50;
 }

--- a/src/config/WalletConfig.h
+++ b/src/config/WalletConfig.h
@@ -76,4 +76,20 @@ namespace WalletConfig
     /* Should we process coinbase transactions? We can skip them to speed up
        syncing, as most people don't have solo mined transactions */
     const bool processCoinbaseTransactions = true;
+
+    /**
+     * Max size of a post body response - 10MB
+     * Will decrease the amount of blocks requested from the daemon if this
+     * is exceeded.
+     * Note - blockStoreMemoryLimit - maxBodyResponseSize should be greater
+     * than zero, or no data will get cached.
+     * Further note: Currently blocks request are not decreased if this is
+     * exceeded. Needs to be implemented in future?
+     */
+    const size_t maxBodyResponseSize = 1024 * 1024 * 10;
+
+    /**
+     * The amount of memory to use storing downloaded blocks - 50MB
+     */
+    const size_t blockStoreMemoryLimit = 1024 * 1024 * 50;
 }

--- a/src/zedwallet++/TransactionMonitor.h
+++ b/src/zedwallet++/TransactionMonitor.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <WalletBackend/WalletBackend.h>
-#include <WalletBackend/ThreadSafeQueue.h>
+
+#include <Utilities/ThreadSafeQueue.h>
 
 class TransactionMonitor
 {


### PR DESCRIPTION
Prefetches blocks to increase syncing speed. Sync speed comparison:

**zedwallet, remote node**: 28719 blocks in 5 mins, **96 blocks a second**
**zedwallet, local node**: 39411 blocks in 5 mins, **131 blocks a second**

**zedwallet-beta, remote node**: 18653 blocks in 5 mins, **62 blocks a second**
**zedwallet-beta with block prefetch**: 41249 blocks in 5 mins, **137 blocks a second**
**zedwallet-beta, with block prefetch, local node**: 87923 blocks in 4:42 mins, **312 blocks a second** - ran out of blocks to sync lol

I have not tested *that* intensively. Might be some bugs I missed. Did not crash in my tests, retains sync progress, and can send/receive transactions successfully. Possibly some race conditions/dead locks.