### PR TITLE
Transaction Pool Optimizations

### DIFF
--- a/src/cryptonotecore/ITransactionPool.h
+++ b/src/cryptonotecore/ITransactionPool.h
@@ -38,6 +38,8 @@ namespace CryptoNote
         virtual uint64_t getTransactionReceiveTime(const Crypto::Hash &hash) const = 0;
 
         virtual std::vector<Crypto::Hash> getTransactionHashesByPaymentId(const Crypto::Hash &paymentId) const = 0;
+
+        virtual void flush() = 0;
     };
 
 } // namespace CryptoNote

--- a/src/cryptonotecore/TransactionPool.cpp
+++ b/src/cryptonotecore/TransactionPool.cpp
@@ -199,4 +199,14 @@ namespace CryptoNote
         return transactionHashes;
     }
 
+    void TransactionPool::flush()
+    {
+        const auto txns = getTransactionHashes();
+
+        for (const auto tx : txns)
+        {
+            removeTransaction(tx);
+        }
+    }
+
 } // namespace CryptoNote

--- a/src/cryptonotecore/TransactionPool.h
+++ b/src/cryptonotecore/TransactionPool.h
@@ -50,6 +50,8 @@ namespace CryptoNote
 
         virtual std::vector<Crypto::Hash> getTransactionHashesByPaymentId(const Crypto::Hash &paymentId) const override;
 
+        virtual void flush() override;
+
       private:
         TransactionValidatorState poolState;
 

--- a/src/cryptonotecore/TransactionPoolCleaner.cpp
+++ b/src/cryptonotecore/TransactionPoolCleaner.cpp
@@ -89,6 +89,11 @@ namespace CryptoNote
         return transactionPool->getTransactionHashesByPaymentId(paymentId);
     }
 
+    void TransactionPoolCleanWrapper::flush()
+    {
+        return transactionPool->flush();
+    }
+
     std::vector<Crypto::Hash> TransactionPoolCleanWrapper::clean(const uint32_t height)
     {
         try

--- a/src/cryptonotecore/TransactionPoolCleaner.h
+++ b/src/cryptonotecore/TransactionPoolCleaner.h
@@ -60,6 +60,8 @@ namespace CryptoNote
 
         virtual std::vector<Crypto::Hash> getTransactionHashesByPaymentId(const Crypto::Hash &paymentId) const override;
 
+        virtual void flush() override;
+
         virtual std::vector<Crypto::Hash> clean(const uint32_t height) override;
 
       private:


### PR DESCRIPTION
- Re-order the transaction validation check a bit and short circuit the check if the transaction is already in our mempool
- Remove used transactions from the pool before actualizing the pool on a new block
- add a flush() method to the transaction pool and add it to the Core destructor

There's still plenty of work that can be done to help but this seems to be a decent start.