### PR TITLE
wallet-api no-console option

### DIFF
--- a/src/walletapi/ParseArguments.cpp
+++ b/src/walletapi/ParseArguments.cpp
@@ -21,7 +21,7 @@ ApiConfig parseArguments(int argc, char **argv)
 
     cxxopts::Options options(argv[0], CryptoNote::getProjectCLIHeader());
 
-    bool help, version, scanCoinbaseTransactions;
+    bool help, version, scanCoinbaseTransactions, noConsole;
 
     int logLevel;
 
@@ -35,19 +35,23 @@ ApiConfig parseArguments(int argc, char **argv)
          cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)),
          "#")
 
-            ("scan-coinbase-transactions",
-             "Scan miner/coinbase transactions",
-             cxxopts::value<bool>(scanCoinbaseTransactions)->default_value("false")->implicit_value("true"))
+        ("no-console",
+         "If set, will not provide an interactive console",
+         cxxopts::value<bool>(noConsole)->default_value("false")->implicit_value("true"))
 
-                ("threads",
-                 "Specify number of wallet sync threads",
-                 cxxopts::value<unsigned int>(threads)->default_value(
-                     std::to_string(std::max(1u, std::thread::hardware_concurrency()))),
-                 "#")
+        ("scan-coinbase-transactions",
+         "Scan miner/coinbase transactions",
+         cxxopts::value<bool>(scanCoinbaseTransactions)->default_value("false")->implicit_value("true"))
 
-                    ("v,version",
-                     "Output software version information",
-                     cxxopts::value<bool>(version)->default_value("false")->implicit_value("true"));
+        ("threads",
+         "Specify number of wallet sync threads",
+         cxxopts::value<unsigned int>(threads)->default_value(
+             std::to_string(std::max(1u, std::thread::hardware_concurrency()))),
+         "#")
+
+        ("v,version",
+         "Output software version information",
+         cxxopts::value<bool>(version)->default_value("false")->implicit_value("true"));
 
     options.add_options("Network")(
         "p,port",
@@ -109,6 +113,11 @@ ApiConfig parseArguments(int argc, char **argv)
     else
     {
         config.logLevel = static_cast<Logger::LogLevel>(logLevel);
+    }
+
+    if (noConsole)
+    {
+        config.noConsole = true;
     }
 
     if (threads == 0)

--- a/src/walletapi/ParseArguments.h
+++ b/src/walletapi/ParseArguments.h
@@ -24,6 +24,9 @@ struct ApiConfig
     /* Controls what level of messages to log */
     Logger::LogLevel logLevel = Logger::DISABLED;
 
+    /* Controls whether an interactive console is provided */
+    bool noConsole = false;
+
     unsigned int threads;
 };
 

--- a/src/walletapi/WalletApi.cpp
+++ b/src/walletapi/WalletApi.cpp
@@ -47,20 +47,33 @@ int main(int argc, char **argv)
 
         std::string address = "http://" + config.rpcBindIp + ":" + std::to_string(config.port);
 
-        std::cout << "The api has been launched on " << address << ".\nType exit to save and shutdown." << std::endl;
+        std::cout << "The api has been launched on " << address << "." << std::endl;
+
+        if (!config.noConsole)
+        {
+            std::cout << "Type exit to save and shutdown." << std::endl;
+        }
 
         while (!ctrl_c)
         {
-            std::string input;
-
-            if (!std::getline(std::cin, input) || input == "exit" || input == "quit")
+            /* If we are providing an interactive console we will do so here. */
+            if (!config.noConsole)
             {
-                break;
+                std::string input;
+
+                if (!std::getline(std::cin, input) || input == "exit" || input == "quit")
+                {
+                    break;
+                }
+
+                if (input == "help")
+                {
+                    std::cout << "Type exit to save and shutdown." << std::endl;
+                }
             }
-
-            if (input == "help")
+            else /* If not, then a brief sleep helps stop the thread from running away */
             {
-                std::cout << "Type exit to save and shutdown." << std::endl;
+                std::this_thread::sleep_for(std::chrono::milliseconds(250));
             }
         }
     }


### PR DESCRIPTION
Adds `--no-console` option to wallet-api to allow for sending the process to the background without third-party utilities.