### PR TITLE
Fix a bug that prevents blockchain to be loaded if the blockindexes.bin corrupts

### DIFF
--- a/src/cryptonotecore/DatabaseBlockchainCache.cpp
+++ b/src/cryptonotecore/DatabaseBlockchainCache.cpp
@@ -569,7 +569,7 @@ namespace CryptoNote
 
         if (getTopBlockIndex() == 0)
         {
-            logger(Logging::DEBUGGING) << "top block index is nill, add genesis block";
+            logger(Logging::DEBUGGING) << "top block index is null, add genesis block";
             addGenesisBlock(CachedBlock(currency.genesisBlock()));
         }
     }

--- a/src/cryptonotecore/SwappedVector.h
+++ b/src/cryptonotecore/SwappedVector.h
@@ -9,10 +9,10 @@
 #include "common/StdOutputStream.h"
 #include "serialization/BinaryInputStreamSerializer.h"
 #include "serialization/BinaryOutputStreamSerializer.h"
+#include "logger/Logger.h"
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
-#include <cstdio>
 #include <iomanip>
 #include <iostream>
 #include <list>
@@ -234,7 +234,7 @@ template<class T> SwappedVector<T>::~SwappedVector()
 template<class T>
 bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &indexFileName, size_t poolSize)
 {
-    if (poolSize == 0)
+	if (poolSize == 0)
     {
         return false;
     }
@@ -263,8 +263,8 @@ bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &
 					return false;
 				}
 				else {
-					i--;
-					std::cout<<"Detected EOF before all indexes begin logged. Adjusting index counts to "<<i<<std::endl;
+					Logger::logger.log("Blockchain indexes file appears to be corrupted. Attempting automatic recovery by rewinding to " + std::to_string(i),
+						Logger::WARNING, { Logger::FILESYSTEM});
 					break;
 				}
             }
@@ -272,7 +272,7 @@ bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &
             offsets.emplace_back(itemsFileSize);
             itemsFileSize += itemSize;
         }
-
+		
         m_offsets.swap(offsets);
         m_itemsFileSize = itemsFileSize;
     }

--- a/src/cryptonotecore/SwappedVector.h
+++ b/src/cryptonotecore/SwappedVector.h
@@ -265,6 +265,9 @@ bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &
 				else {
 					Logger::logger.log("Blockchain indexes file appears to be corrupted. Attempting automatic recovery by rewinding to " + std::to_string(i),
 						Logger::WARNING, {Logger::FILESYSTEM,Logger::DATABASE});
+					//Reopen the indexes file to force changes to be commited
+					m_indexesFile.close();
+					m_indexesFile.open(indexFileName, std::ios::in | std::ios::out | std::ios::binary);
 					break;
 				}
             }

--- a/src/cryptonotecore/SwappedVector.h
+++ b/src/cryptonotecore/SwappedVector.h
@@ -265,9 +265,10 @@ bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &
 				else {
 					Logger::logger.log("Blockchain indexes file appears to be corrupted. Attempting automatic recovery by rewinding to " + std::to_string(i),
 						Logger::WARNING, {Logger::FILESYSTEM,Logger::DATABASE});
-					//Reopen the indexes file to force changes to be commited
-					m_indexesFile.close();
-					m_indexesFile.open(indexFileName, std::ios::in | std::ios::out | std::ios::binary);
+					m_indexesFile.clear(); //clear the error
+					m_indexesFile.seekp(0); //retain compability with C98
+					m_indexesFile.write(reinterpret_cast<char*>(&i), sizeof i); //update the count
+					m_indexesFile.flush(); //commit
 					break;
 				}
             }

--- a/src/cryptonotecore/SwappedVector.h
+++ b/src/cryptonotecore/SwappedVector.h
@@ -264,7 +264,7 @@ bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &
 				}
 				else {
 					Logger::logger.log("Blockchain indexes file appears to be corrupted. Attempting automatic recovery by rewinding to " + std::to_string(i),
-						Logger::WARNING, { Logger::FILESYSTEM});
+						Logger::WARNING, {Logger::FILESYSTEM,Logger::DATABASE});
 					break;
 				}
             }

--- a/src/cryptonotecore/SwappedVector.h
+++ b/src/cryptonotecore/SwappedVector.h
@@ -9,10 +9,10 @@
 #include "common/StdOutputStream.h"
 #include "serialization/BinaryInputStreamSerializer.h"
 #include "serialization/BinaryOutputStreamSerializer.h"
-
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <cstdio>
 #include <iomanip>
 #include <iostream>
 #include <list>
@@ -256,9 +256,17 @@ bool SwappedVector<T>::open(const std::string &itemFileName, const std::string &
         {
             uint32_t itemSize;
             m_indexesFile.read(reinterpret_cast<char *>(&itemSize), sizeof itemSize);
+
             if (!m_indexesFile)
             {
-                return false;
+				if (!m_indexesFile.eof()) { //fail it only if the other IO occured
+					return false;
+				}
+				else {
+					i--;
+					std::cout<<"Detected EOF before all indexes begin logged. Adjusting index counts to "<<i<<std::endl;
+					break;
+				}
             }
 
             offsets.emplace_back(itemsFileSize);

--- a/src/logger/Logger.cpp
+++ b/src/logger/Logger.cpp
@@ -105,6 +105,10 @@ namespace Logger
             {
                 return "Daemon";
             }
+			case DATABASE:
+			{
+				return "Database";
+			}
         }
 
         throw std::invalid_argument("Invalid log category given");

--- a/src/logger/Logger.h
+++ b/src/logger/Logger.h
@@ -26,6 +26,7 @@ namespace Logger
         FILESYSTEM,
         SAVE,
         DAEMON,
+		DATABASE,
     };
 
     std::string logLevelToString(const LogLevel level);


### PR DESCRIPTION
blockindexes.bin hold the indexes for each block in the main storage. The file began with 8 bytes with type of uint64_t to represent the count of the entries. After that, for each entry 4 bytes used to store it. The original code will fail the loading if to read fails. But if the indexes file was corrupt due to the incomplete write then the file should be recoverable by updating the count of entries to the correct value.

In this fix, if the EOF comes before the indexes fully loaded, instead of failing it the code will automatically fix it by simply terminate the loop and allow the deamon still working.