### PR TITLE
Link in SSSE3 Support in Argon2

### DIFF
--- a/external/argon2/CMakeLists.txt
+++ b/external/argon2/CMakeLists.txt
@@ -60,6 +60,7 @@ if(USE_AVX512F OR USE_AVX2 OR USE_SSE3 OR USE_SSE2 OR USE_XOP)
     list(APPEND ARGON2_SRC
         arch/x86_64/lib/argon2-sse2.c
         arch/x86_64/lib/argon2-sse3.c
+        arch/x86_64/lib/argon2-ssse3.c
         arch/x86_64/lib/argon2-xop.c
         arch/x86_64/lib/argon2-avx2.c
         arch/x86_64/lib/argon2-avx512f.c

--- a/external/argon2/arch/x86_64/lib/argon2-ssse3.c
+++ b/external/argon2/arch/x86_64/lib/argon2-ssse3.c
@@ -1,6 +1,9 @@
 #include "argon2-ssse3.h"
 
-#ifdef HAVE_SSSE3
+#include "sse_shim.h"
+
+#ifdef __SSSE3__
+#pragma message ("info: ACTIVATING SSSE3 in argon2-ssse3.c")
 #include <string.h>
 
 #include <immintrin.h>


### PR DESCRIPTION
Looks like [SSSE3](https://en.wikipedia.org/wiki/SSSE3) was mistakenly not linked into the Argon2 code. By linking it in, some CPUs may see a performance increase.