### PR TITLE
Altering default Target Architecture in Build Process

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ before_build:
 build_script:
   - md build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" .. -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64
+  - cmake -G "Visual Studio 15 2017 Win64" .. -DARCH=default -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64
   - MSBuild TurtleCoin.sln /p:CLToolExe=clcache.exe /p:CLToolPath=c:\Python37\Scripts\ /p:Configuration=Release /m
   - src\Release\cryptotest.exe
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ script:
 # we do this in the script stage because this happens after the repo is cloned
 - if [[ "$LABEL" == "aarch64" ]]; then source scripts/prep-aarch64.sh ; fi
 - mkdir build && cd build
-- cmake -DCMAKE_BUILD_TYPE=Release -DSTATIC=true ..
+- cmake -DARCH=default -DCMAKE_BUILD_TYPE=Release -DSTATIC=true ..
 - make -j2
 - if [[ "$LABEL" != "aarch64" ]]; then ./src/cryptotest ; fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug, Release, RelWithDebInfo")
 set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo Release CACHE TYPE INTERNAL)
-set(ARCH default CACHE STRING "CPU to build for: -march value or native")
+set(ARCH native CACHE STRING "CPU to build for: -march value or native")
 
 project(TurtleCoin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ add_subdirectory(src)
 ## We need to setup the RocksDB build environment to match our system
 if(NOT MSVC)
     execute_process(
-        COMMAND cmake ${CMAKE_CURRENT_SOURCE_DIR}/external/rocksdb -DWITH_LZ4=ON -DWITH_GFLAGS=0 -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DPORTABLE=ON -B${PROJECT_BINARY_DIR}/rocksdb
+        COMMAND cmake ${CMAKE_CURRENT_SOURCE_DIR}/external/rocksdb -DARCH=${ARCH} -DWITH_LZ4=ON -DWITH_GFLAGS=0 -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DPORTABLE=ON -B${PROJECT_BINARY_DIR}/rocksdb
     )
   set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${PROJECT_BINARY_DIR}/rocksdb/librocksdb.a")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug, Release, RelWithDebInfo")
 set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo Release CACHE TYPE INTERNAL)
+set(ARCH default CACHE STRING "CPU to build for: -march value or native")
 
 project(TurtleCoin)
 
@@ -52,19 +53,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-## This section is specifically for RocksDB build options that we've disabled for maximum portability
-set(ENABLE_AVX OFF CACHE STRING "Enable RocksDB AVX/AVX2? Defaults to OFF")
-set(ENABLE_LEAF_FRAME OFF CACHE STRING "Enable RocksDB OMIT_LEAF_FRAME_POINTER detection? Defaults to OFF")
-set(ENABLE_SSE42 OFF CACHE STRING "Enable RocksDB SSE4.2 support detection? Defaults to OFF")
-set(ENABLE_THREAD_LOCAL OFF CACHE STRING "Enable RocksDB THREAD_LOCAL support detection? Defaults to OFF")
-set(ENABLE_SYNC_FILE_RANGE_WRITE OFF CACHE STRING "Enable RocksDB SYNC_FILE_RANGE_WRITE support detection? Defaults to OFF")
-set(ENABLE_PTHREAD_MUTEX_ADAPTIVE_NP OFF CACHE STRING "Enable RocksDB PTHREAD_MUTEX_ADAPTIVE_NP support detection? Defaults to OFF")
-set(ENABLE_MALLOC_USABLE_SIZE OFF CACHE STRING "Enable RocksDB MALLOC_USABLE_SIZE support detection? Defaults to OFF")
-set(ENABLE_SCHED_GETCPU OFF CACHE STRING "Enable RocksDB SCHED_GETCPU support detection? Defaults to OFF")
 ## This section is for settings found in the slow-hash routine(s) that may benefit some systems (mostly ARM)
 set(FORCE_USE_HEAP ON CACHE BOOL "Force the use of heap memory allocation")
 set(NO_AES OFF CACHE BOOL "Turn off Hardware AES instructions?")
 set(NO_OPTIMIZED_MULTIPLY_ON_ARM OFF CACHE BOOL "Turn off Optimized Multiplication on ARM?")
+
+message(STATUS "Building for target architecture: ${ARCH}")
 
 if(FORCE_USE_HEAP)
   add_definitions(-DFORCE_USE_HEAP)
@@ -158,7 +152,6 @@ if(NOT MSVC)
   endif()
 
   ## This is here to support building for multiple architecture types... but we all know how well that usually goes...
-  set(ARCH default CACHE STRING "CPU to build for: -march value or default")
   if("${ARCH}" STREQUAL "default")
     set(ARCH_FLAG "")
   else()

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ If you would like to compile yourself, read on.
 
 ### How To Compile
 
+#### Build Optimization
+
+The CMake build system will, by default, create optimized *native* builds for your particuar system type when you build the software. Using this method, the binaries created provide a better experience and all together faster performance.
+
+However, if you wish to create *portable* binaries that can be shared between systems, specify `-DARCH=default` in your CMake arguments during the build process. Note that *portable* binaries will have a noticable difference in performance than *native* binaries. For this reason, it is always best to build for your particuar system if possible.
+
 #### Linux
 
 ##### Prerequisites

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you would like to compile yourself, read on.
 
 #### Build Optimization
 
-The CMake build system will, by default, create optimized *native* builds for your particuar system type when you build the software. Using this method, the binaries created provide a better experience and all together faster performance.
+The CMake build system will, by default, create optimized *native* builds for your particular system type when you build the software. Using this method, the binaries created provide a better experience and all together faster performance.
 
 However, if you wish to create *portable* binaries that can be shared between systems, specify `-DARCH=default` in your CMake arguments during the build process. Note that *portable* binaries will have a noticable difference in performance than *native* binaries. For this reason, it is always best to build for your particuar system if possible.
 

--- a/external/rocksdb/CMakeLists.txt
+++ b/external/rocksdb/CMakeLists.txt
@@ -62,7 +62,7 @@ if(MSVC)
   option(WITH_GFLAGS "build with GFlags" OFF)
   option(WITH_XPRESS "build with windows built in compression" OFF)
   include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
-  
+
   if(WITH_LZ4)
     SET(LZ4_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../lz4")
     SET(LZ4_LIBRARIES lz4)
@@ -188,7 +188,7 @@ else()
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
     include(CheckCXXCompilerFlag)
-    if(ENABLE_LEAF_FRAME)
+    if(NOT "${ARCH}" STREQUAL "default")
       CHECK_CXX_COMPILER_FLAG("-momit-leaf-frame-pointer" HAVE_OMIT_LEAF_FRAME_POINTER)
       if(HAVE_OMIT_LEAF_FRAME_POINTER)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
@@ -234,7 +234,7 @@ else()
 endif()
 
 include(CheckCXXSourceCompiles)
-if(ENABLE_SSE42)
+if(NOT "${ARCH}" STREQUAL "default")
   if(NOT MSVC)
     set(CMAKE_REQUIRED_FLAGS "-msse4.2 -mpclmul")
   endif()
@@ -259,7 +259,7 @@ if(ENABLE_SSE42)
   endif()
 endif()
 
-if(ENABLE_THREAD_LOCAL)
+if(NOT "${ARCH}" STREQUAL "default")
   CHECK_CXX_SOURCE_COMPILES("
   #if defined(_MSC_VER) && !defined(__thread)
   #define __thread __declspec(thread)
@@ -436,7 +436,7 @@ int main() {
   endif()
 endif()
 
-if(ENABLE_SYNC_FILE_RANGE_WRITE)
+if(NOT "${ARCH}" STREQUAL "default")
   CHECK_CXX_SOURCE_COMPILES("
   #include <fcntl.h>
   int main() {
@@ -449,7 +449,7 @@ if(ENABLE_SYNC_FILE_RANGE_WRITE)
   endif()
 endif()
 
-if(ENABLE_PTHREAD_MUTEX_ADAPTIVE_NP)
+if(NOT "${ARCH}" STREQUAL "default")
   CHECK_CXX_SOURCE_COMPILES("
   #include <pthread.h>
   int main() {
@@ -462,14 +462,14 @@ if(ENABLE_PTHREAD_MUTEX_ADAPTIVE_NP)
 endif()
 
 include(CheckCXXSymbolExists)
-if(ENABLE_MALLOC_USABLE_SIZE)
+if(NOT "${ARCH}" STREQUAL "default")
   check_cxx_symbol_exists(malloc_usable_size malloc.h HAVE_MALLOC_USABLE_SIZE)
   if(HAVE_MALLOC_USABLE_SIZE)
     add_definitions(-DROCKSDB_MALLOC_USABLE_SIZE)
   endif()
 endif()
 
-if(ENABLE_SCHED_GETCPU)
+if(NOT "${ARCH}" STREQUAL "default")
   check_cxx_symbol_exists(sched_getcpu sched.h HAVE_SCHED_GETCPU)
   if(HAVE_SCHED_GETCPU)
     add_definitions(-DROCKSDB_SCHED_GETCPU_PRESENT)
@@ -1096,9 +1096,9 @@ if(MSVC)
   string (REPLACE "/arch:AVX2" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
   string (REPLACE "/arch:AVX" ""     CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
-  if(ENABLE_AVX)
+  if(NOT "${ARCH}" STREQUAL "default")
     include(CheckCXXSourceRuns)
-    
+
     # Check AVX
     check_cxx_source_runs("
       #include <immintrin.h>

--- a/external/rocksdb/CMakeLists.txt
+++ b/external/rocksdb/CMakeLists.txt
@@ -34,6 +34,8 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
+message(STATUS "Setting up build environment for RocksDB")
+
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
   message(STATUS "Found ccache package... Activating...")
@@ -51,6 +53,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 
+set(ARCH native CACHE STRING "CPU to build for: -march value or native")
 option(WITH_JEMALLOC "build with JeMalloc" OFF)
 option(WITH_SNAPPY "build with SNAPPY" OFF)
 option(WITH_LZ4 "build with lz4" OFF)


### PR DESCRIPTION
* Sets the default target architecture to `native` instead of `default`
* Alters CI builds to specify a target architecture of `default`
* Removes tons of RocksDB fluff from the project CMakeLists.txt file and has RocksDB look at the `ARCH` flag instead to determine if it needs to run the feature detection(s)
* Updates the README.md to reflect information regarding the difference between `native` and `default` builds

This PR helps prep the code base for Argon2 optimizations coming in the Chukwa branch that benefit highly from `native` builds.