### PR TITLE
Fix Portable Slow Hash

### DIFF
--- a/src/crypto/slow-hash-arm.c
+++ b/src/crypto/slow-hash-arm.c
@@ -41,18 +41,6 @@ STATIC INLINE void xor64(uint64_t *a, const uint64_t b)
     *a ^= b;
 }
 
-  #pragma pack(push, 1)
-union cn_slow_hash_state
-{
-    union hash_state hs;
-    struct
-    {
-        uint8_t k[64];
-        uint8_t init[INIT_SIZE_BYTE];
-    };
-};
-  #pragma pack(pop)
-
   #if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
 
 /* ARMv8-A optimized with NEON and AES instructions.

--- a/src/crypto/slow-hash-common.h
+++ b/src/crypto/slow-hash-common.h
@@ -25,8 +25,20 @@
 #define INIT_SIZE_BLK          8
 #define INIT_SIZE_BYTE         (INIT_SIZE_BLK * AES_BLOCK_SIZE)
 
-extern int aesb_single_round(const uint8_t *in, uint8_t*out, const uint8_t *expandedKey);
-extern int aesb_pseudo_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);
+extern void aesb_single_round(const uint8_t *in, uint8_t*out, const uint8_t *expandedKey);
+extern void aesb_pseudo_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);
+
+#pragma pack(push, 1)
+union cn_slow_hash_state
+{
+    union hash_state hs;
+    struct
+    {
+        uint8_t k[64];
+        uint8_t init[INIT_SIZE_BYTE];
+    };
+};
+#pragma pack(pop)
 
 #define VARIANT1_1(p) \
   do if (variant == 1) \

--- a/src/crypto/slow-hash-portable.c
+++ b/src/crypto/slow-hash-portable.c
@@ -25,13 +25,25 @@ void slow_hash_free_state(void)
     return;
 }
 
+  #if defined(__GNUC__)
+    #define RDATA_ALIGN16 __attribute__ ((aligned(16)))
+    #define STATIC static
+    #define INLINE inline
+  #else /* defined(__GNUC__) */
+    #define RDATA_ALIGN16
+    #define STATIC static
+    #define INLINE
+  #endif /* defined(__GNUC__) */
+
+  #define U64(x) ((uint64_t *) (x))
+
 static void (*const extra_hashes[4])(const void *, size_t, char *) =
 {
     hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein
 };
 
-extern int aesb_single_round(const uint8_t *in, uint8_t*out, const uint8_t *expandedKey);
-extern int aesb_pseudo_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);
+extern void aesb_single_round(const uint8_t *in, uint8_t*out, const uint8_t *expandedKey);
+extern void aesb_pseudo_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);
 
 static size_t e2i(const uint8_t* a, size_t count)
 {
@@ -63,8 +75,6 @@ static void sum_half_blocks(uint8_t* a, const uint8_t* b)
     ((uint64_t*)a)[0] = SWAP64LE(a0);
     ((uint64_t*)a)[1] = SWAP64LE(a1);
 }
-
-  #define U64(x) ((uint64_t *) (x))
 
 static void copy_block(uint8_t* dst, const uint8_t* src)
 {
@@ -100,136 +110,127 @@ static void xor64(uint8_t* left, const uint8_t* right)
     }
 }
 
-  #pragma pack(push, 1)
-union cn_slow_hash_state
-{
-    union hash_state hs;
-    struct
-    {
-        uint8_t k[64];
-        uint8_t init[INIT_SIZE_BYTE];
-    };
-};
-  #pragma pack(pop)
-
 void cn_slow_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t page_size, uint32_t scratchpad, uint32_t iterations)
 {
     uint32_t init_rounds = (scratchpad / INIT_SIZE_BYTE);
     uint32_t aes_rounds = (iterations / 2);
-    size_t aes_init = (page_size / AES_BLOCK_SIZE);
+    size_t lightFlag = (light ? 2: 1);
 
-  #ifndef FORCE_USE_HEAP
-    uint8_t long_state[page_size];
-  #else
-    #pragma message ("warning: ACTIVATING FORCE_USE_HEAP IN portable slow-hash-portable.c")
-    uint8_t *long_state = (uint8_t *)malloc(page_size);
-  #endif
-
-    union cn_slow_hash_state state;
     uint8_t text[INIT_SIZE_BYTE];
     uint8_t a[AES_BLOCK_SIZE];
     uint8_t b[AES_BLOCK_SIZE * 2];
+    uint8_t c[AES_BLOCK_SIZE];
     uint8_t c1[AES_BLOCK_SIZE];
-    uint8_t c2[AES_BLOCK_SIZE];
     uint8_t d[AES_BLOCK_SIZE];
+    RDATA_ALIGN16 uint8_t expandedKey[256];
+
+    union cn_slow_hash_state state;
+
     size_t i, j;
-    uint8_t aes_key[AES_KEY_SIZE];
+    uint8_t *p = NULL;
     oaes_ctx *aes_ctx;
+
+    static void (*const extra_hashes[4])(const void *, size_t, char *) =
+    {
+        hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein
+    };
+
+  #ifndef FORCE_USE_HEAP
+    uint8_t long_state[page_size];
+  #else /* FORCE_USE_HEAP */
+    #pragma message ("warning: ACTIVATING FORCE_USE_HEAP IN slow-hash-portable.c")
+    uint8_t *long_state = (uint8_t *)malloc(page_size);
+  #endif /* FORCE_USE_HEAP */
 
     if (prehashed)
     {
-      memcpy(&state.hs, data, length);
-    }
-    else
-    {
-      hash_process(&state.hs, data, length);
+        memcpy(&state.hs, data, length);
+    } else {
+        hash_process(&state.hs, data, length);
     }
 
     memcpy(text, state.init, INIT_SIZE_BYTE);
-    memcpy(aes_key, state.hs.b, AES_KEY_SIZE);
+
     aes_ctx = (oaes_ctx *) oaes_alloc();
+    oaes_key_import_data(aes_ctx, state.hs.b, AES_KEY_SIZE);
 
     VARIANT1_PORTABLE_INIT();
     VARIANT2_PORTABLE_INIT();
 
-    oaes_key_import_data(aes_ctx, aes_key, AES_KEY_SIZE);
+    // use aligned data
+    memcpy(expandedKey, aes_ctx->key->exp_data, aes_ctx->key->exp_data_len);
 
-    for (i = 0; i < init_rounds; i++)
+    for(i = 0; i < init_rounds; i++)
     {
-      for (j = 0; j < INIT_SIZE_BLK; j++)
-      {
-          aesb_pseudo_round(&text[AES_BLOCK_SIZE * j], &text[AES_BLOCK_SIZE * j], aes_ctx->key->exp_data);
+        for(j = 0; j < INIT_SIZE_BLK; j++)
+            aesb_pseudo_round(&text[AES_BLOCK_SIZE * j], &text[AES_BLOCK_SIZE * j], expandedKey);
+        memcpy(&long_state[i * INIT_SIZE_BYTE], text, INIT_SIZE_BYTE);
+    }
+
+    U64(a)[0] = U64(&state.k[0])[0] ^ U64(&state.k[32])[0];
+    U64(a)[1] = U64(&state.k[0])[1] ^ U64(&state.k[32])[1];
+    U64(b)[0] = U64(&state.k[16])[0] ^ U64(&state.k[48])[0];
+    U64(b)[1] = U64(&state.k[16])[1] ^ U64(&state.k[48])[1];
+
+    for(i = 0; i < aes_rounds; i++)
+    {
+    #define MASK(div) ((uint32_t)(((page_size / AES_BLOCK_SIZE) / (div) - 1) << 4))
+    #define state_index(x,div) ((*(uint32_t *) x) & MASK(div))
+
+      // Iteration 1
+      j = state_index(a,lightFlag);
+      p = &long_state[j];
+      aesb_single_round(p, p, a);
+      copy_block(c1, p);
+
+      VARIANT2_PORTABLE_SHUFFLE_ADD(long_state, j);
+      xor_blocks(p, b);
+      VARIANT1_1(p);
+
+      // Iteration 2
+      j = state_index(c1,lightFlag);
+      p = &long_state[j];
+      copy_block(c, p);
+
+      VARIANT2_PORTABLE_INTEGER_MATH(c, c1);
+      mul(c1, c, d);
+      VARIANT2_2_PORTABLE();
+      VARIANT2_PORTABLE_SHUFFLE_ADD(long_state, j);
+      sum_half_blocks(a, d);
+      swap_blocks(a, c);
+      xor_blocks(a, c);
+      VARIANT1_2(U64(c) + 1);
+      copy_block(p, c);
+
+      if (variant >= 2) {
+          copy_block(b + AES_BLOCK_SIZE, b);
       }
 
-      memcpy(&long_state[i * INIT_SIZE_BYTE], text, INIT_SIZE_BYTE);
-    }
-
-    for (i = 0; i < AES_BLOCK_SIZE; i++)
-    {
-        a[i] = state.k[     i] ^ state.k[AES_BLOCK_SIZE * 2 + i];
-        b[i] = state.k[AES_BLOCK_SIZE + i] ^ state.k[AES_BLOCK_SIZE * 3 + i];
-    }
-
-    for (i = 0; i < aes_rounds; i++)
-    {
-        /* Dependency chain: address -> read value ------+
-         * written value <-+ hard function (AES or MUL) <+
-         * next address  <-+
-         */
-        /* Iteration 1 */
-        j = e2i(a, aes_init);
-        copy_block(c1, &long_state[j]);
-        aesb_single_round(c1, c1, a);
-        VARIANT2_PORTABLE_SHUFFLE_ADD(long_state, j);
-        copy_block(&long_state[j], c1);
-        xor_blocks(&long_state[j], b);
-        assert(j == e2i(a, aes_init));
-        VARIANT1_1(&long_state[j]);
-        /* Iteration 2 */
-        j = e2i(c1, aes_init);
-        copy_block(c2, &long_state[j]);
-        VARIANT2_PORTABLE_INTEGER_MATH(c2, c1);
-        mul(c1, c2, d);
-        VARIANT2_2_PORTABLE();
-        VARIANT2_PORTABLE_SHUFFLE_ADD(long_state, j);
-        swap_blocks(a, c1);
-        sum_half_blocks(c1, d);
-        swap_blocks(c1, c2);
-        xor_blocks(c1, c2);
-        VARIANT1_2(c2 + 8);
-        copy_block(&long_state[j], c2);
-        assert(j == e2i(a, aes_init));
-
-        if (variant == 2)
-        {
-            copy_block(b + AES_BLOCK_SIZE, b);
-        }
-
-        copy_block(b, a);
-        copy_block(a, c1);
+      copy_block(b, c1);
     }
 
     memcpy(text, state.init, INIT_SIZE_BYTE);
     oaes_key_import_data(aes_ctx, &state.hs.b[32], AES_KEY_SIZE);
+    memcpy(expandedKey, aes_ctx->key->exp_data, aes_ctx->key->exp_data_len);
 
-    for (i = 0; i < init_rounds; i++)
+    for(i = 0; i < init_rounds; i++)
     {
-        for (j = 0; j < INIT_SIZE_BLK; j++)
+        for(j = 0; j < INIT_SIZE_BLK; j++)
         {
             xor_blocks(&text[j * AES_BLOCK_SIZE], &long_state[i * INIT_SIZE_BYTE + j * AES_BLOCK_SIZE]);
-            aesb_pseudo_round(&text[AES_BLOCK_SIZE * j], &text[AES_BLOCK_SIZE * j], aes_ctx->key->exp_data);
+            aesb_pseudo_round(&text[AES_BLOCK_SIZE * j], &text[AES_BLOCK_SIZE * j], expandedKey);
         }
     }
 
+    oaes_free((OAES_CTX **) &aes_ctx);
     memcpy(state.init, text, INIT_SIZE_BYTE);
     hash_permutation(&state.hs);
-    /*memcpy(hash, &state, 32);*/
     extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
     oaes_free((OAES_CTX **) &aes_ctx);
 
-  #ifdef FORCE_USE_HEAP
+    #ifdef FORCE_USE_HEAP
     free(long_state);
-  #endif
+    #endif /* FORCE_USE_HEAP */
 }
 
 #endif

--- a/src/crypto/slow-hash-x86.c
+++ b/src/crypto/slow-hash-x86.c
@@ -110,18 +110,6 @@
     #define THREADV __thread
   #endif
 
-  #pragma pack(push, 1)
-union cn_slow_hash_state
-{
-    union hash_state hs;
-    struct
-    {
-        uint8_t k[64];
-        uint8_t init[INIT_SIZE_BYTE];
-    };
-};
-  #pragma pack(pop)
-
 THREADV uint8_t *hp_state = NULL;
 THREADV int hp_allocated = 0;
 


### PR DESCRIPTION
While working on the [turtlecoin-crypto](https://github.com/turtlecoin/turtlecoin-crypto) package, I discovered that the portable slow-hash method was not returning valid hash results. As we seldom build on architectures that aren't x86 or arm (or that don't support AES), this has gone unnoticed for some time.

The easiest way to test for the need for this fix is the following:

### Current Development Branch

To force the use of the portable code, run the following:

```bash
cmake -DNO_AES=1
make -j
./src/cryptotest
```

You will see that the hash test **fails**

Rebuild with AES

```bash
cmake -DNO_AES=0
make -j
./src/cryptotest
```

The hash tests now **pass**

### This PR

Do the same steps above with this PR pulled in and you'll see that the portable slow-hash now passes the hash tests as expected.

**Note:** I've also moved `cn_slow_hash_state` into slow-hash-common.h as it's the same in all of the implementations.