### PR TITLE
Remove unhelpful peer list logging

### DIFF
--- a/src/p2p/NetNode.cpp
+++ b/src/p2p/NetNode.cpp
@@ -1132,9 +1132,7 @@ namespace CryptoNote
         {
             return false;
         }
-        logger(Logging::TRACE) << context << "REMOTE PEERLIST: TIME_DELTA: " << delta
-                               << ", remote peerlist size=" << peerlist_.size();
-        logger(Logging::TRACE) << context << "REMOTE PEERLIST: " << print_peerlist_to_string(peerlist_);
+
         return m_peerlist.merge_peerlist(peerlist_);
     }
     //-----------------------------------------------------------------------------------


### PR DESCRIPTION
When trying to debug something, the constant printing of the peer list is very distracting, often taking up thousands of lines. If people require the peer list, they can always use the `print_pl` command, which prints the same info.