### PR TITLE
simplify Windows build instructions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,13 @@
-os: Visual Studio 2017
+image:
+  - Visual Studio 2019
 
-cache: c:\users\appveyor\clcache
+cache:
+  - c:\users\appveyor\clcache
+  - c:\local\boost_1_69_0
 
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_67_0
-  BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14
+  BOOST_ROOT: C:\local\boost_1_69_0
+  BOOST_LIBRARYDIR: C:\local\boost_1_69_0\lib64-msvc-14
 
 init:
   - set PATH=c:\Python37;c:\Python37\Scripts;%PATH%
@@ -13,10 +16,13 @@ init:
 before_build:
   - clcache -s
 
+install:
+  - ps: Write-Host "Checking for Boost 1.69.0 x64...";$boostdir  = Test-Path $Env:BOOST_ROOT;If ($boostdir -eq $False) {Write-Host "Downloading Boost 1.69.0 x64...";$exePath = "$Env:TEMP\boost_1_69_0-msvc-14.1-64.exe";(New-Object Net.WebClient).DownloadFile('https://bintray.com/boostorg/release/download_file?file_path=1.69.0%2Fbinaries%2Fboost_1_69_0-msvc-14.1-64.exe', $exePath);Write-Host "Installing Boost 1.69.0 x64...";cmd /c start /wait "$exePath" /verysilent;del $exePath};Write-Host "Boost 1.69.0 x64 installed!" -ForegroundColor Green
+
 build_script:
   - md build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" .. -DARCH=default -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64
+  - cmake -G "Visual Studio 16 2019" -A x64 .. -DARCH=default -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64
   - MSBuild TurtleCoin.sln /p:CLToolExe=clcache.exe /p:CLToolPath=c:\Python37\Scripts\ /p:Configuration=Release /m
   - src\Release\cryptotest.exe
 

--- a/README.md
+++ b/README.md
@@ -136,34 +136,32 @@ The binaries will be in the `src` folder when you are complete.
 
 You can build for 32-bit or 64-bit Windows. **If you're not sure, pick 64-bit.**
 
-- Install [Visual Studio 2017 Community Edition](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&page=inlineinstall)
-- When installing Visual Studio, it is **required** that you install **Desktop development with C++**
-- Install the latest version of Boost (currently Boost 1.68). Select the appropriate version for your system:
-  - [Boost 64-bit](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-64.exe)
-  - [Boost 32-bit](https://bintray.com/boostorg/release/download_file?file_path=1.68.0%2Fbinaries%2Fboost_1_68_0-msvc-14.1-32.exe)
-- Install the latest full version of OpenSSL (currently OpenSSL 1.1.1b). Select the appropriate version for your system:
+- Download the [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16) Installer
+- When it opens up select **C++ build tools**, it automatically selects the needed parts
+- Install Boost (1.69 works the latest is 1.70 and doesn't work). Select the appropriate version for your system:
+  - [Boost 64-bit](https://bintray.com/boostorg/release/download_file?file_path=1.69.0%2Fbinaries%2Fboost_1_69_0-msvc-14.1-64.exe)
+  - [Boost 32-bit](https://bintray.com/boostorg/release/download_file?file_path=1.69.0%2Fbinaries%2Fboost_1_69_0-msvc-14.1-32.exe)
+- Install the latest full version of OpenSSL (currently OpenSSL 1.1.1c). Select the appropriate version for your system:
   - [OpenSSL 64-bit](https://slproweb.com/download/Win64OpenSSL-1_1_1c.exe)
   - [OpenSSL 32-bit](https://slproweb.com/download/Win32OpenSSL-1_1_1c.exe)
 
 ##### Building
 
 For 64-bit:
-- From the start menu, open 'x64 Native Tools Command Prompt for vs2017'.
+- From the start menu, open 'x64 Native Tools Command Prompt for VS 2019'.
 - `cd <your_turtlecoin_directory>`
 - `mkdir build`
 - `cd build`
-- `set PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin";%PATH%`
-- `cmake -G "Visual Studio 15 2017 Win64" .. -DBOOST_ROOT=C:/local/boost_1_68_0`
-- `MSBuild TurtleCoin.sln /p:Configuration=Release /m`
+- `cmake -G "Visual Studio 16 2019" -A x64 .. -DBOOST_ROOT=C:/local/boost_1_68_0`
+- `MSBuild TurtleCoin.sln /p:Configuration=Release /m` or `MSBuild src\cli.vcxproj /p:Configuration=Release /m`
 
 For 32-bit:
-- From the start menu, open 'x86 Native Tools Command Prompt for vs2017'.
+- From the start menu, open 'x86 Native Tools Command Prompt for VS 2019'.
 - `cd <your_turtlecoin_directory>`
 - `mkdir build`
 - `cd build`
-- `set PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin";%PATH%`
-- `cmake -G "Visual Studio 15 2017" .. -DBOOST_ROOT=C:/local/boost_1_68_0`
-- `MSBuild TurtleCoin.sln /p:Configuration=Release /p:Platform=Win32 /m`
+- `cmake -G "Visual Studio 16 2019" -A Win32 .. -DBOOST_ROOT=C:/local/boost_1_68_0`
+- `MSBuild TurtleCoin.sln /p:Configuration=Release /p:Platform=Win32 /m` 
 
 The binaries will be in the `src/Release` folder when you are complete.
 


### PR DESCRIPTION
now that VS2017 is behind a login - much easier to
use VS 2019 standalone build tools.