### PR TITLE
Improved Wallet Upgrade Routine

### DIFF
--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -396,15 +396,26 @@ bool WalletBackend::tryUpgradeWalletFormat(
         /* Our connection to turtlecoind */
         std::unique_ptr<CryptoNote::INode> node(new CryptoNote::NodeRpcProxy(daemonHost, daemonPort, 10, logManager));
 
+        /* Save the old wallet to the backup file via simple file copy operation */
+        std::error_code backupError;
+        fs::copy(filename, "old-version-backup-" + filename, fs::copy_options::overwrite_existing, backupError);
+
+        /* If we could not backup the file then instantly fail for safety sake */
+        if (backupError)
+        {
+            return false;
+        }
+
         CryptoNote::WalletGreen wallet(*dispatcher, currency, *node, logManager);
 
+        /* Attempt to open the specified file as a wallet */
         wallet.load(filename, password);
 
         /* Cool, it worked. Upgrade to the new format. */
         const std::string json = wallet.toNewFormatJSON();
 
-        /* Save old wallet to backup file */
-        wallet.exportWallet("old-version-backup-" + filename);
+        /* We have to close the wallet before we can overwrite it */
+        wallet.shutdown();
 
         /* Save to disk with the new format. */
         Error error = saveWalletJSONToDisk(json, filename, password);


### PR DESCRIPTION
* Replaced backup mechanism with a simple backup operation (copy the file) before touching anything
  * If we can't back up, we exit immediately because moving forward, although unlikely, could result in data loss
* Wallet must be shutdown before attempting to write the new wallet format to the wallet file