### PR TITLE
Fix boost linking for >= 1.70

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ if (NOT MSVC)
 endif ()
 
 ## Go get us some static BOOST libraries
+set(Boost_NO_BOOST_CMAKE ON)
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_STATIC_RUNTIME ON)
 find_package(Boost REQUIRED COMPONENTS system thread date_time chrono serialization)


### PR DESCRIPTION
Since boost started shipping cmake config files for all its individual libraries `find_package(Boost)` defaults to those files. We explicitly disable them until boost dependency is removed completely