### PR TITLE
Catch & Re-Throw Deserialization Issues of MainChainStorage

### DIFF
--- a/src/cryptonotecore/MainChainStorage.cpp
+++ b/src/cryptonotecore/MainChainStorage.cpp
@@ -7,6 +7,7 @@
 
 #include "common/CryptoNoteTools.h"
 #include "common/FileSystemShim.h"
+#include <sstream>
 
 namespace CryptoNote
 {
@@ -52,7 +53,26 @@ namespace CryptoNote
                 + " is out of range. Blocks count: " + std::to_string(storage.size()));
         }
 
-        return storage[index];
+        try
+        {
+            return storage[index];
+        }
+        catch (std::exception &)
+        {
+            /* Intercept the exception here and display a friendly help message */
+            std::stringstream errorMessage;
+
+            errorMessage << "Local blockchain cache corruption detected." << std::endl
+                         << "Block with index " << std::to_string(index)
+                         << " could not be deserialized from the blockchain cache."
+                         << std::endl << std::endl
+                         << "Please try to repair this issue by starting the node with the option: "
+                         << "--rewind-to-height " << std::to_string(index - 1) << std::endl
+                         << "If the above does not repair the issue, "
+                         << "please launch the node with the option: --resync" << std::endl;
+
+            throw std::runtime_error(errorMessage.str());
+        }
     }
 
     uint32_t MainChainStorage::getBlockCount() const


### PR DESCRIPTION
Provides a helpful message when data cannot be properly de-serialized from MainChainStorage