### PR TITLE
Threaded input validation

### DIFF
--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -1145,7 +1145,7 @@ namespace CryptoNote
         {
             uint64_t fee = 0;
             auto transactionValidationResult =
-                validateTransaction(transaction, validatorState, cache, fee, previousBlockIndex, false);
+                validateTransaction(transaction, validatorState, cache, m_transactionValidationThreadPool, fee, previousBlockIndex, false);
             if (transactionValidationResult)
             {
                 logger(Logging::DEBUGGING) << "Failed to validate transaction " << transaction.getTransactionHash()
@@ -1706,7 +1706,7 @@ namespace CryptoNote
         uint64_t fee;
 
         if (auto validationResult =
-                validateTransaction(cachedTransaction, validatorState, chainsLeaves[0], fee, getTopBlockIndex(), true))
+                validateTransaction(cachedTransaction, validatorState, chainsLeaves[0], m_transactionValidationThreadPool, fee, getTopBlockIndex(), true))
         {
             logger(Logging::DEBUGGING) << "Transaction " << transactionHash
                                        << " is not valid. Reason: " << validationResult.message();
@@ -1784,7 +1784,7 @@ namespace CryptoNote
         const AccountPublicAddress &adr,
         const BinaryArray &extraNonce,
         uint64_t &difficulty,
-        uint32_t &height) const
+        uint32_t &height)
     {
         throwIfNotInitialized();
 
@@ -2072,6 +2072,7 @@ namespace CryptoNote
         const CachedTransaction &cachedTransaction,
         TransactionValidatorState &state,
         IBlockchainCache *cache,
+        Utilities::ThreadPool<bool> &threadPool,
         uint64_t &fee,
         uint32_t blockIndex,
         const bool isPoolTransaction)
@@ -2082,6 +2083,7 @@ namespace CryptoNote
             cache,
             currency,
             checkpoints,
+            threadPool,
             blockIndex,
             blockMedianSize,
             isPoolTransaction
@@ -2716,7 +2718,6 @@ namespace CryptoNote
     /* A transaction that is valid at the time it was added to the pool, is not
        neccessarily valid now, if the network rules changed. */
     bool Core::validateBlockTemplateTransaction(const CachedTransaction &cachedTransaction, const uint64_t blockHeight)
-        const
     {
         /* Not used in revalidateAfterHeightChange() */
         TransactionValidatorState state;
@@ -2727,6 +2728,7 @@ namespace CryptoNote
             nullptr, /* Not used in revalidateAfterHeightChange() */
             currency,
             checkpoints,
+            m_transactionValidationThreadPool,
             blockHeight,
             blockMedianSize,
             true /* Pool transaction */
@@ -2743,7 +2745,7 @@ namespace CryptoNote
         const size_t maxCumulativeSize,
         const uint64_t height,
         size_t &transactionsSize,
-        uint64_t &fee) const
+        uint64_t &fee)
     {
         transactionsSize = 0;
         fee = 0;

--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -235,7 +235,8 @@ namespace CryptoNote
         Checkpoints &&checkpoints,
         System::Dispatcher &dispatcher,
         std::unique_ptr<IBlockchainCacheFactory> &&blockchainCacheFactory,
-        std::unique_ptr<IMainChainStorage> &&mainchainStorage):
+        std::unique_ptr<IMainChainStorage> &&mainchainStorage,
+        const uint32_t transactionValidationThreads):
         currency(currency),
         dispatcher(dispatcher),
         contextGroup(dispatcher),
@@ -244,7 +245,8 @@ namespace CryptoNote
         upgradeManager(new UpgradeManager()),
         blockchainCacheFactory(std::move(blockchainCacheFactory)),
         mainChainStorage(std::move(mainchainStorage)),
-        initialized(false)
+        initialized(false),
+        m_transactionValidationThreadPool(transactionValidationThreads)
     {
         upgradeManager->addMajorBlockVersion(BLOCK_MAJOR_VERSION_2, currency.upgradeHeight(BLOCK_MAJOR_VERSION_2));
         upgradeManager->addMajorBlockVersion(BLOCK_MAJOR_VERSION_3, currency.upgradeHeight(BLOCK_MAJOR_VERSION_3));

--- a/src/cryptonotecore/Core.h
+++ b/src/cryptonotecore/Core.h
@@ -27,6 +27,7 @@
 #include <logging/LoggerMessage.h>
 #include <system/ContextGroup.h>
 #include <unordered_map>
+#include <utilities/ThreadPool.h>
 #include <vector>
 
 namespace CryptoNote
@@ -174,7 +175,7 @@ namespace CryptoNote
             const AccountPublicAddress &adr,
             const BinaryArray &extraNonce,
             uint64_t &difficulty,
-            uint32_t &height) const override;
+            uint32_t &height) override;
 
         virtual CoreStatistics getCoreStatistics() const override;
 
@@ -237,6 +238,8 @@ namespace CryptoNote
 
         std::unique_ptr<IMainChainStorage> mainChainStorage;
 
+        Utilities::ThreadPool<bool> m_transactionValidationThreadPool;
+
         bool initialized;
 
         time_t start_time;
@@ -254,6 +257,7 @@ namespace CryptoNote
             const CachedTransaction &transaction,
             TransactionValidatorState &state,
             IBlockchainCache *cache,
+            Utilities::ThreadPool<bool> &threadPool,
             uint64_t &fee,
             uint32_t blockIndex,
             const bool isPoolTransaction);
@@ -335,8 +339,7 @@ namespace CryptoNote
 
         size_t calculateCumulativeBlocksizeLimit(uint32_t height) const;
 
-        bool validateBlockTemplateTransaction(const CachedTransaction &cachedTransaction, const uint64_t blockHeight)
-            const;
+        bool validateBlockTemplateTransaction(const CachedTransaction &cachedTransaction, const uint64_t blockHeight);
 
         void fillBlockTemplate(
             BlockTemplate &block,
@@ -344,7 +347,7 @@ namespace CryptoNote
             const size_t maxCumulativeSize,
             const uint64_t height,
             size_t &transactionsSize,
-            uint64_t &fee) const;
+            uint64_t &fee);
 
         void deleteAlternativeChains();
 

--- a/src/cryptonotecore/Core.h
+++ b/src/cryptonotecore/Core.h
@@ -41,7 +41,8 @@ namespace CryptoNote
             Checkpoints &&checkpoints,
             System::Dispatcher &dispatcher,
             std::unique_ptr<IBlockchainCacheFactory> &&blockchainCacheFactory,
-            std::unique_ptr<IMainChainStorage> &&mainChainStorage);
+            std::unique_ptr<IMainChainStorage> &&mainChainStorage,
+            uint32_t transactionValidationThreads);
 
         virtual ~Core();
 

--- a/src/cryptonotecore/ICore.h
+++ b/src/cryptonotecore/ICore.h
@@ -171,7 +171,7 @@ namespace CryptoNote
             const AccountPublicAddress &adr,
             const BinaryArray &extraNonce,
             uint64_t &difficulty,
-            uint32_t &height) const = 0;
+            uint32_t &height) = 0;
 
         virtual CoreStatistics getCoreStatistics() const = 0;
 

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -16,6 +16,7 @@ ValidateTransaction::ValidateTransaction(
     CryptoNote::IBlockchainCache *cache,
     const CryptoNote::Currency &currency,
     const CryptoNote::Checkpoints &checkpoints,
+    Utilities::ThreadPool<bool> &threadPool,
     const uint64_t blockHeight,
     const uint64_t blockSizeMedian,
     const bool isPoolTransaction):
@@ -24,6 +25,7 @@ ValidateTransaction::ValidateTransaction(
     m_validatorState(state),
     m_currency(currency),
     m_checkpoints(checkpoints),
+    m_threadPool(threadPool),
     m_blockchainCache(cache),
     m_blockHeight(blockHeight),
     m_blockSizeMedian(blockSizeMedian),
@@ -429,78 +431,96 @@ bool ValidateTransaction::validateTransactionInputsExpensive()
 
     uint64_t inputIndex = 0;
 
+    std::vector<std::future<bool>> validationResult;
+
+    const Crypto::Hash prefixHash = m_cachedTransaction.getTransactionPrefixHash();
+
     for (const auto &input : m_transaction.inputs)
     {
-        const CryptoNote::KeyInput &in = boost::get<CryptoNote::KeyInput>(input);
+        /* Validate each input on a separate thread in our thread pool */
+        validationResult.push_back(m_threadPool.addJob([inputIndex, &input, &prefixHash, this]{
+            const CryptoNote::KeyInput &in = boost::get<CryptoNote::KeyInput>(input);
 
-        if (m_blockchainCache->checkIfSpent(in.keyImage, m_blockHeight))
-        {
-            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_KEYIMAGE_ALREADY_SPENT;
-            m_validationResult.errorMessage = "Transaction contains key image that has already been spent";
-
-            return false;
-        }
-
-        std::vector<Crypto::PublicKey> outputKeys;
-        std::vector<uint32_t> globalIndexes(in.outputIndexes.size());
-
-        globalIndexes[0] = in.outputIndexes[0];
-
-        /* Convert output indexes from relative to absolute */
-        for (size_t i = 1; i < in.outputIndexes.size(); ++i)
-        {
-            globalIndexes[i] = globalIndexes[i - 1] + in.outputIndexes[i];
-        }
-
-        const auto result = m_blockchainCache->extractKeyOutputKeys(
-            in.amount,
-            m_blockHeight,
-            { globalIndexes.data(), globalIndexes.size() },
-            outputKeys
-        );
-
-        if (result == CryptoNote::ExtractOutputKeysResult::INVALID_GLOBAL_INDEX)
-        {
-            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_GLOBAL_INDEX;
-            m_validationResult.errorMessage = "Transaction contains invalid global indexes";
-
-            return false;
-        }
-
-        if (result == CryptoNote::ExtractOutputKeysResult::OUTPUT_LOCKED)
-        {
-            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_SPEND_LOCKED_OUT;
-            m_validationResult.errorMessage = "Transaction includes an input which is still locked";
-
-            return false;
-        }
-
-        if (m_isPoolTransaction || m_blockHeight >= CryptoNote::parameters::TRANSACTION_SIGNATURE_COUNT_VALIDATION_HEIGHT)
-        {
-            if (outputKeys.size() != m_transaction.signatures[inputIndex].size())
+            if (m_blockchainCache->checkIfSpent(in.keyImage, m_blockHeight))
             {
-                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_SIGNATURES_COUNT;
-                m_validationResult.errorMessage = "Transaction has an invalid number of signatures";
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_KEYIMAGE_ALREADY_SPENT;
+                m_validationResult.errorMessage = "Transaction contains key image that has already been spent";
 
                 return false;
             }
-        }
 
-        if (!Crypto::crypto_ops::checkRingSignature(
-            m_cachedTransaction.getTransactionPrefixHash(),
-            in.keyImage,
-            outputKeys,
-            m_transaction.signatures[inputIndex]))
-        {
-            m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_SIGNATURES;
-            m_validationResult.errorMessage = "Transaction contains invalid signatures";
+            std::vector<Crypto::PublicKey> outputKeys;
+            std::vector<uint32_t> globalIndexes(in.outputIndexes.size());
 
-            return false;
-        }
+            globalIndexes[0] = in.outputIndexes[0];
+
+            /* Convert output indexes from relative to absolute */
+            for (size_t i = 1; i < in.outputIndexes.size(); ++i)
+            {
+                globalIndexes[i] = globalIndexes[i - 1] + in.outputIndexes[i];
+            }
+
+            const auto result = m_blockchainCache->extractKeyOutputKeys(
+                in.amount,
+                m_blockHeight,
+                { globalIndexes.data(), globalIndexes.size() },
+                outputKeys
+            );
+
+            if (result == CryptoNote::ExtractOutputKeysResult::INVALID_GLOBAL_INDEX)
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_GLOBAL_INDEX;
+                m_validationResult.errorMessage = "Transaction contains invalid global indexes";
+
+                return false;
+            }
+
+            if (result == CryptoNote::ExtractOutputKeysResult::OUTPUT_LOCKED)
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_SPEND_LOCKED_OUT;
+                m_validationResult.errorMessage = "Transaction includes an input which is still locked";
+
+                return false;
+            }
+
+            if (m_isPoolTransaction || m_blockHeight >= CryptoNote::parameters::TRANSACTION_SIGNATURE_COUNT_VALIDATION_HEIGHT)
+            {
+                if (outputKeys.size() != m_transaction.signatures[inputIndex].size())
+                {
+                    m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_SIGNATURES_COUNT;
+                    m_validationResult.errorMessage = "Transaction has an invalid number of signatures";
+
+                    return false;
+                }
+            }
+
+            if (!Crypto::crypto_ops::checkRingSignature(
+                prefixHash,
+                in.keyImage,
+                outputKeys,
+                m_transaction.signatures[inputIndex]))
+            {
+                m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::INPUT_INVALID_SIGNATURES;
+                m_validationResult.errorMessage = "Transaction contains invalid signatures";
+
+                return false;
+            }
+
+            return true;
+        }));
 
         inputIndex++;
     }
-    
-    return true;
+
+    /* Wait for every validation thread to finish processing. Valid if every
+     * one returns true. */
+    if (std::all_of(validationResult.begin(), validationResult.end(), [](auto &result) { return result.get(); }))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -514,7 +514,7 @@ bool ValidateTransaction::validateTransactionInputsExpensive()
 
     bool valid = true;
 
-    for (const auto result : validationResult)
+    for (auto &result : validationResult)
     {
         if (!result.get())
         {

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -514,13 +514,5 @@ bool ValidateTransaction::validateTransactionInputsExpensive()
 
     /* Wait for every validation thread to finish processing. Valid if every
      * one returns true. */
-    if (std::all_of(validationResult.begin(), validationResult.end(), [](auto &result) { return result.get(); }))
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return std::all_of(validationResult.begin(), validationResult.end(), [](auto &result) { return result.get(); });
 }
-

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -512,7 +512,15 @@ bool ValidateTransaction::validateTransactionInputsExpensive()
         inputIndex++;
     }
 
-    /* Wait for every validation thread to finish processing. Valid if every
-     * one returns true. */
-    return std::all_of(validationResult.begin(), validationResult.end(), [](auto &result) { return result.get(); });
+    bool valid = true;
+
+    for (const auto result : validationResult)
+    {
+        if (!result.get())
+        {
+            valid = false;
+        }
+    }
+
+    return valid;
 }

--- a/src/cryptonotecore/ValidateTransaction.h
+++ b/src/cryptonotecore/ValidateTransaction.h
@@ -14,6 +14,7 @@
 #include <cryptonotecore/Checkpoints.h>
 #include <cryptonotecore/Currency.h>
 #include <cryptonotecore/IBlockchainCache.h>
+#include <utilities/ThreadPool.h>
 
 struct TransactionValidationResult 
 {
@@ -45,6 +46,7 @@ class ValidateTransaction
             CryptoNote::IBlockchainCache *cache,
             const CryptoNote::Currency &currency,
             const CryptoNote::Checkpoints &checkpoints,
+            Utilities::ThreadPool<bool> &threadPool,
             const uint64_t blockHeight,
             const uint64_t blockSizeMedian,
             const bool isPoolTransaction);
@@ -101,4 +103,6 @@ class ValidateTransaction
 
         uint64_t m_sumOfOutputs = 0;
         uint64_t m_sumOfInputs = 0;
+
+        Utilities::ThreadPool<bool> &m_threadPool;
 };

--- a/src/daemon/Daemon.cpp
+++ b/src/daemon/Daemon.cpp
@@ -347,7 +347,8 @@ int main(int argc, char *argv[])
             std::move(checkpoints),
             dispatcher,
             std::unique_ptr<IBlockchainCacheFactory>(new DatabaseBlockchainCacheFactory(database, logger.getLogger())),
-            std::move(tmainChainStorage));
+            std::move(tmainChainStorage),
+            config.transactionValidationThreads);
 
         ccore.load();
         logger(INFO) << "Core initialized OK";

--- a/src/daemon/DaemonConfiguration.cpp
+++ b/src/daemon/DaemonConfiguration.cpp
@@ -176,6 +176,12 @@ namespace DaemonConfig
                     cxxopts::value<int>()->default_value(std::to_string(config.dbWriteBufferSizeMB)),
                     "#");
 
+        options.add_options("Syncing")(
+            "transaction-validation-threads",
+            "Number of threads to use to validate a transaction's inputs in parallel",
+            cxxopts::value<uint32_t>()->default_value(std::to_string(config.transactionValidationThreads)),
+            "#");
+
         try
         {
             auto cli = options.parse(argc, argv);
@@ -367,6 +373,11 @@ namespace DaemonConfig
             if (cli.count("fee-amount") > 0)
             {
                 config.feeAmount = cli["fee-amount"].as<int>();
+            }
+
+            if (cli.count("transaction-validation-threads") > 0)
+            {
+                config.transactionValidationThreads = cli["transaction-validation-threads"].as<uint32_t>();
             }
 
             if (config.help) // Do we want to display the help message?
@@ -631,6 +642,18 @@ namespace DaemonConfig
                     try
                     {
                         config.feeAmount = std::stoi(cfgValue);
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("transaction-validation-threads") == 0)
+                {
+                    try
+                    {
+                        config.transactionValidationThreads = std::stoi(cfgValue);
                         updated = true;
                     }
                     catch (std::exception &e)

--- a/src/daemon/DaemonConfiguration.h
+++ b/src/daemon/DaemonConfiguration.h
@@ -11,6 +11,7 @@
 #include <config/CryptoNoteConfig.h>
 #include <logging/ILogger.h>
 #include <rapidjson/document.h>
+#include <thread>
 
 using namespace rapidjson;
 
@@ -35,6 +36,7 @@ namespace DaemonConfig
             p2pInterface = "0.0.0.0";
             p2pPort = CryptoNote::P2P_DEFAULT_PORT;
             p2pExternalPort = 0;
+            transactionValidationThreads = std::thread::hardware_concurrency();
             rpcInterface = "127.0.0.1";
             rpcPort = CryptoNote::RPC_DEFAULT_PORT;
             noConsole = false;
@@ -83,6 +85,8 @@ namespace DaemonConfig
         int p2pPort;
 
         int p2pExternalPort;
+
+        uint32_t transactionValidationThreads;
 
         int dbThreads;
 

--- a/src/utilities/ThreadPool.h
+++ b/src/utilities/ThreadPool.h
@@ -1,0 +1,154 @@
+// Copyright (c) 2019, The TurtleCoin Developers
+//
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include <functional>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace Utilities
+{
+    template<typename ReturnValue>
+    class ThreadPool
+    {
+        public:
+            /////////////////
+            /* CONSTRUCTOR */
+            /////////////////
+
+            ThreadPool() : ThreadPool(std::thread::hardware_concurrency())
+            {
+            }
+
+            ThreadPool(uint64_t threadCount)
+            {
+                if (threadCount == 0)
+                {
+                    threadCount = 1;
+                }
+
+                m_threadCount = threadCount;
+
+                /* Launch our worker threads */
+                for (uint64_t i = 0; i < threadCount; i++)
+                {
+                    m_threads.push_back(std::thread(&ThreadPool::waitForJob, this));
+                }
+            }
+
+            ////////////////
+            /* DESTRUCTOR */
+            ////////////////
+
+            ~ThreadPool()
+            {
+                /* Signal threads to stop */
+                m_shouldStop = true;
+
+                /* Wake them all up */
+                m_haveJob.notify_all();
+
+                /* Wait for them to stop */
+                for (auto &thread : m_threads)
+                {
+                    thread.join();
+                }
+            }
+
+            /////////////////////////////
+            /* PUBLIC MEMBER FUNCTIONS */
+            /////////////////////////////
+
+            std::future<ReturnValue> addJob(const std::function<ReturnValue()> job)
+            {
+                std::promise<ReturnValue> promise;
+
+                std::future<ReturnValue> result = promise.get_future();
+
+                /* Aquire lock */
+                std::unique_lock<std::mutex> lock(m_mutex);
+
+                /* Add job to queue */
+                m_queue.push({ job, std::move(promise) });
+
+                /* Manually unlocking here so we don't wake up and instantly
+                 * sleep upon notify_one */
+                lock.unlock();
+
+                /* Wake up a thread to process the job */
+                m_haveJob.notify_one();
+
+                return result;
+            }
+
+        private:
+
+            //////////////////////////////
+            /* PRIVATE MEMBER FUNCTIONS */
+            //////////////////////////////
+
+            void waitForJob()
+            {
+                while (!m_shouldStop)
+                {
+                    std::unique_lock<std::mutex> lock(m_mutex);
+
+                    /* Wait for data to become available or to be stopped */
+                    m_haveJob.wait(lock, [&] {
+                        if (m_shouldStop)
+                        {
+                            return true;
+                        }
+
+                        return !m_queue.empty();
+                    });
+
+                    if (m_shouldStop)
+                    {
+                        return;
+                    }
+
+                    /* Take next job from queue */
+                    auto [job, result] = std::move(m_queue.front());
+
+                    /* Remove item from queue */
+                    m_queue.pop();
+
+                    /* Undo the lock so other threads can process jobs */
+                    lock.unlock();
+
+                    /* Process job and set return value */
+                    result.set_value(job());
+                }
+            }
+
+            //////////////////////////////
+            /* PRIVATE MEMBER VARIABLES */
+            //////////////////////////////
+
+            /* The work threads */
+            std::vector<std::thread> m_threads;
+
+            /* The amount of threads to launch */
+            uint64_t m_threadCount;
+
+            /* Whether we're stopping */
+            std::atomic<bool> m_shouldStop;
+
+            /* Whether we have a new job to process */
+            std::condition_variable m_haveJob;
+
+            /* Mutex to serialize access to job queue */
+            std::mutex m_mutex;
+
+            /* The queue of job functions and job results */
+            std::queue<
+                std::tuple<std::function<ReturnValue()>, std::promise<ReturnValue>>
+            > m_queue;
+    };
+}

--- a/src/utilities/ThreadPool.h
+++ b/src/utilities/ThreadPool.h
@@ -25,7 +25,8 @@ namespace Utilities
             {
             }
 
-            ThreadPool(uint64_t threadCount)
+            ThreadPool(uint64_t threadCount) :
+                m_shouldStop(false)
             {
                 if (threadCount == 0)
                 {


### PR DESCRIPTION
Adds a threadpool which is then utilized to validate the inputs in a transaction in parallel.

Needs a bit more testing. I was seeing some segfaults on my node which I think may be related, running in debug mode to try and track them down now.

This PR is most helpful when
* Syncing from zero *without checkpoints*
* Syncing top blocks which are outside the checkpoints range

I saw my CPU usage go from 8% (1 core out of 12 fully pegged) to between 30-50% usage while syncing without checkpoints.

I think this same idea may be applicable in other parts of the syncing process.