### PR TITLE
Fix a couple of incorrect return codes

### DIFF
--- a/src/walletapi/ApiDispatcher.cpp
+++ b/src/walletapi/ApiDispatcher.cpp
@@ -702,7 +702,7 @@ std::tuple<Error, uint16_t>
 
     res.set_content(j.dump(4) + "\n", "application/json");
 
-    return {SUCCESS, 200};
+    return {SUCCESS, 201};
 }
 
 std::tuple<Error, uint16_t>
@@ -848,7 +848,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::setNodeInfo(const Request &req, Respo
 
     m_walletBackend->swapNode(daemonHost, daemonPort, daemonSSL);
 
-    return {SUCCESS, 202};
+    return {SUCCESS, 200};
 }
 
 //////////////////


### PR DESCRIPTION
All other transaction types return 201, so updating to that.

I don't see any info why setNodeInfo() should return 202 as the request has been accepted and processed, so updating to 200.

Will fix conflicts in a bit, fork is out of date t_t