### PR TITLE
Allow Arbitrary Data in Transaction Extra Nonce via Wallet-API

### DIFF
--- a/src/common/Varint.h
+++ b/src/common/Varint.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace Tools
 {
@@ -68,5 +69,23 @@ namespace Tools
     template<typename InputIt, typename T> int read_varint(InputIt &&first, InputIt &&last, T &i)
     {
         return read_varint<std::numeric_limits<T>::digits, InputIt, T>(std::move(first), std::move(last), i);
+    }
+
+    inline std::vector<uint8_t> uintToVarintVector(size_t i)
+    {
+        std::vector<uint8_t> output;
+
+        while (i >= 0x80)
+        {
+            char elem = (static_cast<char>(i) & 0x7f) | 0x80;
+
+            output.push_back(elem);
+
+            i >>= 7;
+        }
+
+        output.push_back(static_cast<char>(i));
+
+        return output;
     }
 } // namespace Tools

--- a/src/config/Constants.h
+++ b/src/config/Constants.h
@@ -197,6 +197,9 @@ namespace Constants
     /* Indicates the following data is a merge mine depth+merkle root */
     const uint8_t TX_EXTRA_MERGE_MINING_IDENTIFIER = 0x03;
 
+    /* Indicates the following data is arbitrary data in tx_extra */
+    const uint8_t TX_EXTRA_ARBITRARY_DATA_IDENTIFIER = 0x7f;
+
     const Crypto::Hash NULL_HASH = Crypto::Hash({
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     });

--- a/src/errors/Errors.cpp
+++ b/src/errors/Errors.cpp
@@ -278,6 +278,10 @@ std::string Error::getErrorMessage() const
         {
             return "The private key given is not a valid ed25519 public key.";
         }
+        case INVALID_EXTRA_DATA:
+        {
+            return "The extra data given for the transaction could not be decoded.";
+        }
             /* No default case so the compiler warns us if we missed one */
     }
 

--- a/src/errors/Errors.h
+++ b/src/errors/Errors.h
@@ -210,6 +210,9 @@ enum ErrorCode
 
     /* Not on ed25519 curve */
     INVALID_PRIVATE_KEY = 52,
+
+    /* Extra data for transaction is not a valid hexadecimal string */
+    INVALID_EXTRA_DATA = 53,
 };
 
 class Error

--- a/src/utilities/ParseExtra.h
+++ b/src/utilities/ParseExtra.h
@@ -21,6 +21,7 @@ namespace Utilities
         Crypto::PublicKey transactionPublicKey;
         std::string paymentID;
         MergedMiningTag mergedMiningTag;
+        std::vector<uint8_t> extraData;
     };
 
     std::string getPaymentIDFromExtra(const std::vector<uint8_t> &extra);
@@ -28,6 +29,8 @@ namespace Utilities
     Crypto::PublicKey getTransactionPublicKeyFromExtra(const std::vector<uint8_t> &extra);
 
     MergedMiningTag getMergedMiningTagFromExtra(const std::vector<uint8_t> &extra);
+
+    std::vector<uint8_t> getExtraDataFromExtra(const std::vector<uint8_t> &extra);
 
     ParsedExtra parseExtra(const std::vector<uint8_t> &extra);
 } // namespace Utilities

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -8,6 +8,7 @@
 
 #include <config/Constants.h>
 #include <config/WalletConfig.h>
+#include <common/Varint.h>
 #include <errors/ValidateParameters.h>
 #include <utilities/Addresses.h>
 #include <utilities/FormatTools.h>
@@ -26,7 +27,7 @@ namespace SendTransaction
            as the static constructors were used */
         const std::string defaultAddress = subWallets->getPrimaryAddress();
 
-        return sendFusionTransactionAdvanced(defaultMixin, {}, defaultAddress, daemon, subWallets);
+        return sendFusionTransactionAdvanced(defaultMixin, {}, defaultAddress, daemon, subWallets, {});
     }
 
     std::tuple<Error, Crypto::Hash> sendFusionTransactionAdvanced(
@@ -34,7 +35,8 @@ namespace SendTransaction
         const std::vector<std::string> addressesToTakeFrom,
         std::string destination,
         const std::shared_ptr<Nigel> daemon,
-        const std::shared_ptr<SubWallets> subWallets)
+        const std::shared_ptr<SubWallets> subWallets,
+        const std::vector<uint8_t> extraData)
     {
         if (destination == "")
         {
@@ -120,7 +122,7 @@ namespace SendTransaction
             const uint64_t unlockTime = 0;
 
             TransactionResult txResult =
-                makeTransaction(mixin, daemon, ourInputs, paymentID, destinations, subWallets, unlockTime);
+                makeTransaction(mixin, daemon, ourInputs, paymentID, destinations, subWallets, unlockTime, extraData);
 
             tx = txResult.transaction;
             transactionOutputs = txResult.outputs;
@@ -217,7 +219,7 @@ namespace SendTransaction
         const uint64_t unlockTime = 0;
 
         return sendTransactionAdvanced(
-            destinations, defaultMixin, fee, paymentID, {}, changeAddress, daemon, subWallets, unlockTime);
+            destinations, defaultMixin, fee, paymentID, {}, changeAddress, daemon, subWallets, unlockTime, {});
     }
 
     std::tuple<Error, Crypto::Hash> sendTransactionAdvanced(
@@ -229,7 +231,8 @@ namespace SendTransaction
         std::string changeAddress,
         const std::shared_ptr<Nigel> daemon,
         const std::shared_ptr<SubWallets> subWallets,
-        const uint64_t unlockTime)
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData)
     {
         /* Append the fee transaction, if a fee is being used */
         const auto [feeAmount, feeAddress] = daemon->nodeFee();
@@ -301,7 +304,7 @@ namespace SendTransaction
         const auto destinations = setupDestinations(addressesAndAmounts, changeRequired, changeAddress);
 
         TransactionResult txResult =
-            makeTransaction(mixin, daemon, ourInputs, paymentID, destinations, subWallets, unlockTime);
+            makeTransaction(mixin, daemon, ourInputs, paymentID, destinations, subWallets, unlockTime, extraData);
 
         if (txResult.error)
         {
@@ -985,7 +988,8 @@ namespace SendTransaction
         const std::string paymentID,
         const std::vector<WalletTypes::TransactionDestination> destinations,
         const std::shared_ptr<SubWallets> subWallets,
-        const uint64_t unlockTime)
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData)
     {
         /* Mix our inputs with fake ones from the network to hide who we are */
         const auto [mixinError, inputsAndFakes] = prepareRingParticipants(ourInputs, mixin, daemon);
@@ -1011,7 +1015,7 @@ namespace SendTransaction
         /* Setup the transaction outputs */
         std::tie(result.outputs, result.txKeyPair) = setupOutputs(destinations);
 
-        std::vector<uint8_t> extra;
+        std::vector<uint8_t> extraNonce;
 
         if (paymentID != "")
         {
@@ -1019,16 +1023,43 @@ namespace SendTransaction
 
             Common::podFromHex(paymentID, paymentIDBin);
 
+            /* Indicate this is the payment ID */
+            extraNonce.push_back(Constants::TX_EXTRA_PAYMENT_ID_IDENTIFIER);
+
+            /* Write the data to the extra nonce */
+            std::copy(std::begin(paymentIDBin.data), std::end(paymentIDBin.data), std::back_inserter(extraNonce));
+        }
+
+        if (!extraData.empty())
+        {
+            /* Indicate this is arbitrary data */
+            extraNonce.push_back(Constants::TX_EXTRA_ARBITRARY_DATA_IDENTIFIER);
+
+            /* Determine the length of the data and varint encode it */
+            std::vector<uint8_t> extraDataSize = Tools::uintToVarintVector(extraData.size());
+
+            /* Write the length of the data out to extra */
+            std::copy(extraDataSize.begin(), extraDataSize.end(), std::back_inserter(extraNonce));
+
+            /* Write the data to the extra nonce */
+            std::copy(extraData.begin(), extraData.end(), std::back_inserter(extraNonce));
+        }
+
+        std::vector<uint8_t> extra;
+
+        if (!extraNonce.empty())
+        {
             /* Indicate this is the extra nonce */
             extra.push_back(Constants::TX_EXTRA_NONCE_IDENTIFIER);
 
-            /* Add the length of the extra nonce (PID tag + PID length == 33) */
-            extra.push_back(1 + 32);
+            /* Determine the length of the nonce data and varint encode it */
+            std::vector<uint8_t> extraNonceSize = Tools::uintToVarintVector(extraNonce.size());
 
-            /* Indicate this is the payment ID */
-            extra.push_back(Constants::TX_EXTRA_PAYMENT_ID_IDENTIFIER);
+            /* Write the extra nonce length to extra */
+            std::copy(extraNonceSize.begin(), extraNonceSize.end(), std::back_inserter(extra));
 
-            std::copy(std::begin(paymentIDBin.data), std::end(paymentIDBin.data), std::back_inserter(extra));
+            /* Write the data to extra */
+            std::copy(extraNonce.begin(), extraNonce.end(), std::back_inserter(extra));
         }
 
         /* Add the pub key identifier to extra */

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -20,7 +20,8 @@ namespace SendTransaction
         const std::vector<std::string> addressesToTakeFrom,
         std::string destination,
         const std::shared_ptr<Nigel> daemon,
-        const std::shared_ptr<SubWallets> subWallets);
+        const std::shared_ptr<SubWallets> subWallets,
+        const std::vector<uint8_t> extraData);
 
     std::tuple<Error, Crypto::Hash> sendTransactionBasic(
         std::string destination,
@@ -38,7 +39,8 @@ namespace SendTransaction
         std::string changeAddress,
         const std::shared_ptr<Nigel> daemon,
         const std::shared_ptr<SubWallets> subWallets,
-        const uint64_t unlockTime);
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData);
 
     std::vector<WalletTypes::TransactionDestination> setupDestinations(
         std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
@@ -100,7 +102,8 @@ namespace SendTransaction
         const std::string paymentID,
         const std::vector<WalletTypes::TransactionDestination> destinations,
         const std::shared_ptr<SubWallets> subWallets,
-        const uint64_t unlockTime);
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData);
 
     std::tuple<Error, Crypto::Hash>
         relayTransaction(const CryptoNote::Transaction tx, const std::shared_ptr<Nigel> daemon);

--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -765,10 +765,11 @@ std::tuple<Error, Crypto::Hash> WalletBackend::sendTransactionAdvanced(
     const std::string paymentID,
     const std::vector<std::string> subWalletsToTakeFrom,
     const std::string changeAddress,
-    const uint64_t unlockTime)
+    const uint64_t unlockTime,
+    const std::vector<uint8_t> extraData)
 {
     return SendTransaction::sendTransactionAdvanced(
-        destinations, mixin, fee, paymentID, subWalletsToTakeFrom, changeAddress, m_daemon, m_subWallets, unlockTime);
+        destinations, mixin, fee, paymentID, subWalletsToTakeFrom, changeAddress, m_daemon, m_subWallets, unlockTime, extraData);
 }
 
 std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionBasic()
@@ -779,10 +780,11 @@ std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionBasic()
 std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionAdvanced(
     const uint64_t mixin,
     const std::vector<std::string> subWalletsToTakeFrom,
-    const std::string destination)
+    const std::string destination,
+    const std::vector<uint8_t> extraData)
 {
     return SendTransaction::sendFusionTransactionAdvanced(
-        mixin, subWalletsToTakeFrom, destination, m_daemon, m_subWallets);
+        mixin, subWalletsToTakeFrom, destination, m_daemon, m_subWallets, extraData);
 }
 
 void WalletBackend::reset(uint64_t scanHeight, uint64_t timestamp)

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -141,7 +141,8 @@ class WalletBackend
         const std::string paymentID,
         const std::vector<std::string> subWalletsToTakeFrom,
         const std::string changeAddress,
-        const uint64_t unlockTime);
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData);
 
     /* Send a fusion using default mixin, default destination, and
        taking from all subwallets */
@@ -151,7 +152,8 @@ class WalletBackend
     std::tuple<Error, Crypto::Hash> sendFusionTransactionAdvanced(
         const uint64_t mixin,
         const std::vector<std::string> subWalletsToTakeFrom,
-        const std::string destinationAddress);
+        const std::string destinationAddress,
+        const std::vector<uint8_t> extraData);
 
     /* Get the balance for one subwallet (error, unlocked, locked) */
     std::tuple<Error, uint64_t, uint64_t> getBalance(const std::string address) const;


### PR DESCRIPTION
This allows for the addition of arbitrary hexadecimal data to be added to a transaction nonce via wallet-api.

The additional body parameter `extra` has been added to support this.

Once supplied, the data is encoded behind a special nonce tag (`127`) and appended to the nonce such that:

<tag><varint encoded length of data><data>

Example: https://explorer.turtlecoin.lol/transaction.html?hash=5591fc3bb7384d304341066b214635687c615c860b17024d8cdb593e23aae017

Note: This does not remove the 1,024 byte limit for the TX_EXTRA so that limit still applies.

This matches how I handled this in [turtlecoin-utils](https://github.com/turtlecoin/turtlecoin-utils)