### PR TITLE
Fix RawBlock Serialization

### DIFF
--- a/src/rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/rpc/CoreRpcServerCommandsDefinitions.h
@@ -68,9 +68,12 @@ namespace CryptoNote
                 block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64
                            // and so on, and the last one is always genesis block */
 
+            uint32_t blockCount;
+
             void serialize(ISerializer &s)
             {
-                KV_MEMBER(block_ids);
+                KV_MEMBER(block_ids)
+                KV_MEMBER(blockCount)
             }
         };
 

--- a/src/rpc/RpcServer.cpp
+++ b/src/rpc/RpcServer.cpp
@@ -337,10 +337,20 @@ namespace CryptoNote
             return false;
         }
 
+        uint32_t blockCount = COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT;
+
+        /* Allow the requested block count to be specified in the
+           request if it's greater than 0 and less than the configured
+           maximum */
+        if (req.blockCount > 0 && req.blockCount < blockCount)
+        {
+            blockCount = req.blockCount;
+        }
+
         uint32_t totalBlockCount;
         uint32_t startBlockIndex;
         std::vector<Crypto::Hash> supplement = m_core.findBlockchainSupplement(
-            req.block_ids, COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT, totalBlockCount, startBlockIndex);
+            req.block_ids, blockCount, totalBlockCount, startBlockIndex);
 
         res.current_height = totalBlockCount;
         res.start_height = startBlockIndex;

--- a/src/serialization/CryptoNoteSerialization.cpp
+++ b/src/serialization/CryptoNoteSerialization.cpp
@@ -566,25 +566,37 @@ namespace CryptoNote
             serializer(txCount, "tx_count");
             rawBlock.transactions.resize(static_cast<uint64_t>(txCount));
 
+            serializer.beginArray(txCount, "transactions");
+
             for (auto &txBlob : rawBlock.transactions)
             {
+                serializer.beginObject("transaction");
                 uint64_t txSize;
                 serializer(txSize, "tx_size");
                 txBlob.resize(txSize);
                 serializer.binary(txBlob.data(), txBlob.size(), "transaction");
+                serializer.endObject();
             }
+
+            serializer.endArray();
         }
         else
         {
             uint64_t txCount = rawBlock.transactions.size();
             serializer(txCount, "tx_count");
 
+            serializer.beginArray(txCount, "transactions");
+
             for (auto &txBlob : rawBlock.transactions)
             {
+                serializer.beginObject("transaction");
                 uint64_t txSize = txBlob.size();
                 serializer(txSize, "tx_size");
                 serializer.binary(txBlob.data(), txBlob.size(), "transaction");
+                serializer.endObject();
             }
+
+            serializer.endArray();
         }
     }
 


### PR DESCRIPTION
Fixes an issue whereby a RawBlock is serialized in the RPC call '/getblocks' that results in the transactions property only containing ONE transaction in the block. This creates the transactions property as an array and loads the transaction information (blob + size) into properties of an object that is added to the array of transactions.

In my code tracing, I was not able to find RawBlock serialization used like this anywhere else in the code other than the RPC call. I have maintained synchronization with the network after these changes, the DB storage all still works, and everything appears operational; however, additional sets of eyes on this and testing would be much appreciated to ensure that I did not miss something.