### PR TITLE
Allow syncing with /getrawblocks instead of /getwalletsyncdata

### DIFF
--- a/src/cryptonotecore/Core.h
+++ b/src/cryptonotecore/Core.h
@@ -208,6 +208,10 @@ namespace CryptoNote
 
         virtual uint64_t get_current_blockchain_height() const;
 
+        static WalletTypes::RawCoinbaseTransaction getRawCoinbaseTransaction(const CryptoNote::Transaction &t);
+
+        static WalletTypes::RawTransaction getRawTransaction(const std::vector<uint8_t> &rawTX);
+
       private:
         const Currency &currency;
 
@@ -390,10 +394,6 @@ namespace CryptoNote
         void cutSegment(IBlockchainCache &segment, uint32_t startIndex);
 
         void switchMainChainStorage(uint32_t splitBlockIndex, IBlockchainCache &newChain);
-
-        static WalletTypes::RawCoinbaseTransaction getRawCoinbaseTransaction(const CryptoNote::Transaction &t);
-
-        static WalletTypes::RawTransaction getRawTransaction(const std::vector<uint8_t> &rawTX);
     };
 
 } // namespace CryptoNote

--- a/src/nigel/Nigel.h
+++ b/src/nigel/Nigel.h
@@ -63,7 +63,7 @@ class Nigel
         const std::vector<Crypto::Hash> blockHashCheckpoints,
         const uint64_t startHeight,
         const uint64_t startTimestamp,
-        const bool skipCoinbaseTransactions) const;
+        const bool skipCoinbaseTransactions);
 
     /* Returns a bool on success or not */
     bool getTransactionsStatus(
@@ -229,4 +229,7 @@ class Nigel
 
     /* If the daemon is SSL */
     bool m_daemonSSL = false;
+
+    /* Whether we should use /getrawblocks instead of /getwalletsyncdata */
+    bool m_useRawBlocks = true;
 };


### PR DESCRIPTION
Since wallet syncing is generally limited on the speed of fetching data, we can offload some of the daemon's load by letting the client parse the raw blocks, instead. The effect of this will be most apparent when one daemon is serving many different users wallets.
This can also potentially lower the amount of data transferred.

* Should we make it possible to disable this feature using a command line option?

Note: To test this PR, you must be running a daemon with #903 applied.