### PR TITLE
Update Transaction Pool To Account For Additional Metrics in Transaction Ordering

### DIFF
--- a/src/cryptonotecore/CachedTransaction.cpp
+++ b/src/cryptonotecore/CachedTransaction.cpp
@@ -92,3 +92,20 @@ uint64_t CachedTransaction::getTransactionFee() const
 
     return transactionFee.get();
 }
+
+uint64_t CachedTransaction::getTransactionAmount() const
+{
+    if (!transactionAmount.is_initialized())
+    {
+        uint64_t summaryOutputAmount = 0;
+
+        for (const auto &out : transaction.outputs)
+        {
+            summaryOutputAmount += out.amount;
+        }
+
+        transactionAmount = summaryOutputAmount;
+    }
+
+    return transactionAmount.get();
+}

--- a/src/cryptonotecore/CachedTransaction.h
+++ b/src/cryptonotecore/CachedTransaction.h
@@ -29,6 +29,8 @@ namespace CryptoNote
 
         uint64_t getTransactionFee() const;
 
+        uint64_t getTransactionAmount() const;
+
       private:
         Transaction transaction;
 
@@ -39,6 +41,8 @@ namespace CryptoNote
         mutable boost::optional<Crypto::Hash> transactionPrefixHash;
 
         mutable boost::optional<uint64_t> transactionFee;
+
+        mutable boost::optional<uint64_t> transactionAmount;
     };
 
 } // namespace CryptoNote

--- a/src/cryptonotecore/TransactionPool.cpp
+++ b/src/cryptonotecore/TransactionPool.cpp
@@ -28,20 +28,27 @@ namespace CryptoNote
         const auto lhs_ratio = left.getTransaction().inputs.size() / left.getTransaction().outputs.size();
         const auto rhs_ratio = right.getTransaction().inputs.size() / left.getTransaction().outputs.size();
 
+        const auto lhs_amount = left.getTransactionAmount();
+        const auto rhs_amount = right.getTransactionAmount();
+
         return
             // prefer more profitable transactions
             (lhs_hi > rhs_hi) || (lhs_hi == rhs_hi && lhs_lo > rhs_lo) ||
+            // prefer those with a higher aggregate transferred amount
+            (lhs_hi == rhs_hi && lhs_lo == rhs_lo
+             && lhs_amount > rhs_amount) ||
             // prefer those with a higher input to output ratio
             (lhs_hi == rhs_hi && lhs_lo == rhs_lo
-             && lhs_ratio > rhs_ratio)
-            ||
-            // prefer smaller
+             && lhs_amount == rhs_amount
+             && lhs_ratio > rhs_ratio) ||
+            // prefer smaller (bytes)
             (lhs_hi == rhs_hi && lhs_lo == rhs_lo
+             && lhs_amount == rhs_amount
              && lhs_ratio == rhs_ratio
-             && left.getTransactionBinaryArray().size() < right.getTransactionBinaryArray().size())
-            ||
+             && left.getTransactionBinaryArray().size() < right.getTransactionBinaryArray().size()) ||
             // prefer older
             (lhs_hi == rhs_hi && lhs_lo == rhs_lo
+             && lhs_amount == rhs_amount
              && lhs_ratio == rhs_ratio
              && left.getTransactionBinaryArray().size() == right.getTransactionBinaryArray().size()
              && lhs.receiveTime < rhs.receiveTime);

--- a/src/cryptonotecore/TransactionPool.cpp
+++ b/src/cryptonotecore/TransactionPool.cpp
@@ -25,15 +25,24 @@ namespace CryptoNote
         uint64_t lhs_hi, lhs_lo = mul128(left.getTransactionFee(), right.getTransactionBinaryArray().size(), &lhs_hi);
         uint64_t rhs_hi, rhs_lo = mul128(right.getTransactionFee(), left.getTransactionBinaryArray().size(), &rhs_hi);
 
+        const auto lhs_ratio = left.getTransaction().inputs.size() / left.getTransaction().outputs.size();
+        const auto rhs_ratio = right.getTransaction().inputs.size() / left.getTransaction().outputs.size();
+
         return
             // prefer more profitable transactions
             (lhs_hi > rhs_hi) || (lhs_hi == rhs_hi && lhs_lo > rhs_lo) ||
+            // prefer those with a higher input to output ratio
+            (lhs_hi == rhs_hi && lhs_lo == rhs_lo
+             && lhs_ratio > rhs_ratio)
+            ||
             // prefer smaller
             (lhs_hi == rhs_hi && lhs_lo == rhs_lo
+             && lhs_ratio == rhs_ratio
              && left.getTransactionBinaryArray().size() < right.getTransactionBinaryArray().size())
             ||
             // prefer older
             (lhs_hi == rhs_hi && lhs_lo == rhs_lo
+             && lhs_ratio == rhs_ratio
              && left.getTransactionBinaryArray().size() == right.getTransactionBinaryArray().size()
              && lhs.receiveTime < rhs.receiveTime);
     }


### PR DESCRIPTION
This update changes the transaction pool preference ordering such that we now also include the input to output ratio into account when comparing transactions.

- Highest Fee
- Highest aggregate amount transferred
- Highest Input:Output Ratio
- Smaller Transactions
- Older Transactions

Examples:

1) `5` inputs and `35` outputs = `0.142857...`
2) `5` inputs and `20` outputs = `0.25`
3) `25` inputs and `4` outputs = `6.25`
4) `7` inputs and `3500` outputs = `0.002`
5) `80` inputs and `70` outputs = `1.142857...`

The order of which, presuming that all of them have the same fee and aggregate transfer amount would be 3, 5, 2, 1, 4.