### PR TITLE
Enforce max output sizes for both client + node

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -165,7 +165,7 @@ namespace CryptoNote
         /* 30 trillion atomic, or 300 billion TRTL */
         /* This is enforced on the daemon side. An output > 300 billion causes
          * an invalid block. */
-        const uint64_t MAX_OUTPUT_SIZE_NODE   = 300'000'000'000'00;
+        const uint64_t MAX_OUTPUT_SIZE_NODE   = 250'000'000'000'00;
 
         /* 100 billion atomic, or 1 billion TRTL */
         /* This is enforced on the client side. An output > 1 billion will not

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -162,6 +162,18 @@ namespace CryptoNote
 
         const uint64_t MAX_EXTRA_SIZE_V2_HEIGHT = 1300000;
 
+        /* 30 trillion atomic, or 300 billion TRTL */
+        /* This is enforced on the daemon side. An output > 300 billion causes
+         * an invalid block. */
+        const uint64_t MAX_OUTPUT_SIZE_NODE   = 300'000'000'000'00;
+
+        /* 100 billion atomic, or 1 billion TRTL */
+        /* This is enforced on the client side. An output > 1 billion will not
+         * be created in a transaction */
+        const uint64_t MAX_OUTPUT_SIZE_CLIENT = 1'000'000'000'00;
+
+        const uint64_t MAX_OUTPUT_SIZE_HEIGHT = 2000000;
+
         /* For new projects forked from this code base, the values immediately below
            should be changed to 0 to prevent issues with transaction processing
            and other possible unexpected behavior */

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -162,8 +162,8 @@ namespace CryptoNote
 
         const uint64_t MAX_EXTRA_SIZE_V2_HEIGHT = 1300000;
 
-        /* 30 trillion atomic, or 300 billion TRTL */
-        /* This is enforced on the daemon side. An output > 300 billion causes
+        /* 25 trillion atomic, or 250 billion TRTL -> Max supply / mixin+1 outputs */
+        /* This is enforced on the daemon side. An output > 250 billion causes
          * an invalid block. */
         const uint64_t MAX_OUTPUT_SIZE_NODE   = 250'000'000'000'00;
 

--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -2178,6 +2178,14 @@ namespace CryptoNote
                 return error::TransactionValidationError::OUTPUT_ZERO_AMOUNT;
             }
 
+            if (blockIndex >= CryptoNote::parameters::MAX_OUTPUT_SIZE_HEIGHT)
+            {
+                if (output.amount > CryptoNote::parameters::MAX_OUTPUT_SIZE_NODE)
+                {
+                    return error::TransactionValidationError::OUTPUT_AMOUNT_TOO_LARGE;
+                }
+            }
+
             if (output.target.type() == typeid(KeyOutput))
             {
                 if (!check_key(boost::get<KeyOutput>(output.target).key))

--- a/src/cryptonotecore/TransactionValidationErrors.h
+++ b/src/cryptonotecore/TransactionValidationErrors.h
@@ -42,6 +42,7 @@ namespace CryptoNote
             EXTRA_TOO_LARGE,
             BASE_INVALID_SIGNATURES_COUNT,
             INPUT_INVALID_SIGNATURES_COUNT,
+            OUTPUT_AMOUNT_TOO_LARGE
         };
 
         // custom category:
@@ -120,6 +121,8 @@ namespace CryptoNote
                         return "Coinbase transactions must not have input signatures";
                     case TransactionValidationError::INPUT_INVALID_SIGNATURES_COUNT:
                         return "The number of input signatures is not correct";
+                    case TransactionValidationError::OUTPUT_AMOUNT_TOO_LARGE:
+                        return "Transaction has output exceeding max output size";
                     default:
                         return "Unknown error";
                 }

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -47,6 +47,7 @@
 #include <wallet/WalletSerializationV2.h>
 #include <wallet/WalletUtils.h>
 #include <walletbackend/Constants.h>
+#include <walletbackend/Transfer.h>
 #include <walletbackend/WalletBackend.h>
 
 #undef ERROR
@@ -3068,7 +3069,7 @@ namespace CryptoNote
         ReceiverAmounts receiverAmounts;
 
         receiverAmounts.receiver = destination;
-        decomposeAmount(amount, dustThreshold, receiverAmounts.amounts);
+        receiverAmounts.amounts = SendTransaction::splitAmountIntoDenominations(amount);
         return receiverAmounts;
     }
 
@@ -3965,9 +3966,10 @@ namespace CryptoNote
         WalletGreen::decomposeFusionOutputs(const AccountPublicAddress &address, uint64_t inputsAmount)
     {
         WalletGreen::ReceiverAmounts outputs;
-        outputs.receiver = address;
 
-        decomposeAmount(inputsAmount, 0, outputs.amounts);
+        outputs.receiver = address;
+        outputs.amounts = SendTransaction::splitAmountIntoDenominations(inputsAmount);
+
         std::sort(outputs.amounts.begin(), outputs.amounts.end());
 
         return outputs;

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -899,7 +899,7 @@ namespace SendTransaction
 
     /* Split each amount into uniform amounts, e.g.
        1234567 = 1000000 + 200000 + 30000 + 4000 + 500 + 60 + 7 */
-    std::vector<uint64_t> splitAmountIntoDenominations(uint64_t amount)
+    std::vector<uint64_t> splitAmountIntoDenominations(uint64_t amount, bool preventTooLargeOutputs)
     {
         std::vector<uint64_t> splitAmounts;
 
@@ -909,9 +909,27 @@ namespace SendTransaction
         {
             uint64_t denomination = multiplier * (amount % 10);
 
+            /* Denomination will make a too large output */
+            if (denomination > CryptoNote::parameters::MAX_OUTPUT_SIZE_CLIENT && preventTooLargeOutputs)
+            {
+                /* Split amount into ten chunks */
+                uint64_t numSplitAmounts = 10;
+
+                uint64_t splitAmount = denomination / 10;
+
+                /* If still too large, split each chunk into another 10 */
+                while (splitAmount > CryptoNote::parameters::MAX_OUTPUT_SIZE_CLIENT)
+                {
+                    splitAmount /= 10;
+                    numSplitAmounts *= 10;
+                }
+
+                /* Add the split amounts */
+                std::fill_n(std::back_inserter(splitAmounts), numSplitAmounts, splitAmount);
+            }
             /* If we have for example, 1010 - we want 1000 + 10,
                not 1000 + 0 + 10 + 0 */
-            if (denomination != 0)
+            else if (denomination != 0)
             {
                 splitAmounts.push_back(denomination);
             }

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -62,7 +62,9 @@ namespace SendTransaction
         const std::vector<WalletTypes::ObscuredInput> inputsAndFakes,
         const std::vector<Crypto::SecretKey> tmpSecretKeys);
 
-    std::vector<uint64_t> splitAmountIntoDenominations(uint64_t amount);
+    std::vector<uint64_t> splitAmountIntoDenominations(
+        const uint64_t amount,
+        const bool preventTooLargeOutputs = true);
 
     std::vector<CryptoNote::TransactionInput>
         keyInputToTransactionInput(const std::vector<CryptoNote::KeyInput> keyInputs);


### PR DESCRIPTION
Offers separate limits for network and client, client limits ensures users do not create outputs that are unspendable, and network limit ensures outputs that are impossible to spend are not created.