### PR TITLE
Transaction Pool Validation Improvements on addBlock()

### DIFF
--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -1244,13 +1244,10 @@ namespace CryptoNote
 
                     updateBlockMedianSize();
 
-                    /* We've used these transactions, remove them from the pool if they are there */
-                    for (const auto tx : transactions)
-                    {
-                        transactionPool->removeTransaction(tx.getTransactionHash());
-                    }
-
-                    actualizePoolTransactionsLite(validatorState);
+                    /* Take the current block spent key images and run them
+                       against the pool to remove any transactions that may
+                       be in the pool that would now be considered invalid */
+                    checkAndRemoveInvalidPoolTransactions(validatorState);
 
                     ret = error::AddBlockErrorCode::ADDED_TO_MAIN;
                     logger(Logging::DEBUGGING) << "Block " << blockStr << " added to main chain.";
@@ -1286,13 +1283,11 @@ namespace CryptoNote
 
                         updateBlockMedianSize();
 
-                        /* We've used these transactions, remove them from the pool if they are there */
-                        for (const auto tx : transactions)
-                        {
-                            transactionPool->removeTransaction(tx.getTransactionHash());
-                        }
+                        /* Take the current block spent key images and run them
+                           against the pool to remove any transactions that may
+                           be in the pool that would now be considered invalid */
+                        checkAndRemoveInvalidPoolTransactions(validatorState);
 
-                        actualizePoolTransactions();
                         copyTransactionsToPool(chainsLeaves[endpointIndex]);
 
                         switchMainChainStorage(chainsLeaves[0]->getStartBlockIndex(), *chainsLeaves[0]);
@@ -1378,44 +1373,53 @@ namespace CryptoNote
         return ret;
     }
 
-    void Core::actualizePoolTransactions()
+    /* This method is a light version of transaction validation that is used
+       to clear the transaction pool of transactions that have been invalidated
+       by the addition of a block to the blockchain. As the transactions are already
+       in the pool, there are only a subset of normal transaction validation
+       tests that need to be completed to determine if the transaction can
+       stay in the pool at this time. */
+    void Core::checkAndRemoveInvalidPoolTransactions(
+        const TransactionValidatorState blockTransactionsState)
     {
         auto &pool = *transactionPool;
-        auto hashes = pool.getTransactionHashes();
 
-        for (auto &hash : hashes)
+        const auto poolHashes = pool.getTransactionHashes();
+
+        const auto maxTransactionSize = getMaximumTransactionAllowedSize(blockMedianSize, currency);
+
+        for (const auto poolTxHash : poolHashes)
         {
-            auto tx = pool.getTransaction(hash);
-            pool.removeTransaction(hash);
+            const auto poolTx = pool.getTransaction(poolTxHash);
 
-            const auto [success, error] = addTransactionToPool(std::move(tx));
-            if (!success)
+            const auto poolTxState = extractSpentOutputs(poolTx);
+
+            auto [mixinSuccess, err] = Mixins::validate({poolTx}, getTopBlockIndex());
+
+            bool isValid = true;
+
+            /* If the transaction does not have the right number of mixins, fail */
+            if (!mixinSuccess)
             {
-                notifyObservers(makeDelTransactionMessage({hash}, Messages::DeleteTransaction::Reason::NotActual));
+                isValid = false;
             }
-        }
-    }
-
-    void Core::actualizePoolTransactionsLite(const TransactionValidatorState &validatorState)
-    {
-        auto &pool = *transactionPool;
-        auto hashes = pool.getTransactionHashes();
-
-        TransactionValidatorState validator = validatorState;
-
-        for (auto &hash : hashes)
-        {
-            auto tx = pool.getTransaction(hash);
-
-            auto txState = extractSpentOutputs(tx);
-
-            const auto [transactionValidForPool, error] = isTransactionValidForPool(tx, validator);
-            if (hasIntersections(validatorState, txState)
-                || tx.getTransactionBinaryArray().size() > getMaximumTransactionAllowedSize(blockMedianSize, currency)
-                || !transactionValidForPool)
+            /* If the transaction exceeds the maximum size of a transaction, fail */
+            else if (poolTx.getTransactionBinaryArray().size() > maxTransactionSize)
             {
-                pool.removeTransaction(hash);
-                notifyObservers(makeDelTransactionMessage({hash}, Messages::DeleteTransaction::Reason::NotActual));
+                isValid = false;
+            }
+            /* If the the transaction contains outputs that were spent in the new block, fail */
+            else if (hasIntersections(blockTransactionsState, poolTxState))
+            {
+                isValid = false;
+            }
+
+            /* If the transaction is no longer valid, remove it from the pool
+               and tell everyone else that they should also remove it from the pool */
+            if (!isValid)
+            {
+                pool.removeTransaction(poolTxHash);
+                notifyObservers(makeDelTransactionMessage({poolTxHash}, Messages::DeleteTransaction::Reason::NotActual));
             }
         }
     }
@@ -1862,22 +1866,22 @@ namespace CryptoNote
         b.timestamp = time(nullptr);
 
         /* Ok, so if an attacker is fiddling around with timestamps on the network,
-     they can make it so all the valid pools / miners don't produce valid
-     blocks. This is because the timestamp is created as the users current time,
-     however, if the attacker is a large % of the hashrate, they can slowly
-     increase the timestamp into the future, shifting the median timestamp
-     forwards. At some point, this will mean the valid pools will submit a
-     block with their valid timestamps, and it will be rejected for being
-     behind the median timestamp / too far in the past. The simple way to
-     handle this is just to check if our timestamp is going to be invalid, and
-     set it to the median.
+           they can make it so all the valid pools / miners don't produce valid
+           blocks. This is because the timestamp is created as the users current time,
+           however, if the attacker is a large % of the hashrate, they can slowly
+           increase the timestamp into the future, shifting the median timestamp
+           forwards. At some point, this will mean the valid pools will submit a
+           block with their valid timestamps, and it will be rejected for being
+           behind the median timestamp / too far in the past. The simple way to
+           handle this is just to check if our timestamp is going to be invalid, and
+           set it to the median.
 
-     Once the attack ends, the median timestamp will remain how it is, until
-     the time on the clock goes forwards, and we can start submitting valid
-     timestamps again, and then we are back to normal. */
+           Once the attack ends, the median timestamp will remain how it is, until
+           the time on the clock goes forwards, and we can start submitting valid
+           timestamps again, and then we are back to normal. */
 
         /* Thanks to jagerman for this patch:
-     https://github.com/loki-project/loki/pull/26 */
+           https://github.com/loki-project/loki/pull/26 */
 
         /* How many blocks we look in the past to calculate the median timestamp */
         uint64_t blockchain_timestamp_check_window;
@@ -1892,7 +1896,7 @@ namespace CryptoNote
         }
 
         /* Skip the first N blocks, we don't have enough blocks to calculate a
-     proper median yet */
+           proper median yet */
         if (height >= blockchain_timestamp_check_window)
         {
             std::vector<uint64_t> timestamps;
@@ -1922,11 +1926,11 @@ namespace CryptoNote
         fillBlockTemplate(b, medianSize, currency.maxBlockCumulativeSize(height), height, transactionsSize, fee);
 
         /*
-     two-phase miner transaction generation: we don't know exact block size until we prepare block, but we don't know
-     reward until we know
-     block size, so first miner transaction generated with fake amount of money, and with phase we know think we know
-     expected block size
-  */
+           two-phase miner transaction generation: we don't know exact block size until we prepare block, but we don't know
+           reward until we know
+           block size, so first miner transaction generated with fake amount of money, and with phase we know think we know
+           expected block size
+        */
         // make blocks coin-base tx looks close to real coinbase tx to get truthful blob size
         bool r = currency.constructMinerTx(
             b.majorVersion,
@@ -2999,7 +3003,7 @@ namespace CryptoNote
             };
 
         /* First we're going to loop through transactions that have a fee:
-       ie. the transactions that are paying to use the network */
+           ie. the transactions that are paying to use the network */
         for (const auto &transaction : regularTransactions)
         {
             if (addTransactionToBlockTemplate(transaction))
@@ -3015,7 +3019,7 @@ namespace CryptoNote
         }
 
         /* Then we'll loop through the fusion transactions as they don't
-       pay anything to use the network */
+           pay anything to use the network */
         for (const auto &transaction : fusionTransactions)
         {
             if (addTransactionToBlockTemplate(transaction))

--- a/src/cryptonotecore/Core.h
+++ b/src/cryptonotecore/Core.h
@@ -368,10 +368,8 @@ namespace CryptoNote
 
         void copyTransactionsToPool(IBlockchainCache *alt);
 
-        void actualizePoolTransactions();
-
-        void actualizePoolTransactionsLite(
-            const TransactionValidatorState &validatorState); // Checks pool txs only for double spend.
+        void checkAndRemoveInvalidPoolTransactions(
+            const TransactionValidatorState blockTransactionsState);
 
         void transactionPoolCleaningProcedure();
 


### PR DESCRIPTION
Replaced the actualizePoolTransactions & actualizePoolTransactionsLite that is used when a new block is added to the TOP of the chain with another method that takes the pre-computed transaction validator state from a new block then uses that state to perform the following:

- Retrieves the full list of transaction hashes from the current pool
- Computes the new maximum transaction size (bytes)
- Loops through the transactions in the pool to identify any that are now invalid with the addition of the new block. The transaction is removed from the transaction pool if one of the following conditions are met:
  * If the transaction mixins (ring size) is now invalid
  * If the transaction size (bytes) is now too large
  * If the transaction contains outputs that were just spent

It skips the following checks that are redundant as the transaction is already in the pool and the checks have already been completed.

- Does not make sure that tx_extra is less than the configured limit
  - Note: the transaction itself doesn't change just because a block is added
- Does not verify that the correct network transaction fee has been included
  - Note: the transaction itself doesn't change just because a block is added
- Does not verify that the offsets (global indexes) exist
  - Note: unneeded as we're only triggering on adding block to the top not a reorg
- Does not verify that the outputs being spent are unlocked
  - Note: the transaction itself doesn't change just because a block is added
- Does not verify the ring signature(s) are correct
  - Note: the transaction itself doesn't change just because a block is added & unneeded as we're only triggering on adding block to the top not a reorg

I've tested this locally for a bit and I'm maintaining sync. the addBlock routine is running much faster as we aren't getting held up waiting for every transaction in the mempool to *deep* validate again.
