### PR TITLE
Reorder transaction validation to be easier to follow

### DIFF
--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -26,6 +26,7 @@
 #include <cryptonotecore/TransactionPool.h>
 #include <cryptonotecore/TransactionPoolCleaner.h>
 #include <cryptonotecore/UpgradeManager.h>
+#include <cryptonotecore/ValidateTransaction.h>
 #include <cryptonoteprotocol/CryptoNoteProtocolHandlerCommon.h>
 #include <numeric>
 #include <set>
@@ -1138,36 +1139,13 @@ namespace CryptoNote
             }
         }
 
-        // This allows us to accept blocks with transaction mixins for the mined money unlock window
-        // that may be using older mixin rules on the network. This helps to clear out the transaction
-        // pool during a network soft fork that requires a mixin lower or upper bound change
-        uint32_t mixinChangeWindow = blockIndex;
-        if (mixinChangeWindow > CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW)
-        {
-            mixinChangeWindow = mixinChangeWindow - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
-        }
-
-        auto [success, error] = Mixins::validate(transactions, blockIndex);
-
-        if (!success)
-        {
-            /* Warning, this shadows the above variables */
-            auto [success, error] = Mixins::validate(transactions, mixinChangeWindow);
-
-            if (!success)
-            {
-                logger(Logging::DEBUGGING) << error;
-                return error::TransactionValidationError::INVALID_MIXIN;
-            }
-        }
-
         uint64_t cumulativeFee = 0;
 
         for (const auto &transaction : transactions)
         {
             uint64_t fee = 0;
             auto transactionValidationResult =
-                validateTransaction(transaction, validatorState, cache, fee, previousBlockIndex);
+                validateTransaction(transaction, validatorState, cache, fee, previousBlockIndex, false);
             if (transactionValidationResult)
             {
                 logger(Logging::DEBUGGING) << "Failed to validate transaction " << transaction.getTransactionHash()
@@ -1725,61 +1703,14 @@ namespace CryptoNote
             return {false, "Pool already contains the maximum amount of fusion transactions"};
         }
 
-        if (cachedTransaction.getTransaction().outputs.size() >
-            cachedTransaction.getTransaction().inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
-        {
-            logger(Logging::TRACE) << "Not adding transaction " << transactionHash
-                                   << " to transaction pool, excessive input deconstruction.";
-
-            return {false, "Transaction has an excessive number of outputs for the input count"};
-        }
-
-        auto [success, err] = Mixins::validate({cachedTransaction}, getTopBlockIndex());
-
-        if (!success)
-        {
-            return {false, "Transaction does not contain the proper number of ring signatures"};
-        }
-
-        if (cachedTransaction.getTransaction().extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
-        {
-            logger(Logging::TRACE) << "Not adding transaction " << transactionHash
-                                   << " to pool, extra too large.";
-
-            return {false, "Transaction extra data is too large"};
-        }
-
-        auto maxTransactionSize = getMaximumTransactionAllowedSize(blockMedianSize, currency);
-        if (cachedTransaction.getTransactionBinaryArray().size() > maxTransactionSize)
-        {
-            logger(Logging::WARNING) << "Transaction " << transactionHash
-                                     << " is not valid. Reason: transaction is too big ("
-                                     << cachedTransaction.getTransactionBinaryArray().size()
-                                     << "). Maximum allowed size is " << maxTransactionSize;
-            return {false, "Transaction size (bytes) is too large"};
-        }
-
         uint64_t fee;
 
         if (auto validationResult =
-                validateTransaction(cachedTransaction, validatorState, chainsLeaves[0], fee, getTopBlockIndex()))
+                validateTransaction(cachedTransaction, validatorState, chainsLeaves[0], fee, getTopBlockIndex(), true))
         {
             logger(Logging::DEBUGGING) << "Transaction " << transactionHash
                                        << " is not valid. Reason: " << validationResult.message();
             return {false, validationResult.message()};
-        }
-
-        bool isFusion = fee == 0
-                        && currency.isFusionTransaction(
-                            cachedTransaction.getTransaction(),
-                            cachedTransaction.getTransactionBinaryArray().size(),
-                            getTopBlockIndex());
-
-        if (!isFusion && fee < currency.minimumFee())
-        {
-            logger(Logging::WARNING) << "Transaction " << transactionHash
-                                     << " is not valid. Reason: fee is too small and it's not a fusion transaction";
-            return {false, "Transaction fee is too small"};
         }
 
         return {true, ""};
@@ -2142,213 +2073,25 @@ namespace CryptoNote
         TransactionValidatorState &state,
         IBlockchainCache *cache,
         uint64_t &fee,
-        uint32_t blockIndex)
+        uint32_t blockIndex,
+        const bool isPoolTransaction)
     {
-        // TransactionValidatorState currentState;
-        const auto &transaction = cachedTransaction.getTransaction();
-        auto error = validateSemantic(transaction, fee, blockIndex);
-        if (error != error::TransactionValidationError::VALIDATION_SUCCESS)
-        {
-            return error;
-        }
+        ValidateTransaction txValidator(
+            cachedTransaction,
+            state,
+            cache,
+            currency,
+            checkpoints,
+            blockIndex,
+            blockMedianSize,
+            isPoolTransaction
+        );
 
-        if (blockIndex >= CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT &&
-            transaction.outputs.size() > transaction.inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
-        {
-            return error::TransactionValidationError::EXCESSIVE_OUTPUTS;
-        }
+        const auto result = txValidator.validate();
 
-        size_t inputIndex = 0;
-        for (const auto &input : transaction.inputs)
-        {
-            if (input.type() == typeid(KeyInput))
-            {
-                const KeyInput &in = boost::get<KeyInput>(input);
-                if (!state.spentKeyImages.insert(in.keyImage).second)
-                {
-                    return error::TransactionValidationError::INPUT_KEYIMAGE_ALREADY_SPENT;
-                }
+        fee = result.fee;
 
-                if (!checkpoints.isInCheckpointZone(blockIndex + 1))
-                {
-                    if (cache->checkIfSpent(in.keyImage, blockIndex))
-                    {
-                        return error::TransactionValidationError::INPUT_KEYIMAGE_ALREADY_SPENT;
-                    }
-
-                    std::vector<PublicKey> outputKeys;
-                    assert(!in.outputIndexes.empty());
-
-                    std::vector<uint32_t> globalIndexes(in.outputIndexes.size());
-                    globalIndexes[0] = in.outputIndexes[0];
-                    for (size_t i = 1; i < in.outputIndexes.size(); ++i)
-                    {
-                        globalIndexes[i] = globalIndexes[i - 1] + in.outputIndexes[i];
-                    }
-
-                    auto result = cache->extractKeyOutputKeys(
-                        in.amount, blockIndex, {globalIndexes.data(), globalIndexes.size()}, outputKeys);
-                    if (result == ExtractOutputKeysResult::INVALID_GLOBAL_INDEX)
-                    {
-                        return error::TransactionValidationError::INPUT_INVALID_GLOBAL_INDEX;
-                    }
-
-                    if (result == ExtractOutputKeysResult::OUTPUT_LOCKED)
-                    {
-                        return error::TransactionValidationError::INPUT_SPEND_LOCKED_OUT;
-                    }
-
-                    if (blockIndex >= CryptoNote::parameters::TRANSACTION_SIGNATURE_COUNT_VALIDATION_HEIGHT
-                        && outputKeys.size() != cachedTransaction.getTransaction().signatures[inputIndex].size())
-                    {
-                        return error::TransactionValidationError::INPUT_INVALID_SIGNATURES_COUNT;
-                    }
-
-                    if (!Crypto::crypto_ops::checkRingSignature(
-                            cachedTransaction.getTransactionPrefixHash(),
-                            in.keyImage,
-                            outputKeys,
-                            transaction.signatures[inputIndex]))
-                    {
-                        return error::TransactionValidationError::INPUT_INVALID_SIGNATURES;
-                    }
-                }
-            }
-            else
-            {
-                assert(false);
-                return error::TransactionValidationError::INPUT_UNKNOWN_TYPE;
-            }
-
-            inputIndex++;
-        }
-
-        return error::TransactionValidationError::VALIDATION_SUCCESS;
-    }
-
-    std::error_code Core::validateSemantic(const Transaction &transaction, uint64_t &fee, uint32_t blockIndex)
-    {
-        if (transaction.inputs.empty())
-        {
-            return error::TransactionValidationError::EMPTY_INPUTS;
-        }
-
-        /* Small buffer until enforcing - helps clear out tx pool with old, previously
-     valid transactions */
-        if (blockIndex >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2_HEIGHT
-                              + CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW)
-        {
-            if (transaction.extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
-            {
-                return error::TransactionValidationError::EXTRA_TOO_LARGE;
-            }
-        }
-
-        uint64_t summaryOutputAmount = 0;
-        for (const auto &output : transaction.outputs)
-        {
-            if (output.amount == 0)
-            {
-                return error::TransactionValidationError::OUTPUT_ZERO_AMOUNT;
-            }
-
-            if (blockIndex >= CryptoNote::parameters::MAX_OUTPUT_SIZE_HEIGHT)
-            {
-                if (output.amount > CryptoNote::parameters::MAX_OUTPUT_SIZE_NODE)
-                {
-                    return error::TransactionValidationError::OUTPUT_AMOUNT_TOO_LARGE;
-                }
-            }
-
-            if (output.target.type() == typeid(KeyOutput))
-            {
-                if (!check_key(boost::get<KeyOutput>(output.target).key))
-                {
-                    return error::TransactionValidationError::OUTPUT_INVALID_KEY;
-                }
-            }
-            else
-            {
-                return error::TransactionValidationError::OUTPUT_UNKNOWN_TYPE;
-            }
-
-            if (std::numeric_limits<uint64_t>::max() - output.amount < summaryOutputAmount)
-            {
-                return error::TransactionValidationError::OUTPUTS_AMOUNT_OVERFLOW;
-            }
-
-            summaryOutputAmount += output.amount;
-        }
-
-        // parameters used for the additional key_image check
-        static const Crypto::KeyImage Z = {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-        if (Z == Z)
-        {
-        }
-        static const Crypto::KeyImage I = {{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-        static const Crypto::KeyImage L = {{0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7,
-                                            0xa2, 0xde, 0xf9, 0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}};
-
-        uint64_t summaryInputAmount = 0;
-        std::unordered_set<Crypto::KeyImage> ki;
-        std::set<std::pair<uint64_t, uint32_t>> outputsUsage;
-        for (const auto &input : transaction.inputs)
-        {
-            uint64_t amount = 0;
-            if (input.type() == typeid(KeyInput))
-            {
-                const KeyInput &in = boost::get<KeyInput>(input);
-                amount = in.amount;
-                if (!ki.insert(in.keyImage).second)
-                {
-                    return error::TransactionValidationError::INPUT_IDENTICAL_KEYIMAGES;
-                }
-
-                if (in.outputIndexes.empty())
-                {
-                    return error::TransactionValidationError::INPUT_EMPTY_OUTPUT_USAGE;
-                }
-
-                // outputIndexes are packed here, first is absolute, others are offsets to previous,
-                // so first can be zero, others can't
-                // Fix discovered by Monero Lab and suggested by "fluffypony" (bitcointalk.org)
-                if (!(scalarmultKey(in.keyImage, L) == I))
-                {
-                    return error::TransactionValidationError::INPUT_INVALID_DOMAIN_KEYIMAGES;
-                }
-
-                if (std::find(++std::begin(in.outputIndexes), std::end(in.outputIndexes), 0)
-                    != std::end(in.outputIndexes))
-                {
-                    return error::TransactionValidationError::INPUT_IDENTICAL_OUTPUT_INDEXES;
-                }
-            }
-            else
-            {
-                return error::TransactionValidationError::INPUT_UNKNOWN_TYPE;
-            }
-
-            if (std::numeric_limits<uint64_t>::max() - amount < summaryInputAmount)
-            {
-                return error::TransactionValidationError::INPUTS_AMOUNT_OVERFLOW;
-            }
-
-            summaryInputAmount += amount;
-        }
-
-        if (summaryOutputAmount > summaryInputAmount)
-        {
-            return error::TransactionValidationError::WRONG_AMOUNT;
-        }
-
-        assert(transaction.signatures.size() == transaction.inputs.size());
-        fee = summaryInputAmount - summaryOutputAmount;
-        return error::TransactionValidationError::VALIDATION_SUCCESS;
+        return result.errorCode;
     }
 
     uint32_t Core::findBlockchainSupplement(const std::vector<Crypto::Hash> &remoteBlockIds) const
@@ -2975,35 +2718,23 @@ namespace CryptoNote
     bool Core::validateBlockTemplateTransaction(const CachedTransaction &cachedTransaction, const uint64_t blockHeight)
         const
     {
-        const auto &transaction = cachedTransaction.getTransaction();
+        /* Not used in revalidateAfterHeightChange() */
+        TransactionValidatorState state;
 
-        /* Do not select transactions for inclusion in a block that create excessive outputs
-           this is to prevent abuse whereby 1 input is used to create thousands of outputs */
-        if (transaction.outputs.size() > transaction.inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
-        {
-            logger(Logging::TRACE) << "Not adding transaction " << cachedTransaction.getTransactionHash()
-                                   << " to block template, excessive input deconstruction.";
+        ValidateTransaction txValidator(
+            cachedTransaction,
+            state,
+            nullptr, /* Not used in revalidateAfterHeightChange() */
+            currency,
+            checkpoints,
+            blockHeight,
+            blockMedianSize,
+            true /* Pool transaction */
+        );
 
-            return false;
-        }
+        const auto result = txValidator.revalidateAfterHeightChange();
 
-        if (transaction.extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
-        {
-            logger(Logging::TRACE) << "Not adding transaction " << cachedTransaction.getTransactionHash()
-                                   << " to block template, extra too large.";
-            return false;
-        }
-
-        auto [success, error] = Mixins::validate({cachedTransaction}, blockHeight);
-
-        if (!success)
-        {
-            logger(Logging::TRACE) << "Not adding transaction " << cachedTransaction.getTransactionHash()
-                                   << " to block template, " << error;
-            return false;
-        }
-
-        return true;
+        return result.valid;
     }
 
     void Core::fillBlockTemplate(

--- a/src/cryptonotecore/Core.h
+++ b/src/cryptonotecore/Core.h
@@ -250,14 +250,13 @@ namespace CryptoNote
             std::vector<CachedTransaction> &transactions,
             uint64_t &cumulativeSize);
 
-        std::error_code validateSemantic(const Transaction &transaction, uint64_t &fee, uint32_t blockIndex);
-
         std::error_code validateTransaction(
             const CachedTransaction &transaction,
             TransactionValidatorState &state,
             IBlockchainCache *cache,
             uint64_t &fee,
-            uint32_t blockIndex);
+            uint32_t blockIndex,
+            const bool isPoolTransaction);
 
         uint32_t findBlockchainSupplement(const std::vector<Crypto::Hash> &remoteBlockIds) const;
 

--- a/src/cryptonotecore/TransactionValidationErrors.h
+++ b/src/cryptonotecore/TransactionValidationErrors.h
@@ -43,7 +43,9 @@ namespace CryptoNote
             BASE_INVALID_SIGNATURES_COUNT,
             INPUT_INVALID_SIGNATURES_COUNT,
             OUTPUT_AMOUNT_TOO_LARGE,
-            EXCESSIVE_OUTPUTS
+            EXCESSIVE_OUTPUTS,
+            WRONG_FEE,
+            SIZE_TOO_LARGE,
         };
 
         // custom category:
@@ -126,6 +128,10 @@ namespace CryptoNote
                         return "Transaction has output exceeding max output size";
                     case TransactionValidationError::EXCESSIVE_OUTPUTS:
                         return "Transaction has an excessive number of outputs for the input count";
+                    case TransactionValidationError::WRONG_FEE:
+                        return "Transaction fee is below minimum fee and is not a fusion transaction";
+                    case TransactionValidationError::SIZE_TOO_LARGE:
+                        return "Transaction is too large (in bytes)";
                     default:
                         return "Unknown error";
                 }

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -1,0 +1,506 @@
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018-2019, The Galaxia Project Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+//
+// Please see the included LICENSE file for more information.
+
+#include <config/CryptoNoteConfig.h>
+#include <cryptonotecore/Mixins.h>
+#include <cryptonotecore/TransactionValidationErrors.h>
+#include <cryptonotecore/ValidateTransaction.h>
+
+ValidateTransaction::ValidateTransaction(
+    const CryptoNote::CachedTransaction &cachedTransaction,
+    CryptoNote::TransactionValidatorState &state,
+    CryptoNote::IBlockchainCache *cache,
+    const CryptoNote::Currency &currency,
+    const CryptoNote::Checkpoints &checkpoints,
+    const uint64_t blockHeight,
+    const uint64_t blockSizeMedian,
+    const bool isPoolTransaction):
+    m_cachedTransaction(cachedTransaction),
+    m_transaction(cachedTransaction.getTransaction()),
+    m_validatorState(state),
+    m_currency(currency),
+    m_checkpoints(checkpoints),
+    m_blockchainCache(cache),
+    m_blockHeight(blockHeight),
+    m_blockSizeMedian(blockSizeMedian),
+    m_isPoolTransaction(isPoolTransaction)
+{
+}
+
+TransactionValidationResult ValidateTransaction::validate()
+{
+    /* Validate transaction isn't too big */
+    if (!validateTransactionSize())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate the transaction inputs are non empty, key images are valid, etc. */
+    if (!validateTransactionInputs())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate transaction outputs are non zero, don't overflow, etc */
+    if (!validateTransactionOutputs())
+    {
+        return m_validationResult;
+    }
+
+    /* Verify inputs > outputs, fee is > min fee unless fusion, etc */
+    if (!validateTransactionFee())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate the transaction extra is a reasonable size. */
+    if (!validateTransactionExtra())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate transaction input / output ratio is not excessive */
+    if (!validateInputOutputRatio())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate transaction mixin is in the valid range */
+    if (!validateTransactionMixin())
+    {
+        return m_validationResult;
+    }
+
+    /* Verify key images are not spent, ring signatures are valid, etc. We
+     * do this separately from the transaction input verification, because
+     * these checks are much slower to perform, so we want to fail fast on the
+     * cheaper checks first. */
+    if (!validateTransactionInputsExpensive())
+    {
+        return m_validationResult;
+    }
+    
+    m_validationResult.valid = true;
+    m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::VALIDATION_SUCCESS;
+
+    return m_validationResult;
+}
+
+/* Note: Does not set the .fee property */
+TransactionValidationResult ValidateTransaction::revalidateAfterHeightChange()
+{
+    /* Validate transaction isn't too big now that the median size has changed */
+    if (!validateTransactionSize())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate the transaction extra is still a reasonable size. */
+    if (!validateTransactionExtra())
+    {
+        return m_validationResult;
+    }
+
+    /* Validate transaction mixin is still in the valid range */
+    if (!validateTransactionMixin())
+    {
+        return m_validationResult;
+    }
+
+    m_validationResult.valid = true;
+    m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::VALIDATION_SUCCESS;
+
+    return m_validationResult;
+}
+
+
+bool ValidateTransaction::validateTransactionSize()
+{
+    const auto maxTransactionSize = m_blockSizeMedian * 2 - m_currency.minerTxBlobReservedSize();
+
+    if (m_cachedTransaction.getTransactionBinaryArray().size() > maxTransactionSize)
+    {
+        m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::SIZE_TOO_LARGE;
+        m_validationResult.errorMessage = "Transaction is too large (in bytes)";
+        return false;
+    }
+
+    return true;
+}
+
+bool ValidateTransaction::validateTransactionInputs()
+{
+    if (m_transaction.inputs.empty())
+    {
+        m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::EMPTY_INPUTS;
+        m_validationResult.errorMessage = "Transaction has no inputs";
+
+        return false;
+    }
+
+    static const Crypto::KeyImage Z = {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+                                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+    static const Crypto::KeyImage I = {{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+    static const Crypto::KeyImage L = {{0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7,
+                                        0xa2, 0xde, 0xf9, 0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}};
+
+    uint64_t sumOfInputs = 0;
+
+    std::unordered_set<Crypto::KeyImage> ki;
+
+    for (const auto &input : m_transaction.inputs)
+    {
+        uint64_t amount = 0;
+
+        if (input.type() == typeid(CryptoNote::KeyInput))
+        {
+            const CryptoNote::KeyInput &in = boost::get<CryptoNote::KeyInput>(input);
+            amount = in.amount;
+
+            if (!ki.insert(in.keyImage).second)
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_IDENTICAL_KEYIMAGES;
+                m_validationResult.errorMessage = "Transaction contains identical key images";
+
+                return false;
+            }
+
+            if (in.outputIndexes.empty())
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_EMPTY_OUTPUT_USAGE;
+                m_validationResult.errorMessage = "Transaction contains no output indexes";
+
+                return false;
+            }
+
+            /* outputIndexes are packed here, first is absolute, others are offsets to previous,
+             * so first can be zero, others can't
+             * Fix discovered by Monero Lab and suggested by "fluffypony" (bitcointalk.org) */
+            if (!(scalarmultKey(in.keyImage, L) == I))
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_DOMAIN_KEYIMAGES;
+                m_validationResult.errorMessage = "Transaction contains key images in an invalid domain";
+
+                return false;
+            }
+
+            if (std::find(++std::begin(in.outputIndexes), std::end(in.outputIndexes), 0)
+                != std::end(in.outputIndexes))
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_IDENTICAL_OUTPUT_INDEXES;
+                m_validationResult.errorMessage = "Transaction contains identical output indexes";
+
+                return false;
+            }
+
+            if (!m_validatorState.spentKeyImages.insert(in.keyImage).second)
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_KEYIMAGE_ALREADY_SPENT;
+                m_validationResult.errorMessage = "Transaction contains key image that has already been spent";
+
+                return false;
+            }
+        }
+        else
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_UNKNOWN_TYPE;
+            m_validationResult.errorMessage = "Transaction input has an unknown input type";
+
+            return false;
+        }
+
+        if (std::numeric_limits<uint64_t>::max() - amount < sumOfInputs)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUTS_AMOUNT_OVERFLOW;
+            m_validationResult.errorMessage = "Transaction inputs will overflow";
+
+            return false;
+        }
+
+        sumOfInputs += amount;
+    }
+    
+    m_sumOfInputs = sumOfInputs;
+
+    return true;
+}
+
+bool ValidateTransaction::validateTransactionOutputs()
+{
+    uint64_t sumOfOutputs = 0;
+
+    for (const auto &output : m_transaction.outputs)
+    {
+        if (output.amount == 0)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::OUTPUT_ZERO_AMOUNT;
+            m_validationResult.errorMessage = "Transaction has an output amount of zero";
+
+            return false;
+        }
+
+        if (m_blockHeight >= CryptoNote::parameters::MAX_OUTPUT_SIZE_HEIGHT)
+        {
+            if (output.amount > CryptoNote::parameters::MAX_OUTPUT_SIZE_NODE)
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::OUTPUT_AMOUNT_TOO_LARGE;
+                m_validationResult.errorMessage = "Transaction has a too large output amount";
+
+                return false;
+            }
+        }
+
+        if (output.target.type() == typeid(CryptoNote::KeyOutput))
+        {
+            if (!check_key(boost::get<CryptoNote::KeyOutput>(output.target).key))
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::OUTPUT_INVALID_KEY;
+                m_validationResult.errorMessage = "Transaction output has an invalid output key";
+
+                return false;
+            }
+        }
+        else
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::OUTPUT_UNKNOWN_TYPE;
+            m_validationResult.errorMessage = "Transaction output has an unknown output type";
+
+            return false;
+        }
+
+        if (std::numeric_limits<uint64_t>::max() - output.amount < sumOfOutputs)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::OUTPUTS_AMOUNT_OVERFLOW;
+            m_validationResult.errorMessage = "Transaction outputs will overflow";
+
+            return false;
+        }
+
+        sumOfOutputs += output.amount;
+    }
+
+    m_sumOfOutputs = sumOfOutputs;
+
+    return true;
+}
+
+/**
+ * Pre-requisite - Call validateTransactionInputs() and validateTransactionOutputs()
+ * to ensure m_sumOfInputs and m_sumOfOutputs is set
+ */
+bool ValidateTransaction::validateTransactionFee()
+{
+    if (m_sumOfInputs == 0)
+    {
+        throw std::runtime_error(
+            "Error! You must call validateTransactionInputs() and "
+            "validateTransactionOutputs() before calling validateTransactionFee()!"
+        );
+    }
+
+    if (m_sumOfOutputs > m_sumOfInputs)
+    {
+        m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::WRONG_AMOUNT;
+        m_validationResult.errorMessage = "Sum of outputs is greater than sum of inputs";
+
+        return false;
+    }
+
+    const uint64_t fee = m_sumOfInputs - m_sumOfOutputs;
+
+    const bool isFusion = m_currency.isFusionTransaction(
+        m_transaction,
+        m_cachedTransaction.getTransactionBinaryArray().size(),
+        m_blockHeight
+    );
+
+    if (!isFusion)
+    {
+        if (fee == 0 || (fee < CryptoNote::parameters::MINIMUM_FEE && m_isPoolTransaction))
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::WRONG_FEE;
+            m_validationResult.errorMessage = "Transaction fee is below minimum fee and is not a fusion transaction";
+
+            return false;
+        }
+    }
+
+    m_validationResult.fee = fee;
+
+    return true;
+}
+
+bool ValidateTransaction::validateTransactionExtra()
+{
+    const uint64_t heightToEnforce 
+        = CryptoNote::parameters::MAX_EXTRA_SIZE_V2_HEIGHT 
+        + CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
+
+    /* If we're checking if it's valid for the pool, we don't wait for the height
+     * to enforce. */
+    if (m_isPoolTransaction || m_blockHeight >= heightToEnforce)
+    {
+        if (m_transaction.extra.size() >= CryptoNote::parameters::MAX_EXTRA_SIZE_V2)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::EXTRA_TOO_LARGE;
+            m_validationResult.errorMessage = "Transaction extra is too large";
+
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool ValidateTransaction::validateInputOutputRatio()
+{
+    if (m_isPoolTransaction || m_blockHeight >= CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT)
+    {
+        if (m_transaction.outputs.size() > m_transaction.inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::EXCESSIVE_OUTPUTS;
+            m_validationResult.errorMessage = "Transaction has excessive output/input ratio";
+
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool ValidateTransaction::validateTransactionMixin()
+{
+    /* This allows us to accept blocks with transaction mixins for the mined money unlock window
+     * that may be using older mixin rules on the network. This helps to clear out the transaction
+     * pool during a network soft fork that requires a mixin lower or upper bound change */
+    uint32_t mixinChangeWindow = m_blockHeight;
+
+    if (mixinChangeWindow > CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW)
+    {
+        mixinChangeWindow = mixinChangeWindow - CryptoNote::parameters::CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
+    }
+
+    auto [success, err] = CryptoNote::Mixins::validate({m_cachedTransaction}, m_blockHeight);
+
+    if (!success)
+    {
+        if (m_isPoolTransaction)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INVALID_MIXIN;
+            m_validationResult.errorMessage = err;
+
+            return false;
+        }
+
+        /* Warning, this shadows the above variables */
+        auto [success, err] = CryptoNote::Mixins::validate({m_cachedTransaction}, m_blockHeight);
+
+        if (!success)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INVALID_MIXIN;
+            m_validationResult.errorMessage = err;
+
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool ValidateTransaction::validateTransactionInputsExpensive()
+{
+    /* Don't need to do expensive transaction validation for transactions
+     * in a checkpoints range - they are assumed valid, and the transaction
+     * hash would change thus invalidation the checkpoints if not. */
+    if (m_checkpoints.isInCheckpointZone(m_blockHeight + 1))
+    {
+        return true;
+    }
+
+    uint64_t inputIndex = 0;
+
+    for (const auto &input : m_transaction.inputs)
+    {
+        const CryptoNote::KeyInput &in = boost::get<CryptoNote::KeyInput>(input);
+
+        if (m_blockchainCache->checkIfSpent(in.keyImage, m_blockHeight))
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_KEYIMAGE_ALREADY_SPENT;
+            m_validationResult.errorMessage = "Transaction contains key image that has already been spent";
+
+            return false;
+        }
+
+        std::vector<Crypto::PublicKey> outputKeys;
+        std::vector<uint32_t> globalIndexes(in.outputIndexes.size());
+
+        globalIndexes[0] = in.outputIndexes[0];
+
+        /* Convert output indexes from relative to absolute */
+        for (size_t i = 1; i < in.outputIndexes.size(); ++i)
+        {
+            globalIndexes[i] = globalIndexes[i - 1] + in.outputIndexes[i];
+        }
+
+        const auto result = m_blockchainCache->extractKeyOutputKeys(
+            in.amount,
+            m_blockHeight,
+            { globalIndexes.data(), globalIndexes.size() },
+            outputKeys
+        );
+
+        if (result == CryptoNote::ExtractOutputKeysResult::INVALID_GLOBAL_INDEX)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_GLOBAL_INDEX;
+            m_validationResult.errorMessage = "Transaction contains invalid global indexes";
+
+            return false;
+        }
+
+        if (result == CryptoNote::ExtractOutputKeysResult::OUTPUT_LOCKED)
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_SPEND_LOCKED_OUT;
+            m_validationResult.errorMessage = "Transaction includes an input which is still locked";
+
+            return false;
+        }
+
+        if (m_isPoolTransaction || m_blockHeight >= CryptoNote::parameters::TRANSACTION_SIGNATURE_COUNT_VALIDATION_HEIGHT)
+        {
+            if (outputKeys.size() != m_transaction.signatures[inputIndex].size())
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_SIGNATURES_COUNT;
+                m_validationResult.errorMessage = "Transaction has an invalid number of signatures";
+
+                return false;
+            }
+        }
+
+        if (!Crypto::crypto_ops::checkRingSignature(
+            m_cachedTransaction.getTransactionPrefixHash(),
+            in.keyImage,
+            outputKeys,
+            m_transaction.signatures[inputIndex]))
+        {
+            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_SIGNATURES;
+            m_validationResult.errorMessage = "Transaction contains invalid signatures";
+
+            return false;
+        }
+
+        inputIndex++;
+    }
+    
+    return true;
+}
+

--- a/src/cryptonotecore/ValidateTransaction.h
+++ b/src/cryptonotecore/ValidateTransaction.h
@@ -1,0 +1,104 @@
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018-2019, The Galaxia Project Developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+//
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include <system_error>
+
+#include <CryptoNote.h>
+#include <cryptonotecore/CachedTransaction.h>
+#include <cryptonotecore/Checkpoints.h>
+#include <cryptonotecore/Currency.h>
+#include <cryptonotecore/IBlockchainCache.h>
+
+struct TransactionValidationResult 
+{
+    /* A programmatic error code of the result */
+    std::error_code errorCode;
+
+    /* An error message describing the error code */
+    std::string errorMessage;
+
+    /* Whether the transaction is valid */
+    bool valid = false;
+
+    /* The fee of the transaction */
+    uint64_t fee = 0;
+
+    /* Is this transaction a fusion transaction */
+    bool isFusionTransaction = false;
+};
+
+class ValidateTransaction
+{
+    public:
+        /////////////////
+        /* CONSTRUCTOR */
+        /////////////////
+        ValidateTransaction(
+            const CryptoNote::CachedTransaction &cachedTransaction,
+            CryptoNote::TransactionValidatorState &state,
+            CryptoNote::IBlockchainCache *cache,
+            const CryptoNote::Currency &currency,
+            const CryptoNote::Checkpoints &checkpoints,
+            const uint64_t blockHeight,
+            const uint64_t blockSizeMedian,
+            const bool isPoolTransaction);
+
+        /////////////////////////////
+        /* PUBLIC MEMBER FUNCTIONS */
+        /////////////////////////////
+        TransactionValidationResult validate();
+
+        TransactionValidationResult revalidateAfterHeightChange();
+
+    private:
+        //////////////////////////////
+        /* PRIVATE MEMBER FUNCTIONS */
+        //////////////////////////////
+        bool validateTransactionSize();
+
+        bool validateTransactionInputs();
+
+        bool validateTransactionOutputs();
+
+        bool validateTransactionFee();
+
+        bool validateTransactionExtra();
+
+        bool validateInputOutputRatio();
+
+        bool validateTransactionMixin();
+
+        bool validateTransactionInputsExpensive();
+
+        /////////////////////////
+        /* PRIVATE MEMBER VARS */
+        /////////////////////////
+        const CryptoNote::Transaction m_transaction;
+
+        const CryptoNote::CachedTransaction &m_cachedTransaction;
+
+        CryptoNote::TransactionValidatorState &m_validatorState;
+
+        const CryptoNote::IBlockchainCache *m_blockchainCache;
+
+        const CryptoNote::Currency &m_currency;
+
+        const CryptoNote::Checkpoints &m_checkpoints;
+
+        const uint64_t m_blockHeight;
+
+        const uint64_t m_blockSizeMedian;
+
+        const bool m_isPoolTransaction;
+
+        TransactionValidationResult m_validationResult;
+
+        uint64_t m_sumOfOutputs = 0;
+        uint64_t m_sumOfInputs = 0;
+};


### PR DESCRIPTION
Pulls transaction validation into a separate file, making it much easier to follow and easier to maintain. 
Needs testing, I have not got around to throwing a ton of invalid transactions at it yet to ensure it works as expected.