### PR TITLE
Multithreaded wallet syncing

### DIFF
--- a/src/Utilities/ThreadSafeDeque.h
+++ b/src/Utilities/ThreadSafeDeque.h
@@ -293,11 +293,17 @@ class ThreadSafeDeque
            Otherwise, sizeof() is unlikely to be accurate. */
         size_t memoryUsage() const
         {
+            /* Aquire the lock */
+            std::unique_lock<std::mutex> lock(m_mutex);
+
             return m_deque.size() * sizeof(T) + sizeof(m_deque);
         }
 
         size_t memoryUsage(std::function<size_t(T)> memUsage) const
         {
+            /* Aquire the lock */
+            std::unique_lock<std::mutex> lock(m_mutex);
+
             return std::accumulate(
                 m_deque.begin(),
                 m_deque.end(),

--- a/src/Utilities/ThreadSafeDeque.h
+++ b/src/Utilities/ThreadSafeDeque.h
@@ -238,9 +238,6 @@ class ThreadSafeDeque
            Otherwise returns max available. Does not remove items from the queue. */
         std::vector<T> front_n(const size_t numElements) const
         {
-            std::cout << "Requested " << numElements << " blocks. Available: "
-                      << m_deque.size() << std::endl;
-
             /* Aquire the lock */
             std::unique_lock<std::mutex> lock(m_mutex);
 

--- a/src/Utilities/ThreadSafePriorityQueue.h
+++ b/src/Utilities/ThreadSafePriorityQueue.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2019, The TurtleCoin Developers
 // 
 // Please see the included LICENSE file for more information.
 
@@ -6,47 +6,43 @@
 
 #include <condition_variable>
 
-#include <deque>
+#include <queue>
 
 #include <mutex>
 
-#include <iostream>
-
-template<typename T>
-class ThreadSafeDeque
+template<typename T, typename Comparison = std::less<T>>
+class ThreadSafePriorityQueue
 {
     public:
-        ThreadSafeDeque() :
+        ThreadSafePriorityQueue() :
             m_shouldStop(false)
         {
         }
 
-        ThreadSafeDeque(bool startStopped) :
+        ThreadSafePriorityQueue(bool startStopped) :
             m_shouldStop(startStopped)
         {
         }
 
         /* Move constructor */
-        ThreadSafeDeque(ThreadSafeDeque && old)
+        ThreadSafePriorityQueue(ThreadSafePriorityQueue && old)
         {
             *this = std::move(old);
         }
 
-        ThreadSafeDeque& operator=(ThreadSafeDeque && old)
+        ThreadSafePriorityQueue& operator=(ThreadSafePriorityQueue && old)
         {
             /* Stop anything running */
             stop();
 
-            m_deque = std::move(old.m_deque);
+            m_priorityQueue = std::move(old.m_priorityQueue);
 
             return *this;
         }
 
-        /* Add the items to the end of the queue. They are added in the order
-           of the iterators passed in, so once the operation has completed,
-           the item pointed to by end will be at the end of the queue. */
+        /* Add the items between [begin, end] to the queue */
         template<typename Iterator>
-        bool push_back_n(Iterator begin, Iterator end)
+        bool push_n(Iterator begin, Iterator end)
         {
             /* Aquire the lock */
             std::unique_lock<std::mutex> lock(m_mutex);
@@ -59,7 +55,7 @@ class ThreadSafeDeque
 
             for (auto it = begin; it < end; it++)
             {
-                m_deque.push_back(*it);
+                m_priorityQueue.push(*it);
             }
 
             /* Unlock the mutex before notifying, so it doesn't block after
@@ -73,7 +69,7 @@ class ThreadSafeDeque
         }
 
         /* Add an item to the end of the queue */
-        bool push_back(T item)
+        bool push(T item)
         {
             /* Aquire the lock */
             std::unique_lock<std::mutex> lock(m_mutex);
@@ -84,8 +80,7 @@ class ThreadSafeDeque
                 return false;
             }
 
-            /* Add the item to the front of the queue */
-            m_deque.push_back(item);
+            m_priorityQueue.push(item);
 
             /* Unlock the mutex before notifying, so it doesn't block after
                waking up */
@@ -98,7 +93,7 @@ class ThreadSafeDeque
         }
 
         /* Delete the front item from the queue */
-        void pop_front()
+        void pop()
         {
             /* Aquire the lock */
             std::unique_lock<std::mutex> lock(m_mutex);
@@ -111,13 +106,13 @@ class ThreadSafeDeque
                force a removal short of running it in a while loop.
                Instead, if we just force the queue to have to have data in,
                we can make sure a removal always suceeds. */
-            if (m_deque.empty())
+            if (m_priorityQueue.empty())
             {
                 throw std::runtime_error("Cannot remove from an empty queue!");
             }
 
             /* Remove the first item from the queue */
-            m_deque.pop_front();
+            m_priorityQueue.pop();
 
             /* Unlock the mutex before notifying, so it doesn't block after
                waking up */
@@ -126,8 +121,26 @@ class ThreadSafeDeque
             m_consumedData.notify_all();
         }
 
+        /* Delete the front item from the queue, without aquiring the lock */
+        void pop_unsafe()
+        {
+            m_priorityQueue.pop();
+        }
+
+        /* Get the top item, without aquiring the lock */
+        T top_unsafe()
+        {
+            return m_priorityQueue.top();
+        }
+
+        /* Determine if the container is empty, without aquiring the lock */
+        bool empty_unsafe()
+        {
+            return m_priorityQueue.empty();
+        }
+
         /* Removes numElements from the start of the queue */
-        void pop_front_n(size_t numElements)
+        void pop_n(size_t numElements)
         {
             /* Aquire the lock */
             std::unique_lock<std::mutex> lock(m_mutex);
@@ -140,12 +153,12 @@ class ThreadSafeDeque
                force a removal short of running it in a while loop.
                Instead, if we just force the queue to have to have data in,
                we can make sure a removal always suceeds. */
-            if (m_deque.empty())
+            if (m_priorityQueue.empty())
             {
                 throw std::runtime_error("Cannot remove from an empty queue!");
             }
 
-            if (m_deque.size() < numElements)
+            if (m_priorityQueue.size() < numElements)
             {
                 throw std::runtime_error("Cannot remove more elements than are stored!");
             }
@@ -153,7 +166,7 @@ class ThreadSafeDeque
             while (numElements > 0)
             {
                 /* Remove first item from queue */
-                m_deque.pop_front();
+                m_priorityQueue.pop_front();
                 numElements--;
             }
 
@@ -165,43 +178,15 @@ class ThreadSafeDeque
         }
 
         /* Take an item from the front of the queue, and do NOT remove it */
-        T front()
+        T top()
         {
             return getFirstItem(false);
         }
 
         /* Take and remove an item from the front of the queue */
-        T front_and_remove()
+        T top_and_remove()
         {
             return getFirstItem(true);
-        }
-
-        std::vector<T> front_n_and_remove(const size_t numElements)
-        {
-            /* Aquire the lock */
-            std::unique_lock<std::mutex> lock(m_mutex);
-
-            std::vector<T> results;
-
-            if (m_deque.size() == 0)
-            {
-                return results;
-            }
-
-            if (m_deque.size() <= numElements)
-            {
-                results.resize(m_deque.size());
-                std::copy(m_deque.begin(), m_deque.end(), results.begin());
-                m_deque.clear();
-            }
-            else
-            {
-                results.resize(numElements);
-                std::copy(m_deque.begin(), m_deque.begin() + numElements, results.begin());
-                m_deque.erase(m_deque.begin(), m_deque.begin() + numElements);
-            }
-
-            return results;
         }
 
         /* Stop the queue if something is waiting on it, so we don't block
@@ -231,56 +216,7 @@ class ThreadSafeDeque
                but hey) */
             std::unique_lock<std::mutex> lock(m_mutex);
 
-            return m_deque.size();
-        }
-
-        /* Takes n elements, if available, starting at the head of the queue.
-           Otherwise returns max available. Does not remove items from the queue. */
-        std::vector<T> front_n(const size_t numElements) const
-        {
-            std::cout << "Requested " << numElements << " blocks. Available: "
-                      << m_deque.size() << std::endl;
-
-            /* Aquire the lock */
-            std::unique_lock<std::mutex> lock(m_mutex);
-
-            std::vector<T> results;
-
-            if (m_deque.size() <= numElements)
-            {
-                results.resize(m_deque.size());
-                std::copy(m_deque.begin(), m_deque.end(), results.begin());
-            }
-            else
-            {
-                results.resize(numElements);
-                std::copy(m_deque.begin(), m_deque.begin() + numElements, results.begin());
-            }
-
-            return results;
-        }
-
-        /* Takes n elements, if available, starting at the tail of the queue.
-           Otherwise returns max available. Does not remove items from the queue. */
-        std::vector<T> back_n(const size_t numElements) const
-        {
-            /* Aquire the lock */
-            std::unique_lock<std::mutex> lock(m_mutex);
-
-            std::vector<T> results;
-
-            if (m_deque.size() <= numElements)
-            {
-                results.resize(m_deque.size());
-                std::copy(m_deque.rbegin(), m_deque.rend(), results.begin());
-            }
-            else
-            {
-                results.resize(numElements);
-                std::copy(m_deque.rbegin(), m_deque.rbegin() + numElements, results.begin());
-            }
-
-            return results;
+            return m_priorityQueue.size();
         }
 
         void clear()
@@ -288,27 +224,10 @@ class ThreadSafeDeque
             /* Aquire the lock */
             std::unique_lock<std::mutex> lock(m_mutex);
 
-            m_deque.clear();
-        }
-        
-        /* Recommended to implement a memoryUsage() method for your type, if not using
-           a simple type, and pass to the below function instead.
-           Otherwise, sizeof() is unlikely to be accurate. */
-        size_t memoryUsage() const
-        {
-            return m_deque.size() * sizeof(T) + sizeof(m_deque);
-        }
-
-        size_t memoryUsage(std::function<size_t(T)> memUsage) const
-        {
-            return std::accumulate(
-                m_deque.begin(),
-                m_deque.end(),
-                sizeof(m_deque),
-                [&memUsage](const auto acc, const auto item) {
-
-                return acc + memUsage(item);
-            });
+            while (!m_priorityQueue.empty())
+            {
+                m_priorityQueue.pop();
+            }
         }
 
     private:
@@ -335,7 +254,7 @@ class ThreadSafeDeque
                     return true;
                 }
 
-                return !m_deque.empty();
+                return !m_priorityQueue.empty();
             });
 
             /* Stopping, don't return data */
@@ -345,12 +264,12 @@ class ThreadSafeDeque
             }
 
             /* Get the first item in the queue */
-            item = m_deque.front();
+            item = m_priorityQueue.top();
 
             /* Remove the first item from the queue */
             if (removeFromQueue)
             {
-                m_deque.pop_front();
+                m_priorityQueue.pop();
             }
 
             /* Unlock the mutex before notifying, so it doesn't block after
@@ -363,9 +282,8 @@ class ThreadSafeDeque
             return item;
         }
         
-    private:
         /* The deque data structure */
-        std::deque<T> m_deque;
+        std::priority_queue<T, std::vector<T>, Comparison> m_priorityQueue;
 
         /* The mutex, to ensure we have atomic access to the queue */
         mutable std::mutex m_mutex;

--- a/src/WalletApi/ApiDispatcher.cpp
+++ b/src/WalletApi/ApiDispatcher.cpp
@@ -36,12 +36,20 @@ ApiDispatcher::ApiDispatcher(
     const uint16_t bindPort,
     const std::string rpcBindIp,
     const std::string rpcPassword,
-    const std::string corsHeader) :
+    const std::string corsHeader,
+    unsigned int walletSyncThreads) :
     m_port(bindPort),
     m_host(rpcBindIp),
     m_corsHeader(corsHeader),
     m_rpcPassword(rpcPassword)
 {
+    if (walletSyncThreads == 0)
+    {
+        walletSyncThreads = 1;
+    }
+
+    m_walletSyncThreads = walletSyncThreads;
+
     /* Generate the salt used for pbkdf2 api authentication */
     Random::randomBytes(16, m_salt);
 
@@ -378,7 +386,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::openWallet(
     Error error;
 
     std::tie(error, m_walletBackend) = WalletBackend::openWallet(
-        filename, password, daemonHost, daemonPort, daemonSSL
+        filename, password, daemonHost, daemonPort, daemonSSL, m_walletSyncThreads
     );
 
     return {error, 200};
@@ -407,7 +415,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::keyImportWallet(
 
     std::tie(error, m_walletBackend) = WalletBackend::importWalletFromKeys(
         privateSpendKey, privateViewKey, filename, password, scanHeight,
-        daemonHost, daemonPort, daemonSSL
+        daemonHost, daemonPort, daemonSSL, m_walletSyncThreads
     );
 
     return {error, 200};
@@ -434,7 +442,8 @@ std::tuple<Error, uint16_t> ApiDispatcher::seedImportWallet(
     Error error;
 
     std::tie(error, m_walletBackend) = WalletBackend::importWalletFromSeed(
-        mnemonicSeed, filename, password, scanHeight, daemonHost, daemonPort, daemonSSL
+        mnemonicSeed, filename, password, scanHeight, daemonHost, daemonPort,
+        daemonSSL, m_walletSyncThreads
     );
 
     return {error, 200};
@@ -463,7 +472,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::importViewWallet(
 
     std::tie(error, m_walletBackend) = WalletBackend::importViewWallet(
         privateViewKey, address, filename, password, scanHeight,
-        daemonHost, daemonPort, daemonSSL
+        daemonHost, daemonPort, daemonSSL, m_walletSyncThreads
     );
 
     return {error, 200};
@@ -481,7 +490,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::createWallet(
     Error error;
 
     std::tie(error, m_walletBackend) = WalletBackend::createWallet(
-        filename, password, daemonHost, daemonPort, daemonSSL
+        filename, password, daemonHost, daemonPort, daemonSSL, m_walletSyncThreads
     );
 
     return {error, 200};

--- a/src/WalletApi/ApiDispatcher.h
+++ b/src/WalletApi/ApiDispatcher.h
@@ -54,7 +54,8 @@ class ApiDispatcher
             const uint16_t bindPort,
             const std::string rpcBindIp,
             const std::string rpcPassword,
-            std::string corsHeader);
+            std::string corsHeader,
+            unsigned int walletSyncThreads = std::thread::hardware_concurrency());
 
         /////////////////////////////
         /* Public member functions */
@@ -378,4 +379,7 @@ class ApiDispatcher
 
         /* Used along with our password with pbkdf2 */
         CryptoPP::byte m_salt[16];
+
+        /* Amount of threads to use during wallet syncing */
+        unsigned int m_walletSyncThreads;
 };

--- a/src/WalletApi/ParseArguments.cpp
+++ b/src/WalletApi/ParseArguments.cpp
@@ -30,10 +30,9 @@ Config parseArguments(int argc, char **argv)
 
     options.add_options("Core")
         ("h,help", "Display this help message", cxxopts::value<bool>(help)->implicit_value("true"))
-
-        ("v,version", "Output software version information", cxxopts::value<bool>(version)->default_value("false")->implicit_value("true"))
         ("log-level", "Specify log level", cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)), "#")
-        ("threads", "Specify number of wallet sync threads", cxxopts::value<unsigned int>(threads)->default_value(std::to_string(std::max(1u, std::thread::hardware_concurrency()))), "#");
+        ("threads", "Specify number of wallet sync threads", cxxopts::value<unsigned int>(threads)->default_value(std::to_string(std::max(1u, std::thread::hardware_concurrency()))), "#")
+        ("v,version", "Output software version information", cxxopts::value<bool>(version)->default_value("false")->implicit_value("true"));
 
     options.add_options("Network")
         ("p,port", "The port to listen on for http requests",

--- a/src/WalletApi/ParseArguments.cpp
+++ b/src/WalletApi/ParseArguments.cpp
@@ -12,6 +12,8 @@
 #include <config/CryptoNoteConfig.h>
 #include <config/WalletConfig.h>
 
+#include <thread>
+
 #include "version.h"
 
 Config parseArguments(int argc, char **argv)
@@ -24,11 +26,14 @@ Config parseArguments(int argc, char **argv)
 
     int logLevel;
 
+    unsigned int threads;
+
     options.add_options("Core")
         ("h,help", "Display this help message", cxxopts::value<bool>(help)->implicit_value("true"))
 
         ("v,version", "Output software version information", cxxopts::value<bool>(version)->default_value("false")->implicit_value("true"))
-        ("log-level", "Specify log level", cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)), "#");
+        ("log-level", "Specify log level", cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)), "#")
+        ("threads", "Specify number of wallet sync threads", cxxopts::value<unsigned int>(threads)->default_value(std::to_string(std::max(1u, std::thread::hardware_concurrency()))), "#");
 
     options.add_options("Network")
         ("p,port", "The port to listen on for http requests",
@@ -81,6 +86,16 @@ Config parseArguments(int argc, char **argv)
     else
     {
         config.logLevel = static_cast<Logger::LogLevel>(logLevel);
+    }
+
+    if (threads == 0)
+    {
+        std::cout << "Thread count must be at least 1" << std::endl;
+        exit(1);
+    }
+    else
+    {
+        config.threads = threads;
     }
 
     return config;

--- a/src/WalletApi/ParseArguments.h
+++ b/src/WalletApi/ParseArguments.h
@@ -24,6 +24,8 @@ struct Config
 
     /* Controls what level of messages to log */
     Logger::LogLevel logLevel = Logger::DISABLED;
+
+    unsigned int threads;
 };
 
 Config parseArguments(int argc, char **argv);

--- a/src/WalletApi/WalletApi.cpp
+++ b/src/WalletApi/WalletApi.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
         /* Init the API */
         api = std::make_shared<ApiDispatcher>(
             config.port, config.rpcBindIp, config.rpcPassword,
-            config.corsHeader
+            config.corsHeader, config.threads
         );
 
         /* Launch the API */

--- a/src/WalletBackend/BlockDownloader.h
+++ b/src/WalletBackend/BlockDownloader.h
@@ -46,7 +46,7 @@ class BlockDownloader
         /* Retrieve blockCount blocks from the internal store. does not remove
            them. Returns as many as possible if the amount requested is not
            available. May be empty (this is the norm when synced.) */
-        std::vector<WalletTypes::WalletBlockInfo> fetchBlocks(const size_t blockCount);
+        std::vector<std::tuple<WalletTypes::WalletBlockInfo, uint32_t>> fetchBlocks(const size_t blockCount);
 
         /* Drops the oldest block from the internal queue */
         void dropBlock(const uint64_t blockHeight, const Crypto::Hash blockHash);
@@ -97,7 +97,7 @@ class BlockDownloader
         //////////////////////////////
 
         /* Cached blocks */
-        ThreadSafeDeque<WalletTypes::WalletBlockInfo> m_storedBlocks;
+        ThreadSafeDeque<std::tuple<WalletTypes::WalletBlockInfo, uint32_t>> m_storedBlocks;
 
         /* The daemon connection */
         std::shared_ptr<Nigel> m_daemon;
@@ -127,4 +127,6 @@ class BlockDownloader
 
         /* Thread that performs the actual downloading of blocks */
         std::thread m_downloadThread;
+
+        uint32_t m_arrivalIndex = 0;
 };

--- a/src/WalletBackend/Constants.h
+++ b/src/WalletBackend/Constants.h
@@ -65,5 +65,5 @@ namespace Constants
        then split into threads and process. Too large will result in large
        jumps in the sync height, but should offer better performance from a
        decrease in locking of data structures. */
-    const uint64_t BLOCK_PROCESSING_CHUNK = 200;
+    const uint64_t BLOCK_PROCESSING_CHUNK = 500;
 }

--- a/src/WalletBackend/WalletBackend.h
+++ b/src/WalletBackend/WalletBackend.h
@@ -64,7 +64,8 @@ class WalletBackend
             const uint64_t scanHeight,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount = std::thread::hardware_concurrency());
 
         /* Imports a wallet from a private spend key and a view key. Returns
            the wallet class, or an error. */
@@ -76,7 +77,8 @@ class WalletBackend
             const uint64_t scanHeight,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount = std::thread::hardware_concurrency());
 
         /* Imports a view wallet from a private view key and an address.
            Returns the wallet class, or an error. */
@@ -88,7 +90,8 @@ class WalletBackend
             const uint64_t scanHeight,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount = std::thread::hardware_concurrency());
 
         /* Creates a new wallet with the given filename and password */
         static std::tuple<Error, std::shared_ptr<WalletBackend>> createWallet(
@@ -96,7 +99,8 @@ class WalletBackend
             const std::string password,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount = std::thread::hardware_concurrency());
 
         /* Opens a wallet already on disk with the given filename + password */
         static std::tuple<Error, std::shared_ptr<WalletBackend>> openWallet(
@@ -104,7 +108,8 @@ class WalletBackend
             const std::string password,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount = std::thread::hardware_concurrency());
 
         /////////////////////////////
         /* Public member functions */
@@ -127,7 +132,8 @@ class WalletBackend
             const std::string password,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount);
 
         /* Send a transaction of amount to destination with paymentID */
         std::tuple<Error, Crypto::Hash> sendTransactionBasic(
@@ -279,7 +285,8 @@ class WalletBackend
             const bool newWallet,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount);
 
         /* View wallet constructor */
         WalletBackend(
@@ -290,7 +297,8 @@ class WalletBackend
             const uint64_t scanHeight,
             const std::string daemonHost,
             const uint16_t daemonPort,
-            const bool daemonSSL);
+            const bool daemonSSL,
+            const unsigned int syncThreadCount);
 
         //////////////////////////////
         /* Private member functions */
@@ -317,23 +325,9 @@ class WalletBackend
         /* The daemon connection */
         std::shared_ptr<Nigel> m_daemon = nullptr;
 
-        /* We use a shared pointer here, because we start the thread in the
-           class, with the class as a context, hence, when we go to move the
-           WalletSynchronizer class, the thread gets moved() across, but it
-           is still pointing to a class which has been moved from, which
-           is undefined behaviour. So, none of our changes to the
-           WalletSynchronizer class reflect in the thread.
-
-           The ideal way to fix this would probably to disable move semantics,
-           and just assign once - however this is pretty tricky to do, as
-           we want to use the factory pattern so we're not initializing
-           with crappy data, and can return a meaningful error to the user
-           rather than having to throw() or check isInitialized() everywhere.
-
-           More info here: https://stackoverflow.com/q/43203869/8737306
-
-           PS: I want to die */
         std::shared_ptr<WalletSynchronizer> m_walletSynchronizer;
 
         std::shared_ptr<WalletSynchronizerRAIIWrapper> m_syncRAIIWrapper;
+
+        unsigned int m_syncThreadCount;
 };

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -194,10 +194,18 @@ void WalletSynchronizer::blockProcessingThread()
     /* Take the max chunk size, split by the threads, divided by 2. So in
        theory, each thread processes 2 chunks. This is to decrease locking,
        while also trying to stop slower threads from delaying the system. */
-    const size_t chunkSize = std::max(
-        (Constants::BLOCK_PROCESSING_CHUNK / m_threadCount) / 2,
-        1ul
-    );
+    size_t chunkSize = Constants::BLOCK_PROCESSING_CHUNK / m_threadCount / 2;
+
+    if (chunkSize == 0)
+    {
+        chunkSize = 1;
+    }
+
+    /* No point splitting into chunks if we're only using 1 thread */
+    if (m_threadCount == 1)
+    {
+        chunkSize = Constants::BLOCK_PROCESSING_CHUNK;
+    }
 
     std::vector<SemiProcessedBlock> processedBlocks;
 

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -335,7 +335,7 @@ void WalletSynchronizer::completeBlockProcessing(
     const std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> &ourInputs)
 {
     /* Chain forked, invalidate previous transactions */
-    if (m_blockDownloader.getHeight() >= block.blockHeight)
+    if (m_blockDownloader.getHeight() >= block.blockHeight && block.blockHeight != 0)
     {
         Logger::logger.log(
             "Blockchain forked, resolving...",
@@ -414,7 +414,7 @@ void WalletSynchronizer::completeBlockProcessing(
     }
 
     Logger::logger.log(
-        "Finshed processing block " + std::to_string(block.blockHeight),
+        "Finished processing block " + std::to_string(block.blockHeight),
         Logger::DEBUG,
         {Logger::SYNC}
     );

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -163,7 +163,7 @@ void WalletSynchronizer::mainLoop()
             /* Nothing else should be pushing to the queue here, since the
                child threads are waiting for a new chunk, so don't need to
                use mutex to access */
-            while (!m_processedBlocks.empty_unsafe())
+            while (!m_processedBlocks.empty_unsafe() && !m_shouldStop)
             {
                 const auto [block, ourInputs, arrivalIndex] = m_processedBlocks.top_unsafe();
                 completeBlockProcessing(block, ourInputs);

--- a/src/WalletBackend/WalletSynchronizer.cpp
+++ b/src/WalletBackend/WalletSynchronizer.cpp
@@ -34,6 +34,16 @@ WalletSynchronizer::WalletSynchronizer() :
     m_startTimestamp(0),
     m_startHeight(0)
 {
+    unsigned int threads = std::thread::hardware_concurrency();
+
+    /* Number of concurrent threads supported.
+       If the value is not well defined or not computable, returns 0. */
+    if (threads == 0)
+    {
+        threads = 1;
+    }
+
+    m_threadCount = threads;
 }
 
 /* Parameterized constructor */
@@ -42,7 +52,8 @@ WalletSynchronizer::WalletSynchronizer(
     const uint64_t startHeight,
     const uint64_t startTimestamp,
     const Crypto::SecretKey privateViewKey,
-    const std::shared_ptr<EventHandler> eventHandler) :
+    const std::shared_ptr<EventHandler> eventHandler,
+    unsigned int threadCount) :
 
     m_daemon(daemon),
     m_shouldStop(false),
@@ -52,6 +63,12 @@ WalletSynchronizer::WalletSynchronizer(
     m_eventHandler(eventHandler),
     m_blockDownloader(daemon, nullptr, startHeight, startTimestamp)
 {
+    if (threadCount == 0)
+    {
+        threadCount = 1;
+    }
+
+    m_threadCount = threadCount;
 }
 
 /* Move constructor */
@@ -80,6 +97,14 @@ WalletSynchronizer & WalletSynchronizer::operator=(WalletSynchronizer && old)
 
     m_blockDownloader = std::move(old.m_blockDownloader);
 
+    m_subWallets = std::move(old.m_subWallets);
+
+    m_blockProcessingQueue = std::move(old.m_blockProcessingQueue);
+
+    m_processedBlocks = std::move(old.m_processedBlocks);
+
+    m_threadCount = std::move(old.m_threadCount);
+
     return *this;
 }
 
@@ -101,14 +126,48 @@ void WalletSynchronizer::mainLoop()
     {
         const auto blocks = m_blockDownloader.fetchBlocks(Constants::BLOCK_PROCESSING_CHUNK);
 
-        for (const auto &block : blocks)
+        if (!blocks.empty())
         {
-            if (m_shouldStop)
+            m_blockProcessingQueue.push_back_n(blocks.begin(), blocks.end());
+
+            /* Tell the child threads to wake up */
+            m_haveBlocksToProcess.notify_all();
+
+            const size_t chunkSize = blocks.size();
+
             {
-                return;
+                /* *possibly* should use another mutex here for the different
+                    condition variable? I think it's fine since we're only
+                    stopping the child threads from aquiring the mutex for
+                    a very short time (since the check will fail when not all
+                    blocks are available) */
+                std::unique_lock<std::mutex> lock(m_mutex);
+
+                m_haveProcessedBlocksToHandle.wait(lock, [&]{
+                    if (m_shouldStop)
+                    {
+                        return true;
+                    }
+                    
+                    /* Wait until all the blocks have been added to the queue */
+                    return m_processedBlocks.size() == chunkSize;
+                });
+
+                if (m_shouldStop)
+                {
+                    return;
+                }
             }
 
-            processBlock(block);
+            /* Nothing else should be pushing to the queue here, since the
+               child threads are waiting for a new chunk, so don't need to
+               use mutex to access */
+            while (!m_processedBlocks.empty_unsafe())
+            {
+                const auto [block, ourInputs] = m_processedBlocks.top_unsafe();
+                completeBlockProcessing(block, ourInputs);
+                m_processedBlocks.pop_unsafe();
+            }
         }
 
         /* If we're synced, check any transactions that may be in the pool */
@@ -126,6 +185,114 @@ void WalletSynchronizer::mainLoop()
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }
+    }
+}
+
+void WalletSynchronizer::blockProcessingThread()
+{
+    /* Take the max chunk size, split by the threads, divided by 2. So in
+       theory, each thread processes 2 chunks. This is to decrease locking,
+       while also trying to stop slower threads from delaying the system. */
+    const size_t chunkSize = std::max(
+        (Constants::BLOCK_PROCESSING_CHUNK / m_threadCount) / 2,
+        1ul
+    );
+
+    std::vector<SemiProcessedBlock> processedBlocks;
+
+    while (!m_shouldStop)
+    {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            /* Wait for blocks to be available */
+            m_haveBlocksToProcess.wait(lock, [&]{
+                if (m_shouldStop)
+                {
+                    return true;
+                }
+
+                return m_blockProcessingQueue.size() > 0;
+            });
+
+            if (m_shouldStop)
+            {
+                return;
+            }
+        }
+
+        auto chunk = m_blockProcessingQueue.front_n_and_remove(chunkSize);
+
+        /* Process blocks while we've got more to process */
+        while (!chunk.empty() && !m_shouldStop)
+        {
+            for (const auto &block : chunk)
+            {
+                Logger::logger.log(
+                    "Processing block " + std::to_string(block.blockHeight),
+                    Logger::DEBUG,
+                    {Logger::SYNC}
+                );
+
+                auto ourInputs = processBlockOutputs(block);
+
+                std::unordered_map<Crypto::Hash, std::vector<uint64_t>> globalIndexes;
+
+                for (auto &[publicKey, input] : ourInputs)
+                {
+                    if (!m_subWallets->isViewWallet() && !input.globalOutputIndex)
+                    {
+                        if (globalIndexes.empty())
+                        {
+                            globalIndexes = getGlobalIndexes(block.blockHeight);
+                        }
+
+                        const auto it = globalIndexes.find(input.parentTransactionHash);
+
+                        /* Daemon returns indexes for hashes in a range. If we don't
+                           find our hash, either the chain has forked, or the daemon
+                           is faulty. Print a warning message, then return so we
+                           can fetch new blocks, in the likely case the daemon has
+                           forked.
+
+                           Also need to check there are enough indexes for the one we want */
+                        if (it == globalIndexes.end() || it->second.size() <= input.transactionIndex)
+                        {
+                            Logger::logger.log(
+                                "Warning: Failed to get correct global indexes from daemon."
+                                "\nIf you see this error message repeatedly, the daemon "
+                                "may be faulty. More likely, the chain just forked.",
+                                Logger::WARNING,
+                                {Logger::SYNC, Logger::DAEMON}
+                            );
+
+                            return;
+                        }
+
+                        input.globalOutputIndex = it->second[input.transactionIndex];
+                    }
+                }
+
+                processedBlocks.push_back({ block, ourInputs });
+            }
+
+            chunk = m_blockProcessingQueue.front_n_and_remove(chunkSize);
+        }
+
+        /* Push our processed blocks */
+        if (!processedBlocks.empty())
+        {
+            /* Store this chunks worth of blocks */
+            m_processedBlocks.push_n(processedBlocks.begin(), processedBlocks.end());
+
+            /* Notify the parent thread we've pushed data to the queue */
+            m_haveProcessedBlocksToHandle.notify_all();
+
+            /* Empty the processed blocks */
+            processedBlocks.clear();
+        }
+
+        /* Then go back to waiting for more data */
     }
 }
 
@@ -153,14 +320,10 @@ std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> Wallet
     return inputs;
 }
 
-void WalletSynchronizer::processBlock(const WalletTypes::WalletBlockInfo &block)
+void WalletSynchronizer::completeBlockProcessing(
+    const WalletTypes::WalletBlockInfo &block,
+    const std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> &ourInputs)
 {
-    Logger::logger.log(
-        "Processing block " + std::to_string(block.blockHeight),
-        Logger::DEBUG,
-        {Logger::SYNC}
-    );
-
     /* Chain forked, invalidate previous transactions */
     if (m_blockDownloader.getHeight() >= block.blockHeight)
     {
@@ -178,45 +341,6 @@ void WalletSynchronizer::processBlock(const WalletTypes::WalletBlockInfo &block)
      && block.blockHeight > Constants::PRUNE_SPENT_INPUTS_INTERVAL)
     {
         m_subWallets->pruneSpentInputs(block.blockHeight - Constants::PRUNE_SPENT_INPUTS_INTERVAL);
-    }
-
-    auto ourInputs = processBlockOutputs(block);
-
-    std::unordered_map<Crypto::Hash, std::vector<uint64_t>> globalIndexes;
-
-    for (auto &[publicKey, input] : ourInputs)
-    {
-        if (!m_subWallets->isViewWallet() && !input.globalOutputIndex)
-        {
-            if (globalIndexes.empty())
-            {
-                globalIndexes = getGlobalIndexes(block.blockHeight);
-            }
-
-            const auto it = globalIndexes.find(input.parentTransactionHash);
-
-            /* Daemon returns indexes for hashes in a range. If we don't
-               find our hash, either the chain has forked, or the daemon
-               is faulty. Print a warning message, then return so we
-               can fetch new blocks, in the likely case the daemon has
-               forked.
-
-               Also need to check there are enough indexes for the one we want */
-            if (it == globalIndexes.end() || it->second.size() <= input.transactionIndex)
-            {
-                Logger::logger.log(
-                    "Warning: Failed to get correct global indexes from daemon."
-                    "\nIf you see this error message repeatedly, the daemon "
-                    "may be faulty. More likely, the chain just forked.",
-                    Logger::WARNING,
-                    {Logger::SYNC, Logger::DAEMON}
-                );
-
-                return;
-            }
-
-            input.globalOutputIndex = it->second[input.transactionIndex];
-        }
     }
 
     BlockScanTmpInfo blockScanInfo = processBlockTransactions(block, ourInputs);
@@ -572,8 +696,17 @@ void WalletSynchronizer::start()
     }
 
     m_blockDownloader.start();
+    m_blockProcessingQueue.start();
+    m_processedBlocks.start();
 
     m_syncThread = std::thread(&WalletSynchronizer::mainLoop, this);
+
+    m_syncThreads.clear();
+
+    for (unsigned int i = 0; i < m_threadCount; i++)
+    {
+        m_syncThreads.push_back(std::thread(&WalletSynchronizer::blockProcessingThread, this));
+    }
 }
 
 void WalletSynchronizer::stop()
@@ -589,11 +722,28 @@ void WalletSynchronizer::stop()
 
     /* Tell the block downloader to stop and wait for it */
     m_blockDownloader.stop();
+    m_blockProcessingQueue.stop();
+    m_processedBlocks.stop();
+
+    m_haveBlocksToProcess.notify_all();
+    m_haveProcessedBlocksToHandle.notify_all();
+
+    m_blockProcessingQueue.clear();
+    m_processedBlocks.clear();
 
     /* Wait for the block downloader thread to finish (if applicable) */
     if (m_syncThread.joinable())
     {
         m_syncThread.join();
+    }
+
+    /* Wait for each child thread to finish */
+    for (auto &thread : m_syncThreads)
+    {
+        if (thread.joinable())
+        {
+            thread.join();
+        }
     }
 }
 
@@ -619,11 +769,19 @@ void WalletSynchronizer::removeForkedTransactions(const uint64_t forkHeight)
 
 void WalletSynchronizer::initializeAfterLoad(
     const std::shared_ptr<Nigel> daemon,
-    const std::shared_ptr<EventHandler> eventHandler)
+    const std::shared_ptr<EventHandler> eventHandler,
+    unsigned int threadCount)
 {
     m_daemon = daemon;
     m_eventHandler = eventHandler;
     m_blockDownloader.initializeAfterLoad(m_daemon);
+
+    if (threadCount == 0)
+    {
+        threadCount = 1;
+    }
+
+    m_threadCount = threadCount;
 }
 
 uint64_t WalletSynchronizer::getCurrentScanHeight() const

--- a/src/WalletBackend/WalletSynchronizer.h
+++ b/src/WalletBackend/WalletSynchronizer.h
@@ -10,11 +10,17 @@
 
 #include <SubWallets/SubWallets.h>
 
+#include <Utilities/ThreadSafeDeque.h>
+#include <Utilities/ThreadSafePriorityQueue.h>
+
 #include <WalletBackend/BlockDownloader.h>
 #include <WalletBackend/EventHandler.h>
 #include <WalletBackend/SynchronizationStatus.h>
 
 #include <WalletTypes.h>
+
+typedef std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> BlockInputsAndOwners;
+typedef std::tuple<WalletTypes::WalletBlockInfo, BlockInputsAndOwners> SemiProcessedBlock;
 
 /* Used to store the data we have accumulating when scanning a specific
    block. We can't add the items directly, because we may stop midway
@@ -26,10 +32,19 @@ struct BlockScanTmpInfo
 
     /* The corresponding inputs to the transactions, indexed by public key
        (i.e., the corresponding subwallet to add the input to) */
-    std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> inputsToAdd;
+    BlockInputsAndOwners inputsToAdd;
 
     /* Need to mark these as spent so we don't include them later */
     std::vector<std::tuple<Crypto::PublicKey, Crypto::KeyImage>> keyImagesToMarkSpent;
+};
+
+class OrderByHeight
+{
+    public:
+        bool operator() (SemiProcessedBlock a, SemiProcessedBlock b)
+        {
+            return std::get<0>(a).blockHeight > std::get<0>(b).blockHeight;
+        }
 };
 
 class WalletSynchronizer
@@ -48,7 +63,8 @@ class WalletSynchronizer
             const uint64_t startTimestamp,
             const uint64_t startHeight,
             const Crypto::SecretKey privateViewKey,
-            const std::shared_ptr<EventHandler> eventHandler);
+            const std::shared_ptr<EventHandler> eventHandler,
+            unsigned int threadCount);
 
         /* Delete the copy constructor */
         WalletSynchronizer(const WalletSynchronizer &) = delete;
@@ -81,7 +97,8 @@ class WalletSynchronizer
 
         void initializeAfterLoad(
             const std::shared_ptr<Nigel> daemon,
-            const std::shared_ptr<EventHandler> eventHandler);
+            const std::shared_ptr<EventHandler> eventHandler,
+            unsigned int threadCount);
 
         void reset(uint64_t startHeight);
 
@@ -101,10 +118,14 @@ class WalletSynchronizer
 
         void mainLoop();
 
+        void blockProcessingThread();
+
         std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> processBlockOutputs(
             const WalletTypes::WalletBlockInfo &block) const;
 
-        void processBlock(const WalletTypes::WalletBlockInfo &block);
+        void completeBlockProcessing(
+            const WalletTypes::WalletBlockInfo &block,
+            const std::vector<std::tuple<Crypto::PublicKey, WalletTypes::TransactionInput>> &ourInputs);
 
         BlockScanTmpInfo processBlockTransactions(
             const WalletTypes::WalletBlockInfo &block,
@@ -159,4 +180,29 @@ class WalletSynchronizer
 
         /* The sub wallets (shared with the main class) */
         std::shared_ptr<SubWallets> m_subWallets;
+
+        /* Stores blocks for processing by processing threads */
+        ThreadSafeDeque<WalletTypes::WalletBlockInfo> m_blockProcessingQueue;
+
+        /* Synchronizes the child threads waiting for blocks to process
+           and the parent pushing blocks in */
+        std::condition_variable m_haveBlocksToProcess;
+
+        /* Synchronizes the child threads pushing blocks into the priority
+           queue and the parent thread waiting for them all to arrive */
+        std::condition_variable m_haveProcessedBlocksToHandle;
+
+        std::mutex m_mutex;
+
+        /* yeah.... that's a thread safe queue, which holds a block, and it's
+           corresponding inputs, and the subwallet public key that each input
+           belongs to. The blocks with smaller height come at the front of
+           the queue. */
+        ThreadSafePriorityQueue<SemiProcessedBlock, OrderByHeight> m_processedBlocks;
+
+        /* Amount of sync threads to run */
+        unsigned int m_threadCount;
+
+        /* Stores thread ids of the block output processing threads */
+        std::vector<std::thread> m_syncThreads;
 };

--- a/src/zedwallet++/Open.cpp
+++ b/src/zedwallet++/Open.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<WalletBackend> importViewWallet(const Config &config)
 
     auto [error, walletBackend] = WalletBackend::importViewWallet(
         privateViewKey, address, walletFileName, walletPass, scanHeight,
-        config.host, config.port, config.ssl
+        config.host, config.port, config.ssl, config.threads
     );
 
     if (error)
@@ -121,7 +121,7 @@ std::shared_ptr<WalletBackend> importWalletFromKeys(const Config &config)
 
     const auto [error, walletBackend] = WalletBackend::importWalletFromKeys(
         privateSpendKey, privateViewKey, walletFileName, walletPass,
-        scanHeight, config.host, config.port, config.ssl
+        scanHeight, config.host, config.port, config.ssl, config.threads
     );
 
     if (error)
@@ -178,7 +178,7 @@ std::shared_ptr<WalletBackend> importWalletFromSeed(const Config &config)
 
     auto [error, walletBackend] = WalletBackend::importWalletFromSeed(
         mnemonicSeed, walletFileName, walletPass, scanHeight,
-        config.host, config.port, config.ssl
+        config.host, config.port, config.ssl, config.threads
     );
 
     if (error)
@@ -209,7 +209,8 @@ std::shared_ptr<WalletBackend> createWallet(const Config &config)
     const std::string walletPass = getWalletPassword(verifyPassword, msg);
 
     const auto [error, walletBackend] = WalletBackend::createWallet(
-        walletFileName, walletPass, config.host, config.port, config.ssl
+        walletFileName, walletPass, config.host, config.port, config.ssl,
+        config.threads
     );
 
     if (error)
@@ -255,7 +256,8 @@ std::shared_ptr<WalletBackend> openWallet(const Config &config)
         }
 
         const auto [error, walletBackend] = WalletBackend::openWallet(
-            walletFileName, walletPass, config.host, config.port, config.ssl
+            walletFileName, walletPass, config.host, config.port, config.ssl,
+            config.threads
         );
 
         if (error == WRONG_PASSWORD)

--- a/src/zedwallet++/ParseArguments.cpp
+++ b/src/zedwallet++/ParseArguments.cpp
@@ -32,6 +32,8 @@ Config parseArguments(int argc, char **argv)
 
     int logLevel;
 
+    unsigned int threads;
+
     options.add_options("Core")
         ("h,help", "Display this help message", cxxopts::value<bool>(help)->implicit_value("true"))
         ("v,version", "Output software version information", cxxopts::value<bool>(version)->default_value("false")->implicit_value("true"));
@@ -48,7 +50,8 @@ Config parseArguments(int argc, char **argv)
     options.add_options("Wallet")
         ("w,wallet-file", "Open the wallet <file>", cxxopts::value<std::string>(config.walletFile), "<file>")
         ("p,password", "Use the password <pass> to open the wallet", cxxopts::value<std::string>(config.walletPass), "<pass>")
-        ("log-level", "Specify log level", cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)), "#");
+        ("log-level", "Specify log level", cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)), "#")
+        ("threads", "Specify number of wallet sync threads", cxxopts::value<unsigned int>(threads)->default_value(std::to_string(std::max(1u, std::thread::hardware_concurrency()))), "#");
 
     try
     {
@@ -85,6 +88,16 @@ Config parseArguments(int argc, char **argv)
     else
     {
         config.logLevel = static_cast<Logger::LogLevel>(logLevel);
+    }
+
+    if (threads == 0)
+    {
+        std::cout << "Thread count must be at least 1" << std::endl;
+        exit(1);
+    }
+    else
+    {
+        config.threads = threads;
     }
 
     if (!remoteDaemon.empty())

--- a/src/zedwallet++/ParseArguments.h
+++ b/src/zedwallet++/ParseArguments.h
@@ -33,6 +33,8 @@ struct Config
     
     /* Use SSL with daemon */
     bool ssl = false;
+
+    unsigned int threads;
 };
 
 Config parseArguments(int argc, char **argv);


### PR DESCRIPTION
Multi-threads the wallet syncing progress. Threads are configurable via command line option.

* ~~I have encountered a couple of rare crashes with `std::bad_alloc`. Have not managed to track down or have a good method to reproduce, hence marked WIP. If anyone is bored and wants to do some performance testing or debugging and could figure out how to reproduce it, that would be grand.~~

* ~~I don't have any performance numbers right now.~~ It was not much faster than with block prefetch when I tested, due to being bottlenecked by the daemon. Planning on looking for some performance improvements there, but do not expect to find many. ~~I also plan on doing a full sync from zero comparison, but the daemon is not playing ball right now.~~

* This should help lower powered devices which are not bottlenecked on the daemon so much (for example, arm devices and phones) to sync with more speed by utilizing their threads more effectively.

| Program            | Node Type         | Block Pre Fetch      | Time To Sync From Zero          | Blocks Per Second | Threads |
|:------------------:|:-----------------:|:--------------------:|:-------------------------------:|:-----------------:|:--------|
| zedwallet-beta     | Local             | Yes                  | 57:40 minutes                   | 440               | 12      |
| zedwallet-beta     | Local             | Yes                  | 108:36 minutes                  | 232               | 1       |
| C++ on Phone     | Cache            | Yes                  | 280:44 minutes                 | 89                 | 1        |
| C++ on Phone     | Cache            | Yes                  | 275:43 minutes                 | 91                 | 8        |
| zedwallet             | Local             | Unknown          | 85:00 minutes                  | 295               | Unknown       |