### PR TITLE
Mac OSX CI Builds Need To Go

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libboost-all-dev libssl-dev ${{ matrix.package_name }}
-      
+
       # Configure the project with cmake
       - name: Configure
         if: matrix.build_name != 'aarch64'
@@ -41,7 +41,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DARCH=default -DCMAKE_BUILD_TYPE=Release -DSTATIC=true ..
-      
+
       # Build for linux
       - name: Build
         if: matrix.build_name != 'aarch64'
@@ -59,45 +59,10 @@ jobs:
           mkdir build && cd build
           cmake -DARCH=default -DCMAKE_BUILD_TYPE=Release -DSTATIC=true ..
           make -j2
-      
+
       # Test the crypto
       - name: Test Crypto
         if: matrix.build_name != 'aarch64'
-        run: |
-          cd build/src
-          ./cryptotest
-
-  # Mac builds on Mojave VM
-  macos_build:
-    name: macOS
-    runs-on: macOS-10.14
-    env:
-      CC: /usr/local/opt/llvm@8/bin/clang
-      CXX: /usr/local/opt/llvm@8/bin/clang++
-    steps:
-      - uses: actions/checkout@v1
-      
-      # Fetch Dependencies
-      - name: Dependencies
-        run: |
-          brew install --force boost llvm@8
-          brew link --force llvm@8
-          ln -s /usr/local/opt/llvm@8 /usr/local/opt/llvm
-      
-      # Configure project with cmake
-      - name: Configure
-        run: |
-          mkdir build && cd build
-          cmake -DARCH=default -DCMAKE_BUILD_TYPE=Release -DSTATIC=true ..
-      
-      # Build for macOS
-      - name: Build
-        run: |
-          cd build
-          make -j2
-      
-      # Test the crypto
-      - name: Test Crypto
         run: |
           cd build/src
           ./cryptotest
@@ -110,7 +75,7 @@ jobs:
       MSBUILD_PATH: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin"
     steps:
       - uses: actions/checkout@v1
-      
+
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
 
@@ -120,13 +85,13 @@ jobs:
           mkdir build
           cd build
           cmake -G "Visual Studio 16 2019" -A x64 .. -DARCH=default
-      
+
       # Build for Windows
       - name: Build
         run: |
           cd build
           MSBuild TurtleCoin.sln /p:Configuration=Release /m
-      
+
       # Test the crypto
       - name: Test Crypto
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,16 +64,6 @@ matrix:
     - LABEL="linux-clang-6"
     - STRIP="strip"
 
-  # OSX, clang
-  - os: osx
-    osx_image: xcode10
-    compiler: clang
-    env:
-    - MATRIX_EVAL="CC=/usr/local/opt/llvm@8/bin/clang && CXX=/usr/local/opt/llvm@8/bin/clang++"
-    - LABEL="osx"
-    - _DEPLOYABLE="true"
-    - STRIP="strip"
-
   # Arm (aarch64) cross compile
   - os: linux
     dist: trusty
@@ -85,24 +75,6 @@ matrix:
 
 before_install:
 - eval $MATRIX_EVAL
-
-install:
-# Need to uninstall oclint to get newer gcc installed https://github.com/travis-ci/travis-ci/issues/8826
-- if [[ "${LABEL:0:3}" == "osx" ]]; then brew cask uninstall --force oclint || true ; fi
-
-# Need a newer version of llvm to link against to get std::filesystem / std::experimental::filesystem
-- if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew install llvm@8 || travis_retry brew upgrade llvm@8 ; fi
-- if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew link --force llvm@8 ; fi
-- if [[ "${LABEL:0:3}" == "osx" ]]; then ln -s /usr/local/opt/llvm@8 /usr/local/opt/llvm ; fi
-
-# Need to make sure that we have openssl installed
-- if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew install openssl || travis_retry brew upgrade openssl ; fi
-- if [[ "${LABEL:0:3}" == "osx" ]]; then brew link --force openssl ; fi
-- if [[ "${LABEL:0:3}" == "osx" ]]; then ln -s /usr/local/opt/openssl/include/openssl /usr/local/include ; fi
-
-# Neeed to install ccache
-- if [[ "${LABEL:0:3}" == "osx" ]]; then travis_retry brew install ccache ; fi
-- if [[ "${LABEL:0:3}" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH" ; fi
 
 script:
 - eval $MATRIX_EVAL


### PR DESCRIPTION
![f9a](https://user-images.githubusercontent.com/20562132/68168552-2759ee00-ff37-11e9-921a-021ebc7f2c56.gif)

None of the CI tools are building properly for Catalina and others now that the SDK is all wonky. For now, this insanity needs to stop.