### PR TITLE
Enforce Excessive Output Creation Limits

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -203,6 +203,10 @@ namespace CryptoNote
 
         const size_t FUSION_TX_MIN_IN_OUT_COUNT_RATIO = 4;
 
+        const size_t NORMAL_TX_MAX_OUTPUT_RATIO_V1 = 10;
+
+        const size_t NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT = 2200000;
+
         const uint32_t UPGRADE_HEIGHT_V2 = 1;
 
         const uint32_t UPGRADE_HEIGHT_V3 = 2;

--- a/src/cryptonotecore/TransactionValidationErrors.h
+++ b/src/cryptonotecore/TransactionValidationErrors.h
@@ -42,7 +42,8 @@ namespace CryptoNote
             EXTRA_TOO_LARGE,
             BASE_INVALID_SIGNATURES_COUNT,
             INPUT_INVALID_SIGNATURES_COUNT,
-            OUTPUT_AMOUNT_TOO_LARGE
+            OUTPUT_AMOUNT_TOO_LARGE,
+            EXCESSIVE_OUTPUTS
         };
 
         // custom category:
@@ -123,6 +124,8 @@ namespace CryptoNote
                         return "The number of input signatures is not correct";
                     case TransactionValidationError::OUTPUT_AMOUNT_TOO_LARGE:
                         return "Transaction has output exceeding max output size";
+                    case TransactionValidationError::EXCESSIVE_OUTPUTS:
+                        return "Transaction has an excessive number of outputs for the input count";
                     default:
                         return "Unknown error";
                 }


### PR DESCRIPTION
- Adds new config parameters: NORMAL_TX_MAX_OUTPUT_RATIO_V1 & NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT
  - NORMAL_TX_MAX_OUTPUT_RATIO_V1: `10`
  - NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT: `2200000`
- The parameters above are used such that a transaction cannot create more than `transactions.inputs.size()` * `NORMAL_TX_MAX_OUTPUT_RATIO` ouputs. This helps to mitigate the decomposition of inputs into hundreds or thousands of outputs that is considered "abnormal" behavior.
- Adds new transaction validation error message describing excessive outputs
- Updates blocktemplate creation routine to NOT select transactions that create an excessive number of outputs when filling the blocktemplate with transactions
- Rejects transactions that fail to follow the above rule from being added to the transaction pool
- Implements a network upgrade (consensus update) at block `2,200,000` that enforces the above rule such that blocks may not contain transactions that violate this consensus rule.