### PR TITLE
Follow up to #904

### DIFF
--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -1398,8 +1398,13 @@ namespace CryptoNote
 
             bool isValid = true;
 
+            /* If the transaction is in the chain but somehow was not previously removed, fail */
+            if (isTransactionInChain(poolTxHash))
+            {
+                isValid = false;
+            }
             /* If the transaction does not have the right number of mixins, fail */
-            if (!mixinSuccess)
+            else if (!mixinSuccess)
             {
                 isValid = false;
             }
@@ -1422,6 +1427,21 @@ namespace CryptoNote
                 notifyObservers(makeDelTransactionMessage({poolTxHash}, Messages::DeleteTransaction::Reason::NotActual));
             }
         }
+    }
+
+    /* This quickly finds out if a transaction is in the blockchain somewhere */
+    bool Core::isTransactionInChain(const Crypto::Hash &txnHash)
+    {
+        throwIfNotInitialized();
+
+        auto segment = findSegmentContainingTransaction(txnHash);
+
+        if (segment != nullptr)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     void Core::switchMainChainStorage(uint32_t splitBlockIndex, IBlockchainCache &newChain)

--- a/src/cryptonotecore/Core.h
+++ b/src/cryptonotecore/Core.h
@@ -371,6 +371,8 @@ namespace CryptoNote
         void checkAndRemoveInvalidPoolTransactions(
             const TransactionValidatorState blockTransactionsState);
 
+        bool isTransactionInChain(const Crypto::Hash &txnHash);
+
         void transactionPoolCleaningProcedure();
 
         void updateBlockMedianSize();


### PR DESCRIPTION
Small patch on the heels of 904 that helps make sure that the transaction pool is clean during some edge cases. In some edge cases, transactions may be left in the mempool due to a reorg as they aren't caught and cleaned. This adds one extra sanity check that if a transaction in the mempool is found in the chain that we need to clear it from the mempool without doing a deep search.