### PR TITLE
Disable CryptoPP default build parameters that we do not use

### DIFF
--- a/external/cryptopp/CMakeLists.txt
+++ b/external/cryptopp/CMakeLists.txt
@@ -76,8 +76,8 @@ set(TEST_CXX_FILE ${TEST_PROG_DIR}/test_cxx.cxx)
 #============================================================================
 
 option(BUILD_STATIC "Build static library" ON)
-option(BUILD_SHARED "Build shared library" ON)
-option(BUILD_TESTING "Build library tests" ON)
+option(BUILD_SHARED "Build shared library" OFF)
+option(BUILD_TESTING "Build library tests" OFF)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 option(USE_INTERMEDIATE_OBJECTS_TARGET "Use a common intermediate objects target for the static and shared library targets" ON)
 


### PR DESCRIPTION
We don't use the cryptopp shared library and tests so we really should not waste time building them as part of our build processes