### PR TITLE
Generating deterministic private spend keys for subwallets

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -653,34 +653,33 @@ namespace Crypto
 
         std::memcpy(subwalletSalt.data(), &subwalletIndex, sizeof(subwalletIndex));
 
-        /* Our new spend key starts as just the key that was supplied */
-        subSpend = baseSpend;
+        /* Set up our temporary key as 32 byte key + 8 byte wallet index */
+        std::vector<uint8_t> tmpKey(40);
+
+        /* Copy our base key into the vector */
+        std::copy(std::begin(baseSpend.data), std::end(baseSpend.data), tmpKey.begin());
 
         /* Loop through the iteration count and stretch this key */
-        for (size_t i = 0; i < iterations; i++)
+        for (uint64_t i = 0; i < iterations; i++)
         {
-            /* Copy the existing new spend key into a new binary array for
-               further manipulation */
-            std::vector<uint8_t> newKey;
+            /* Copy our wallet index on to the end of the temporary key vector
+               to salt the input to the hashing method */
+            std::copy(subwalletSalt.begin(), subwalletSalt.end(), tmpKey.begin() + 32);
 
-            std::copy(std::begin(subSpend.data), std::end(subSpend.data), std::back_inserter(newKey));
+            /* Hash the binary array */
+            Hash h;
 
-            /* Append our salt (the subwallet index as defined above to the key information */
-            std::copy(subwalletSalt.begin(), subwalletSalt.end(), std::back_inserter(newKey));
+            cn_fast_hash(tmpKey.data(), tmpKey.size(), h);
 
-            /* Hash that new key data with cn_fast_hash to make it computationally
-               infeasible to reverse */
-            Crypto::Hash hash;
-
-            cn_fast_hash(newKey.data(), newKey.size(), hash);
-
-            /* The resulting hash is our new spend key before scalar reduction */
-            subSpend = hash.data;
+            /* Copy the hash back into the tmpKey vector */
+            std::copy(std::begin(h.data), std::end(h.data), tmpKey.begin());
         }
+
+        std::copy(tmpKey.begin(), tmpKey.begin() + 32, subSpend.data);
 
         /* Run the resulting key through scalar reduction to make sure we have a good
            private key that is returned to the caller */
-        sc_reduce32(reinterpret_cast<unsigned char *>(&subSpend));
+        sc_reduce32(reinterpret_cast<unsigned char *>(&subSpend.data));
     }
 
 } // namespace Crypto

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -52,7 +52,11 @@ namespace Crypto
             const SecretKey &recovery_key = SecretKey(),
             bool recover = false);
 
-        friend SecretKey generate_m_keys(PublicKey &pub, SecretKey &sec, const SecretKey &recovery_key, bool recover);
+        friend SecretKey generate_m_keys(
+            PublicKey &pub,
+            SecretKey &sec,
+            const SecretKey &recovery_key,
+            bool recover);
 
         static bool check_key(const PublicKey &);
 
@@ -132,6 +136,10 @@ namespace Crypto
 
         friend void hash_data_to_ec(const uint8_t *, std::size_t, PublicKey &);
 
+        static void generate_deterministic_subwallet_key(const SecretKey &, uint64_t, SecretKey &);
+
+        friend void generate_deterministic_subwallet_key(const SecretKey &, uint64_t, SecretKey &);
+
       public:
         static std::tuple<bool, std::vector<Signature>> generateRingSignatures(
             const Hash prefixHash,
@@ -152,10 +160,22 @@ namespace Crypto
             const Crypto::SecretKey &spend,
             Crypto::SecretKey &viewSecret,
             Crypto::PublicKey &viewPublic);
+
+        static bool generate_deterministic_subwallet_keys(
+            const SecretKey basePrivate,
+            const uint64_t subwalletIndex,
+            SecretKey &subwalletPrivate,
+            PublicKey &subwalletPublic)
+        {
+            /* Generate our new deterministic private key */
+            generate_deterministic_subwallet_key(basePrivate, subwalletIndex, subwalletPrivate);
+
+            /* Generate the related public key for the new deterministic private key */
+            return secret_key_to_public_key(subwalletPrivate, subwalletPublic);
+        }
     };
 
-    /* Generate a new key pair
-     */
+    /* Generate a new key pair */
     inline void generate_keys(PublicKey &pub, SecretKey &sec)
     {
         crypto_ops::generate_keys(pub, sec);
@@ -164,6 +184,19 @@ namespace Crypto
     inline void generate_deterministic_keys(PublicKey &pub, SecretKey &sec, SecretKey &second)
     {
         crypto_ops::generate_deterministic_keys(pub, sec, second);
+    }
+
+    inline bool generate_deterministic_subwallet_keys(
+        const SecretKey basePrivate,
+        const uint64_t subwalletIndex,
+        SecretKey &subwalletPrivate,
+        PublicKey &subwalletPublic)
+    {
+        return crypto_ops::generate_deterministic_subwallet_keys(
+            basePrivate,
+            subwalletIndex,
+            subwalletPrivate,
+            subwalletPublic);
     }
 
     inline SecretKey generate_m_keys(

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -136,9 +136,15 @@ namespace Crypto
 
         friend void hash_data_to_ec(const uint8_t *, std::size_t, PublicKey &);
 
-        static void generate_deterministic_subwallet_key(const SecretKey &, uint64_t, SecretKey &);
+        static void generate_deterministic_subwallet_key(
+            const SecretKey &basePrivateKey,
+            uint64_t walletIndex,
+            SecretKey &subWalletPrivateKey);
 
-        friend void generate_deterministic_subwallet_key(const SecretKey &, uint64_t, SecretKey &);
+        friend void generate_deterministic_subwallet_key(
+            const SecretKey &basePrivateKey,
+            uint64_t walletIndex,
+            SecretKey &subWalletPrivateKey);
 
       public:
         static std::tuple<bool, std::vector<Signature>> generateRingSignatures(
@@ -186,17 +192,21 @@ namespace Crypto
         crypto_ops::generate_deterministic_keys(pub, sec, second);
     }
 
-    inline bool generate_deterministic_subwallet_keys(
+    inline std::tuple<SecretKey, PublicKey> generate_deterministic_subwallet_keys(
         const SecretKey basePrivate,
-        const uint64_t subwalletIndex,
-        SecretKey &subwalletPrivate,
-        PublicKey &subwalletPublic)
+        const uint64_t subwalletIndex)
     {
-        return crypto_ops::generate_deterministic_subwallet_keys(
+        SecretKey privateKey;
+
+        PublicKey publicKey;
+
+        crypto_ops::generate_deterministic_subwallet_keys(
             basePrivate,
             subwalletIndex,
-            subwalletPrivate,
-            subwalletPublic);
+            privateKey,
+            publicKey);
+
+        return {privateKey, publicKey};
     }
 
     inline SecretKey generate_m_keys(

--- a/src/cryptotest/main.cpp
+++ b/src/cryptotest/main.cpp
@@ -292,11 +292,7 @@ void TestDeterministicSubwalletCreation (const std::string baseSpendKey, const u
         exit(1);
     }
 
-    Crypto::SecretKey subwalletPrivateKey;
-
-    Crypto::PublicKey subwalletPublicKey;
-
-    Crypto::generate_deterministic_subwallet_keys(f_baseSpendKey, subWalletIndex, subwalletPrivateKey, subwalletPublicKey);
+    const auto [subwalletPrivateKey, subwalletPublicKey] = Crypto::generate_deterministic_subwallet_keys(f_baseSpendKey, subWalletIndex);
 
     if (subwalletPrivateKey != f_expectedSpendKey)
     {

--- a/src/cryptotest/main.cpp
+++ b/src/cryptotest/main.cpp
@@ -272,6 +272,41 @@ void benchmarkGenerateKeyDerivation()
     std::cout << "Time to perform generateKeyDerivation: " << timePerDerivation / 1000.0 << " ms" << std::endl;
 }
 
+void TestDeterministicSubwalletCreation (const std::string baseSpendKey, const uint64_t subWalletIndex, const std::string expectedSpendKey)
+{
+    Crypto::SecretKey f_baseSpendKey;
+
+    if (!Common::podFromHex(baseSpendKey, f_baseSpendKey))
+    {
+        std::cout << "Could not decode base private spend key!\nTerminating...";
+
+        exit(1);
+    }
+
+    Crypto::SecretKey f_expectedSpendKey;
+
+    if (!Common::podFromHex(expectedSpendKey, f_expectedSpendKey))
+    {
+        std::cout << "Could not decode expected private spend key!\nTerminating...";
+
+        exit(1);
+    }
+
+    Crypto::SecretKey subwalletPrivateKey;
+
+    Crypto::PublicKey subwalletPublicKey;
+
+    Crypto::generate_deterministic_subwallet_keys(f_baseSpendKey, subWalletIndex, subwalletPrivateKey, subwalletPublicKey);
+
+    if (subwalletPrivateKey != f_expectedSpendKey)
+    {
+        std::cout << "Could not deterministically create subwallet spend keys!\n"
+                  << "Expected: " << expectedSpendKey << "\nActual: " << subwalletPrivateKey << "\nTerminating.";
+
+        exit(1);
+    }
+}
+
 int main(int argc, char **argv)
 {
     bool o_help, o_version, o_benchmark;
@@ -423,6 +458,16 @@ int main(int argc, char **argv)
 
             BENCHMARK(chukwa_slow_hash, o_iterations_long);
         }
+
+        std::cout <<std::endl << "Deterministic Subwallet Creation Tests: ";
+
+        TestDeterministicSubwalletCreation("dd0c02d3202634821b4d9d91b63d919725f5c3e97e803f3512e52fb0dc2aab0c", 0, "dd0c02d3202634821b4d9d91b63d919725f5c3e97e803f3512e52fb0dc2aab0c");
+        TestDeterministicSubwalletCreation("dd0c02d3202634821b4d9d91b63d919725f5c3e97e803f3512e52fb0dc2aab0c", 1, "c55cbe4fd1c49dca5958fa1c7b9212c2dbf3fd5bfec84de741d434056e298600");
+        TestDeterministicSubwalletCreation("dd0c02d3202634821b4d9d91b63d919725f5c3e97e803f3512e52fb0dc2aab0c", 2, "9813c40428ed9b380a2f72bac1374a9d3852a974b0527e003cbc93afab764d01");
+        TestDeterministicSubwalletCreation("dd0c02d3202634821b4d9d91b63d919725f5c3e97e803f3512e52fb0dc2aab0c", 64, "29c2afed13271e2bb3321c2483356fd8798f2709af4de3906b6627ec71727108");
+        TestDeterministicSubwalletCreation("dd0c02d3202634821b4d9d91b63d919725f5c3e97e803f3512e52fb0dc2aab0c", 65, "0c6b5fff72260832558e35c38e690072503211af065056862288dc7fd992350a");
+
+        std::cout << "Passed." << std::endl;
     }
     catch (std::exception &e)
     {

--- a/src/subwallets/SubWallet.cpp
+++ b/src/subwallets/SubWallet.cpp
@@ -38,13 +38,15 @@ SubWallet::SubWallet(
     const std::string address,
     const uint64_t scanHeight,
     const uint64_t scanTimestamp,
-    const bool isPrimaryAddress):
+    const bool isPrimaryAddress,
+    const uint64_t walletIndex):
     m_publicSpendKey(publicSpendKey),
     m_address(address),
     m_syncStartHeight(scanHeight),
     m_syncStartTimestamp(scanTimestamp),
     m_privateSpendKey(privateSpendKey),
-    m_isPrimaryAddress(isPrimaryAddress)
+    m_isPrimaryAddress(isPrimaryAddress),
+    m_walletIndex(walletIndex)
 {
 }
 
@@ -147,6 +149,11 @@ bool SubWallet::isPrimaryAddress() const
 std::string SubWallet::address() const
 {
     return m_address;
+}
+
+uint64_t SubWallet::walletIndex() const
+{
+    return m_walletIndex;
 }
 
 Crypto::PublicKey SubWallet::publicSpendKey() const
@@ -419,6 +426,11 @@ std::vector<Crypto::KeyImage> SubWallet::getKeyImages() const
 
 void SubWallet::fromJSON(const JSONValue &j)
 {
+    if (j.HasMember("walletIndex"))
+    {
+        m_walletIndex = getUint64FromJSON(j, "walletIndex");
+    }
+
     m_publicSpendKey.fromString(getStringFromJSON(j, "publicSpendKey"));
     m_privateSpendKey.fromString(getStringFromJSON(j, "privateSpendKey"));
     m_address = getStringFromJSON(j, "address");
@@ -454,6 +466,8 @@ void SubWallet::fromJSON(const JSONValue &j)
 void SubWallet::toJSON(rapidjson::Writer<rapidjson::StringBuffer> &writer) const
 {
     writer.StartObject();
+    writer.Key("walletIndex");
+    writer.Uint64(m_walletIndex);
     writer.Key("publicSpendKey");
     m_publicSpendKey.toJSON(writer);
     writer.Key("privateSpendKey");

--- a/src/subwallets/SubWallet.h
+++ b/src/subwallets/SubWallet.h
@@ -35,7 +35,8 @@ class SubWallet
         const std::string address,
         const uint64_t scanHeight,
         const uint64_t scanTimestamp,
-        const bool isPrimaryAddress);
+        const bool isPrimaryAddress,
+        const uint64_t walletIndex = 0);
 
     /////////////////////////////
     /* Public member functions */
@@ -64,6 +65,8 @@ class SubWallet
     bool isPrimaryAddress() const;
 
     std::string address() const;
+
+    uint64_t walletIndex() const;
 
     Crypto::PublicKey publicSpendKey() const;
 
@@ -118,6 +121,9 @@ class SubWallet
 
     /* The subwallet's private spend key */
     Crypto::SecretKey m_privateSpendKey;
+
+    /* The subwallet's deterministic index value */
+    uint64_t m_walletIndex = 0;
 
     /* The timestamp to begin syncing the wallet at
        (usually creation time or zero) */

--- a/src/subwallets/SubWallets.h
+++ b/src/subwallets/SubWallets.h
@@ -39,10 +39,13 @@ class SubWallets
     /////////////////////////////
 
     /* Adds a sub wallet with a random spend key */
-    std::tuple<Error, std::string, Crypto::SecretKey> addSubWallet();
+    std::tuple<Error, std::string, Crypto::SecretKey, uint64_t> addSubWallet();
 
     /* Imports a sub wallet with the given private spend key */
     std::tuple<Error, std::string> importSubWallet(const Crypto::SecretKey privateSpendKey, const uint64_t scanHeight);
+
+    /* Imports a sub wallet with the given wallet counter */
+    std::tuple<Error, std::string> importSubWallet(const uint64_t walletIndex, const uint64_t scanHeight);
 
     /* Imports a sub view only wallet with the given public spend key */
     std::tuple<Error, std::string>
@@ -116,8 +119,8 @@ class SubWallets
 
     Crypto::SecretKey getPrivateViewKey() const;
 
-    /* Gets the private spend key for the given public spend, if it exists */
-    std::tuple<Error, Crypto::SecretKey> getPrivateSpendKey(const Crypto::PublicKey publicSpendKey) const;
+    /* Gets the private spend key and subwallet index for the given public spend, if it exists */
+    std::tuple<Error, Crypto::SecretKey, uint64_t> getPrivateSpendKey(const Crypto::PublicKey publicSpendKey) const;
 
     std::vector<Crypto::SecretKey> getPrivateSpendKeys() const;
 
@@ -186,6 +189,9 @@ class SubWallets
     //////////////////////////////
     /* Private member variables */
     //////////////////////////////
+
+    /* The current subwallet index counter */
+    uint64_t m_subWalletIndexCounter = 0;
 
     /* The subwallets, indexed by public spend key */
     std::unordered_map<Crypto::PublicKey, SubWallet> m_subWallets;

--- a/src/walletapi/ApiDispatcher.h
+++ b/src/walletapi/ApiDispatcher.h
@@ -120,6 +120,10 @@ class ApiDispatcher
     std::tuple<Error, uint16_t>
         importAddress(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
+    /* Imports a deterministic address using a wallet index */
+    std::tuple<Error, uint16_t>
+        importDeterministicAddress(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
+
     /* Imports a view only address with a public spend key */
     std::tuple<Error, uint16_t>
         importViewAddress(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);

--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -814,7 +814,7 @@ void WalletBackend::reset(uint64_t scanHeight, uint64_t timestamp)
     });
 }
 
-std::tuple<Error, std::string, Crypto::SecretKey> WalletBackend::addSubWallet()
+std::tuple<Error, std::string, Crypto::SecretKey, uint64_t> WalletBackend::addSubWallet()
 {
     return m_syncRAIIWrapper->pauseSynchronizerToRunFunction([this]() {
         /* Add the sub wallet */
@@ -833,6 +833,34 @@ std::tuple<Error, std::string>
     return m_syncRAIIWrapper->pauseSynchronizerToRunFunction([&, this]() {
         /* Add the sub wallet */
         const auto [error, address] = m_subWallets->importSubWallet(privateSpendKey, scanHeight);
+
+        if (!error)
+        {
+            /* If we're not making a new wallet, check if we need to reset the scan
+               height of the wallet synchronizer, to pick up the new wallet data
+               from the requested height */
+            uint64_t currentHeight = m_walletSynchronizer->getCurrentScanHeight();
+
+            if (currentHeight >= scanHeight)
+            {
+                /* Empty the sync status and reset the start height */
+                m_walletSynchronizer->reset(scanHeight);
+
+                /* Reset transactions, inputs, etc */
+                m_subWallets->reset(scanHeight);
+            }
+        }
+
+        return std::make_tuple(error, address);
+    });
+}
+
+std::tuple<Error, std::string>
+    WalletBackend::importSubWallet(const uint64_t walletIndex, const uint64_t scanHeight)
+{
+    return m_syncRAIIWrapper->pauseSynchronizerToRunFunction([&, this]() {
+        /* Add the sub wallet */
+        const auto [error, address] = m_subWallets->importSubWallet(walletIndex, scanHeight);
 
         if (!error)
         {
@@ -959,20 +987,20 @@ Error WalletBackend::changePassword(const std::string newPassword)
     return save();
 }
 
-std::tuple<Error, Crypto::PublicKey, Crypto::SecretKey> WalletBackend::getSpendKeys(const std::string &address) const
+std::tuple<Error, Crypto::PublicKey, Crypto::SecretKey, uint64_t> WalletBackend::getSpendKeys(const std::string &address) const
 {
     const bool allowIntegratedAddresses = false;
 
     if (Error error = validateAddresses({address}, allowIntegratedAddresses); error != SUCCESS)
     {
-        return {error, Crypto::PublicKey(), Crypto::SecretKey()};
+        return {error, Crypto::PublicKey(), Crypto::SecretKey(), 0};
     }
 
     const auto [publicSpendKey, publicViewKey] = Utilities::addressToKeys(address);
 
-    const auto [success, privateSpendKey] = m_subWallets->getPrivateSpendKey(publicSpendKey);
+    const auto [success, privateSpendKey, walletIndex] = m_subWallets->getPrivateSpendKey(publicSpendKey);
 
-    return {success, publicSpendKey, privateSpendKey};
+    return {success, publicSpendKey, privateSpendKey, walletIndex};
 }
 
 Crypto::SecretKey WalletBackend::getPrivateViewKey() const
@@ -1001,7 +1029,7 @@ std::tuple<Error, std::string> WalletBackend::getMnemonicSeedForAddress(const st
     }
 
     const auto privateViewKey = getPrivateViewKey();
-    const auto [error, publicSpendKey, privateSpendKey] = getSpendKeys(address);
+    const auto [error, publicSpendKey, privateSpendKey, walletIndex] = getSpendKeys(address);
 
     if (error)
     {

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -163,11 +163,14 @@ class WalletBackend
 
     uint64_t getTotalUnlockedBalance() const;
 
-    /* Make a new sub wallet (gens a privateSpendKey) */
-    std::tuple<Error, std::string, Crypto::SecretKey> addSubWallet();
+    /* Make a new sub wallet (gens a deterministic privateSpendKey) */
+    std::tuple<Error, std::string, Crypto::SecretKey, uint64_t> addSubWallet();
 
     /* Import a sub wallet with the given privateSpendKey */
     std::tuple<Error, std::string> importSubWallet(const Crypto::SecretKey privateSpendKey, const uint64_t scanHeight);
+
+    /* Import a deterministic sub wallet using the given wallet index */
+    std::tuple<Error, std::string> importSubWallet(const uint64_t walletIndex, const uint64_t scanHeight);
 
     /* Import a view only sub wallet with the given publicSpendKey */
     std::tuple<Error, std::string>
@@ -206,7 +209,7 @@ class WalletBackend
     Crypto::SecretKey getPrivateViewKey() const;
 
     /* Gets the public and private spend key for the given address */
-    std::tuple<Error, Crypto::PublicKey, Crypto::SecretKey> getSpendKeys(const std::string &address) const;
+    std::tuple<Error, Crypto::PublicKey, Crypto::SecretKey, uint64_t> getSpendKeys(const std::string &address) const;
 
     /* Get the private spend and private view for the primary address */
     std::tuple<Crypto::SecretKey, Crypto::SecretKey> getPrimaryAddressPrivateKeys() const;
@@ -299,7 +302,7 @@ class WalletBackend
 
     void init();
 
-    
+
     //////////////////////////////
     /* Private member variables */
     //////////////////////////////


### PR DESCRIPTION
Resolves #831 

- Add new method `Crypto::generate_deterministic_subwallet_keys` that generates new deterministic subwallet keys as defined in #831
- Add walletIndex value to a singular subwallet
- Extend SubWallets to contain the counter used to create subwallets deterministically.
- Switch addSubWallet() to use the new deterministic process
- Add SubWallets::importSubWallet(const uint64_t walletIndex, const uint64_t scanHeight)
- Add WalletBackend::importSubWallet(const uint64_t walletIndex, const uint64_t scanHeight)
- Add new wallet-api endpoint /addresses/import/deterministic
- Requesting /keys/:address: via wallet-api will now return the subwallet index