### PR TITLE
Fix tx extra public key parsing rare bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 
 # Add the dependencies we need
 target_link_libraries(Common __filesystem)
-target_link_libraries(CryptoNoteCore Common Logging Crypto P2P Rpc Http Serialization System sqlite3 ${Boost_LIBRARIES})
+target_link_libraries(CryptoNoteCore Utilities Common Logging Crypto P2P Rpc Http Serialization System sqlite3 ${Boost_LIBRARIES})
 target_link_libraries(cryptotest Crypto Common)
 target_link_libraries(Errors Crypto SubWallets Utilities)
 target_link_libraries(Logging Common)

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -37,9 +37,10 @@
 
 #include <System/Timer.h>
 
+#include <Utilities/Container.h>
 #include <Utilities/FormatTools.h>
 #include <Utilities/LicenseCanary.h>
-#include <Utilities/Container.h>
+#include <Utilities/ParseExtra.h>
 
 #include <unordered_set>
 
@@ -733,7 +734,7 @@ WalletTypes::RawCoinbaseTransaction Core::getRawCoinbaseTransaction(
 
     transaction.hash = getBinaryArrayHash(toBinaryArray(t));
 
-    transaction.transactionPublicKey = getPubKeyFromExtra(t.extra);
+    transaction.transactionPublicKey = Utilities::getTransactionPublicKeyFromExtra(t.extra);
 
     transaction.unlockTime = t.unlockTime;
 
@@ -764,12 +765,14 @@ WalletTypes::RawTransaction Core::getRawTransaction(
     /* Get the transaction hash from the binary array */
     transaction.hash = getBinaryArrayHash(rawTX);
 
+    Utilities::ParsedExtra parsedExtra = Utilities::parseExtra(t.extra);
+
     /* Transaction public key, used for decrypting transactions along with
        private view key */
-    transaction.transactionPublicKey = getPubKeyFromExtra(t.extra);
+    transaction.transactionPublicKey = parsedExtra.transactionPublicKey;
 
     /* Get the payment ID if it exists (Empty string if it doesn't) */
-    transaction.paymentID = getPaymentIDFromExtra(t.extra);
+    transaction.paymentID = parsedExtra.paymentID;
 
     transaction.unlockTime = t.unlockTime;
 
@@ -791,103 +794,6 @@ WalletTypes::RawTransaction Core::getRawTransaction(
     }
 
     return transaction;
-}
-
-/* Public key looks like this
-
-   [...data...] 0x01 [public key] [...data...]
-
-*/
-Crypto::PublicKey Core::getPubKeyFromExtra(const std::vector<uint8_t> &extra)
-{
-    Crypto::PublicKey publicKey;
-
-    const int pubKeySize = 32;
-
-    for (size_t i = 0; i < extra.size(); i++)
-    {
-        /* If the following data is the transaction public key, this is
-           indicated by the preceding value being 0x01. */
-        if (extra[i] == Constants::TX_EXTRA_PUBKEY_IDENTIFIER)
-        {
-            /* The amount of data remaining in the vector (minus one because
-               we start reading the public key from the next character) */
-            size_t dataRemaining = extra.size() - i - 1;
-
-            /* We need to check that there is enough space following the tag,
-               as someone could just pop a random 0x01 in there and make our
-               code mess up */
-            if (dataRemaining < pubKeySize)
-            {
-                return publicKey;
-            }
-
-            const auto dataBegin = extra.begin() + i + 1;
-            const auto dataEnd = dataBegin + pubKeySize;
-
-            /* Copy the data from the vector to the array */
-            std::copy(dataBegin, dataEnd, std::begin(publicKey.data));
-
-            return publicKey;
-        }
-    }
-
-    /* Couldn't find the tag */
-    return publicKey;
-}
-
-/* Payment ID looks like this (payment ID is stored in extra nonce)
-
-   [...data...] 0x02 [size of extra nonce] 0x00 [payment ID] [...data...]
-
-*/
-std::string Core::getPaymentIDFromExtra(const std::vector<uint8_t> &extra)
-{
-    const int paymentIDSize = 32;
-
-    for (size_t i = 0; i < extra.size(); i++)
-    {
-        /* Extra nonce tag found */
-        if (extra[i] == Constants::TX_EXTRA_NONCE_IDENTIFIER)
-        {
-            /* Skip the extra nonce tag */
-            size_t dataRemaining = extra.size() - i - 1;
-
-            /* Not found, not enough space. We need a +1, since payment ID
-               is stored inside extra nonce, with a special tag for it,
-               and there is a size parameter right after the extra nonce
-               tag */
-            if (dataRemaining < paymentIDSize + 1 + 1)
-            {
-                return std::string();
-            }
-
-            /* Payment ID in extra nonce */
-            if (extra[i+2] == Constants::TX_EXTRA_PAYMENT_ID_IDENTIFIER)
-            {
-                /* Plus three to skip the two 0x02 0x00 tags and the size value */
-                const auto dataBegin = extra.begin() + i + 3;
-                const auto dataEnd = dataBegin + paymentIDSize;
-
-                Crypto::Hash paymentIDHash;
-
-                /* Copy the payment ID into the hash */
-                std::copy(dataBegin, dataEnd, std::begin(paymentIDHash.data));
-
-                /* Convert to a string */
-                std::string paymentID = Common::podToHex(paymentIDHash);
-
-                /* Convert it to lower case */
-                std::transform(paymentID.begin(), paymentID.end(),
-                               paymentID.begin(), ::tolower);
-
-                return paymentID;
-            }
-        }
-    }
-
-    /* Not found */
-    return std::string();
 }
 
 std::optional<BinaryArray> Core::getTransaction(const Crypto::Hash& hash) const {

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -235,10 +235,6 @@ private:
 
   static WalletTypes::RawTransaction getRawTransaction(
     const std::vector<uint8_t> &rawTX);
-
-  static Crypto::PublicKey getPubKeyFromExtra(const std::vector<uint8_t> &extra);
-
-  static std::string getPaymentIDFromExtra(const std::vector<uint8_t> &extra);
 };
 
 }

--- a/src/Utilities/ParseExtra.cpp
+++ b/src/Utilities/ParseExtra.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2019, The TurtleCoin Developers
+//
+// Please see the included LICENSE file for more information.
+
+/////////////////////////////////
+#include <Utilities/ParseExtra.h>
+/////////////////////////////////
+
+#include <config/Constants.h>
+
+namespace Utilities
+{
+    std::string getPaymentIDFromExtra(const std::vector<uint8_t> &extra)
+    {
+        const ParsedExtra parsed = parseExtra(extra);
+        return parsed.paymentID;
+    }
+
+    Crypto::PublicKey getTransactionPublicKeyFromExtra(const std::vector<uint8_t> &extra)
+    {
+        const ParsedExtra parsed = parseExtra(extra);
+        return parsed.transactionPublicKey;
+    }
+
+    ParsedExtra parseExtra(const std::vector<uint8_t> &extra)
+    {
+        ParsedExtra parsed { Constants::NULL_PUBLIC_KEY, std::string() } ;
+
+        bool seenPubKey = false;
+        bool seenPaymentID = false;
+
+        for (auto it = extra.begin(); it != extra.end(); it++)
+        {
+            const uint8_t c = *it;
+
+            const auto elementsRemaining = std::distance(it, extra.end());
+
+            /* Found a pubkey */
+
+            /* Public key looks like this
+
+               [...data...] 0x01 [public key] [...data...]
+
+            */
+            if (c == Constants::TX_EXTRA_PUBKEY_IDENTIFIER && elementsRemaining > 32 && !seenPubKey)
+            {
+                /* Copy 32 chars, beginning from the next char */
+                std::copy(it + 1, it + 1 + 32, std::begin(parsed.transactionPublicKey.data));
+
+                /* Advance past the public key */
+                it += 32;
+
+                seenPubKey = true;
+
+                /* And continue parsing. */
+                continue;
+            }
+
+            /* Found a payment ID, and have space for extra nonce size, pid identifier,
+               and pid. */
+
+            /* Payment ID looks like this (payment ID is stored in extra nonce)
+
+               [...data...] 0x02 [size of extra nonce] 0x00 [payment ID] [...data...]
+
+            */
+            if (c == Constants::TX_EXTRA_NONCE_IDENTIFIER 
+                && elementsRemaining > 1 + 1 + 32
+                && *(it + 2) == Constants::TX_EXTRA_PAYMENT_ID_IDENTIFIER
+                && !seenPaymentID)
+            {
+                const auto dataBegin = it + 3;
+
+                Crypto::Hash paymentIDHash;
+
+                /* Copy the payment ID into the hash */
+                std::copy(dataBegin, dataBegin + 32, std::begin(paymentIDHash.data));
+
+                /* Convert to a string */
+                std::string paymentID = Common::podToHex(paymentIDHash);
+
+                /* Convert it to lower case */
+                std::transform(paymentID.begin(), paymentID.end(),
+                               paymentID.begin(), ::tolower);
+
+                parsed.paymentID = paymentID;
+
+                /* Advance past the payment ID */
+                it += 32 + 1 + 1;
+
+                seenPaymentID = true;
+
+                /* And continue parsing */
+                continue;
+            }
+        }
+
+        return parsed;
+    }
+}

--- a/src/Utilities/ParseExtra.cpp
+++ b/src/Utilities/ParseExtra.cpp
@@ -31,6 +31,12 @@ namespace Utilities
 
         for (auto it = extra.begin(); it != extra.end(); it++)
         {
+            /* Nothing else to parse. */
+            if (seenPubKey && seenPaymentID)
+            {
+                break;
+            }
+
             const uint8_t c = *it;
 
             const auto elementsRemaining = std::distance(it, extra.end());

--- a/src/Utilities/ParseExtra.h
+++ b/src/Utilities/ParseExtra.h
@@ -12,15 +12,24 @@
 
 namespace Utilities
 {
+    struct MergedMiningTag
+    {
+        uint8_t depth;
+        Crypto::Hash merkleRoot;
+    };
+
     struct ParsedExtra
     {
         Crypto::PublicKey transactionPublicKey;
         std::string paymentID;
+        MergedMiningTag mergedMiningTag;
     };
 
     std::string getPaymentIDFromExtra(const std::vector<uint8_t> &extra);
 
     Crypto::PublicKey getTransactionPublicKeyFromExtra(const std::vector<uint8_t> &extra);
+
+    MergedMiningTag getMergedMiningTagFromExtra(const std::vector<uint8_t> &extra);
 
     ParsedExtra parseExtra(const std::vector<uint8_t> &extra);
 }

--- a/src/Utilities/ParseExtra.h
+++ b/src/Utilities/ParseExtra.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, The TurtleCoin Developers
+//
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include <CryptoTypes.h>
+
+#include <string>
+
+#include <vector>
+
+namespace Utilities
+{
+    struct ParsedExtra
+    {
+        Crypto::PublicKey transactionPublicKey;
+        std::string paymentID;
+    };
+
+    std::string getPaymentIDFromExtra(const std::vector<uint8_t> &extra);
+
+    Crypto::PublicKey getTransactionPublicKeyFromExtra(const std::vector<uint8_t> &extra);
+
+    ParsedExtra parseExtra(const std::vector<uint8_t> &extra);
+}

--- a/src/config/Constants.h
+++ b/src/config/Constants.h
@@ -46,6 +46,9 @@ namespace Constants
     /* Indicates the following data is an extra nonce */
     const uint8_t TX_EXTRA_NONCE_IDENTIFIER = 0x02;
 
+    /* Indicates the following data is a merge mine depth+merkle root */
+    const uint8_t TX_EXTRA_MERGE_MINING_IDENTIFIER = 0x03;
+
     const Crypto::Hash NULL_HASH = Crypto::Hash({
         0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/zedwallet/CommandImplementations.cpp
+++ b/src/zedwallet/CommandImplementations.cpp
@@ -21,10 +21,11 @@
 
 #include <Mnemonics/Mnemonics.h>
 
+#include <Utilities/ColouredMsg.h>
 #include <Utilities/FormatTools.h>
+#include <Utilities/ParseExtra.h>
 
 #include <zedwallet/AddressBook.h>
-#include <Utilities/ColouredMsg.h>
 #include <zedwallet/Commands.h>
 #include <zedwallet/Fusion.h>
 #include <zedwallet/Menu.h>
@@ -435,7 +436,7 @@ void printOutgoingTransfer(CryptoNote::WalletTransaction t,
               << WarningMsg("Total Spent: " + formatAmount(-t.totalAmount))
               << std::endl;
 
-    const std::string paymentID = getPaymentIDFromExtra(t.extra);
+    const std::string paymentID = Utilities::getPaymentIDFromExtra(Common::fromHex(t.extra));
 
     if (paymentID != "")
     {
@@ -467,7 +468,7 @@ void printIncomingTransfer(CryptoNote::WalletTransaction t,
     std::cout << SuccessMsg("Amount: " + formatAmount(t.totalAmount))
               << std::endl;
 
-    const std::string paymentID = getPaymentIDFromExtra(t.extra);
+    const std::string paymentID = Utilities::getPaymentIDFromExtra(Common::fromHex(t.extra));
 
     if (paymentID != "")
     {

--- a/src/zedwallet/Tools.cpp
+++ b/src/zedwallet/Tools.cpp
@@ -168,30 +168,6 @@ bool confirm(const std::string &msg, const bool defaultReturn)
     }
 }
 
-std::string getPaymentIDFromExtra(const std::string &extra)
-{
-    std::string paymentID;
-
-    if (extra.length() > 0)
-    {
-        std::vector<uint8_t> vecExtra;
-
-        for (const auto it : extra)
-        {
-            vecExtra.push_back(static_cast<uint8_t>(it));
-        }
-
-        Crypto::Hash paymentIdHash;
-
-        if (CryptoNote::getPaymentIdFromTxExtra(vecExtra, paymentIdHash))
-        {
-            return Common::podToHex(paymentIdHash);
-        }
-    }
-
-    return paymentID;
-}
-
 std::string unixTimeToDate(const uint64_t timestamp)
 {
     const std::time_t time = timestamp;

--- a/src/zedwallet/Tools.h
+++ b/src/zedwallet/Tools.h
@@ -41,8 +41,6 @@ std::string formatAmount(const uint64_t amount);
 std::string formatDollars(const uint64_t amount);
 std::string formatCents(const uint64_t amount);
 
-std::string getPaymentIDFromExtra(const std::string &extra);
-
 std::string unixTimeToDate(const uint64_t timestamp);
 
 std::string createIntegratedAddress(const std::string &address,

--- a/src/zedwallet/Transfer.cpp
+++ b/src/zedwallet/Transfer.cpp
@@ -30,6 +30,7 @@
 #include <Wallet/WalletUtils.h>
 
 #include <Utilities/Addresses.h>
+#include <Utilities/ParseExtra.h>
 
 bool parseAmount(std::string strAmount, uint64_t &amount)
 {
@@ -105,7 +106,7 @@ bool confirmTransaction(CryptoNote::TransactionParameters t,
               << "," << std::endl
               << "and a node fee of " << SuccessMsg(formatAmount(nodeFee));
 
-    const std::string paymentID = getPaymentIDFromExtra(t.extra);
+    const std::string paymentID = Utilities::getPaymentIDFromExtra(Common::fromHex(t.extra));
 
     /* Lets not split the integrated address out into its address and
        payment ID combo. It'll confused users. */


### PR DESCRIPTION
If the payment ID ends with `01`, the public key will be incorrectly parsed, causing transactions to not be scanned correctly. Assuming payment ID's are uniformly distributed, this effects one in every 256 transactions sent with a payment ID.

For example, https://explorer.turtlecoin.lol/transaction.html?hash=13f86f5871526403dd18cc435e0788f254e7e2fd7137c65becf1c09a98a22992 will have the public key parsed as  `01ca1d931715391de63748b4640a2a75faedd53e9da24aee989ca56236ed8921` instead of `ca1d931715391de63748b4640a2a75faedd53e9da24aee989ca56236ed892193`

The bug is in /getwalletsyncdata - so you will need to update your daemon and resync if you are effected by this bug.

The fix takes into account payment ID's and public keys when parsing the extra. I'm not sure if we need to handle any other tags to make it foolproof. We don't need to handle extra padding - this could only cause an issue if the padding contained a `0x02`, indicating a payment ID - but padding must be all zeros.