### PR TITLE
Fee per byte

### DIFF
--- a/include/WalletGreenTypes.h
+++ b/include/WalletGreenTypes.h
@@ -10,6 +10,7 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include "WalletTypes.h"
 
 namespace CryptoNote
 {
@@ -114,7 +115,7 @@ namespace CryptoNote
     {
         std::vector<std::string> sourceAddresses;
         std::vector<WalletOrder> destinations;
-        uint64_t fee = 0;
+        WalletTypes::FeeType fee = WalletTypes::FeeType::MinimumFee();
         uint16_t mixIn = 0;
         std::string extra;
         uint64_t unlockTimestamp = 0;

--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -484,8 +484,9 @@ namespace WalletTypes
             /* Fee will be specified as fee per byte, for example, 1 atomic TRTL per byte. */
             bool isFeePerByte = false;
 
-            /* Fee for each byte, in atomic units */
-            uint64_t feePerByte = 0;
+            /* Fee for each byte, in atomic units. Allowed to be a double, since
+             * we will truncate it to an int upon performing the chunking. */
+            double feePerByte = 0;
 
             /* Fee will be specified as a fixed fee */
             bool isFixedFee = false;
@@ -503,7 +504,7 @@ namespace WalletTypes
                 return fee;
             }
 
-            static FeeType FeePerByte(const uint64_t feePerByte)
+            static FeeType FeePerByte(const double feePerByte)
             {
                 FeeType fee;
                 fee.isFeePerByte = true;

--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -8,6 +8,7 @@
 #include "rapidjson/writer.h"
 
 #include <CryptoNote.h>
+#include <errors/Errors.h>
 #include <JsonHelper.h>
 #include <optional>
 #include <string>
@@ -475,6 +476,77 @@ namespace WalletTypes
     {
         Crypto::Hash hash;
         uint64_t height;
+    };
+
+    class FeeType
+    {
+        public:
+            /* Fee will be specified as fee per byte, for example, 1 atomic TRTL per byte. */
+            bool isFeePerByte = false;
+
+            /* Fee for each byte, in atomic units */
+            uint64_t feePerByte = 0;
+
+            /* Fee will be specified as a fixed fee */
+            bool isFixedFee = false;
+
+            /* Total fee to use */
+            uint64_t fixedFee = 0;
+
+            /* Fee will not be specified, use the minimum possible */
+            bool isMinimumFee = false;
+
+            static FeeType MinimumFee()
+            {
+                FeeType fee;
+                fee.isMinimumFee = true;
+                return fee;
+            }
+
+            static FeeType FeePerByte(const uint64_t feePerByte)
+            {
+                FeeType fee;
+                fee.isFeePerByte = true;
+                fee.feePerByte = feePerByte;
+                return fee;
+            }
+
+            static FeeType FixedFee(const uint64_t fixedFee)
+            {
+                FeeType fee;
+                fee.isFixedFee = true;
+                fee.fixedFee = fixedFee;
+                return fee;
+            }
+
+        private:
+            FeeType() = default;
+    };
+
+    struct TransactionResult
+    {
+        /* The error, if any */
+        Error error;
+
+        /* The raw transaction */
+        CryptoNote::Transaction transaction;
+
+        /* The transaction outputs, before converted into boost uglyness, used
+           for determining key inputs from the tx that belong to us */
+        std::vector<WalletTypes::KeyOutput> outputs;
+
+        /* The random key pair we generated */
+        CryptoNote::KeyPair txKeyPair;
+    };
+
+    struct PreparedTransactionInfo
+    {
+        uint64_t fee;
+        std::string paymentID;
+        std::vector<WalletTypes::TxInputAndOwner> inputs;
+        std::string changeAddress;
+        uint64_t changeRequired;
+        TransactionResult tx;
     };
 
     inline void to_json(nlohmann::json &j, const TopBlock &t)

--- a/include/WalletTypes.h
+++ b/include/WalletTypes.h
@@ -547,6 +547,7 @@ namespace WalletTypes
         std::string changeAddress;
         uint64_t changeRequired;
         TransactionResult tx;
+        Crypto::Hash transactionHash;
     };
 
     inline void to_json(nlohmann::json &j, const TopBlock &t)

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -89,17 +89,22 @@ namespace CryptoNote
         /* TODO: Remove? */
         const uint64_t MINIMUM_FEE = UINT64_C(10);
 
-        /* Fee to charge per byte of transaction. Effective, because we round
-         * it up in chunks of 256 bytes. */
+        /* Fee to charge per byte of transaction. Will be applied in chunks, see
+         * below. */
         const uint64_t MINIMUM_FEE_PER_BYTE_V1 = 2;
+
+        /* Fee per byte is rounded up in chunks. This helps makes estimates
+         * more accurate. It's suggested to make this a power of two, to relate
+         * to the underlying storage cost / page sizes for storing a transaction. */
+        const uint64_t FEE_PER_BYTE_CHUNK_SIZE = 256;
 
         /* 512 atomic units of fee, per 256 bytes of transaction - i.e., 2
          * atomic units per byte. We do it in chunks of 256 bytes, as we have
          * varint fields and so on. */
-        const uint64_t MINIMUM_FEE_PER_256_BYTES_V1 = 256 * MINIMUM_FEE_PER_BYTE_V1;
+        const uint64_t MINIMUM_FEE_PER_CHUNK = FEE_PER_BYTE_CHUNK_SIZE * MINIMUM_FEE_PER_BYTE_V1;
 
         /* Height for our first fee to byte change to take effect. */
-        const uint64_t MINIMUM_FEE_PER_256_BYTES_V1_HEIGHT = 2200000;
+        const uint64_t MINIMUM_FEE_PER_BYTE_V1_HEIGHT = 2200000;
 
         /* This section defines our minimum and maximum mixin counts required for transactions */
         const uint64_t MINIMUM_MIXIN_V1 = 0;

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -89,20 +89,18 @@ namespace CryptoNote
         /* TODO: Remove? */
         const uint64_t MINIMUM_FEE = UINT64_C(10);
 
-        /* Fee to charge per byte of transaction. Will be applied in chunks, see
-         * below. */
-        const uint64_t MINIMUM_FEE_PER_BYTE_V1 = 2;
-
         /* Fee per byte is rounded up in chunks. This helps makes estimates
          * more accurate. It's suggested to make this a power of two, to relate
          * to the underlying storage cost / page sizes for storing a transaction. */
         const uint64_t FEE_PER_BYTE_CHUNK_SIZE = 256;
 
-        /* 512 atomic units of fee, per 256 bytes of transaction - i.e., 2
-         * atomic units per byte. We do it in chunks of 256 bytes, as we have
-         * varint fields and so on. */
-        const uint64_t MINIMUM_FEE_PER_CHUNK = FEE_PER_BYTE_CHUNK_SIZE * MINIMUM_FEE_PER_BYTE_V1;
-
+        /* Fee to charge per byte of transaction. Will be applied in chunks, see
+         * above. This value comes out to 1.953125. We use this value instead of
+         * something like 2 because it makes for pretty resulting fees
+         * - 5 TRTL vs 5.12 TRTL. You can read this as.. the fee per chunk
+         * is 500 atomic units. The fee per byte is 500 / chunk size. */
+        const double MINIMUM_FEE_PER_BYTE_V1 = 500.00 / FEE_PER_BYTE_CHUNK_SIZE;
+        
         /* Height for our first fee to byte change to take effect. */
         const uint64_t MINIMUM_FEE_PER_BYTE_V1_HEIGHT = 2200000;
 

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -86,7 +86,20 @@ namespace CryptoNote
 
         const size_t CRYPTONOTE_DISPLAY_DECIMAL_POINT = 2;
 
+        /* TODO: Remove? */
         const uint64_t MINIMUM_FEE = UINT64_C(10);
+
+        /* Fee to charge per byte of transaction. Effective, because we round
+         * it up in chunks of 256 bytes. */
+        const uint64_t MINIMUM_FEE_PER_BYTE_V1 = 2;
+
+        /* 512 atomic units of fee, per 256 bytes of transaction - i.e., 2
+         * atomic units per byte. We do it in chunks of 256 bytes, as we have
+         * varint fields and so on. */
+        const uint64_t MINIMUM_FEE_PER_256_BYTES_V1 = 256 * MINIMUM_FEE_PER_BYTE_V1;
+
+        /* Height for our first fee to byte change to take effect. */
+        const uint64_t MINIMUM_FEE_PER_256_BYTES_V1_HEIGHT = 2200000;
 
         /* This section defines our minimum and maximum mixin counts required for transactions */
         const uint64_t MINIMUM_MIXIN_V1 = 0;

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -9,6 +9,7 @@
 #include <cryptonotecore/Mixins.h>
 #include <cryptonotecore/TransactionValidationErrors.h>
 #include <cryptonotecore/ValidateTransaction.h>
+#include <utilities/Utilities.h>
 
 ValidateTransaction::ValidateTransaction(
     const CryptoNote::CachedTransaction &cachedTransaction,
@@ -325,7 +326,23 @@ bool ValidateTransaction::validateTransactionFee()
 
     if (!isFusion)
     {
-        if (fee == 0 || (fee < CryptoNote::parameters::MINIMUM_FEE && m_isPoolTransaction))
+        bool validFee = fee != 0;
+
+        if (m_blockHeight >= CryptoNote::parameters::MINIMUM_FEE_PER_256_BYTES_V1_HEIGHT)
+        {
+            const auto minFee = Utilities::getMinimumTransactionFee(
+                m_cachedTransaction.getTransactionBinaryArray().size(),
+                m_blockHeight
+            );
+
+            validFee = fee >= minFee;
+        }
+        else if (m_isPoolTransaction)
+        {
+            validFee = fee >= CryptoNote::parameters::MINIMUM_FEE;
+        }
+
+        if (!validFee)
         {
             m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::WRONG_FEE;
             m_validationResult.errorMessage = "Transaction fee is below minimum fee and is not a fusion transaction";

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -328,7 +328,7 @@ bool ValidateTransaction::validateTransactionFee()
     {
         bool validFee = fee != 0;
 
-        if (m_blockHeight >= CryptoNote::parameters::MINIMUM_FEE_PER_256_BYTES_V1_HEIGHT)
+        if (m_blockHeight >= CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1_HEIGHT)
         {
             const auto minFee = Utilities::getMinimumTransactionFee(
                 m_cachedTransaction.getTransactionBinaryArray().size(),

--- a/src/errors/Errors.cpp
+++ b/src/errors/Errors.cpp
@@ -68,7 +68,7 @@ std::string Error::getErrorMessage() const
         {
             return "Not enough unlocked funds were found to cover this "
                    "transaction in the subwallets specified (or all wallets, "
-                   "if not specified. (Sum of amounts + fee + node fee)";
+                   "if not specified). (Sum of amounts + fee + node fee)";
         }
         case ADDRESS_WRONG_LENGTH:
         {

--- a/src/errors/Errors.cpp
+++ b/src/errors/Errors.cpp
@@ -301,6 +301,21 @@ std::string Error::getErrorMessage() const
                    "If the problem persists, please reduce the number of "
                    "destinations that you are trying to send to.";
         }
+        case PREPARED_TRANSACTION_EXPIRED:
+        {
+            return "The prepared transaction contains inputs that have since "
+                   "been spent or are no longer available, probably due to sending "
+                   "another transaction in between preparing this transaction and "
+                   "sending it. The prepared transaction has been cancelled.";
+        }
+        case PREPARED_TRANSACTION_NOT_FOUND:
+        {
+            return "The prepared transaction hash given does not exist, either "
+                   "because it never existed or because the wallet process was "
+                   "restarted and the previously prepared transactions were lost. "
+                   "Please re-prepare and re-send the transaction, ensuring you "
+                   "specify the correct transaction hash.";
+        }
         /* No default case so the compiler warns us if we missed one */
     }
 

--- a/src/errors/Errors.h
+++ b/src/errors/Errors.h
@@ -224,6 +224,15 @@ enum ErrorCode
     /* The transaction has more outputs than are permitted for the number
      * inputs that have been provided */
     OUTPUT_DECOMPOSITION = 56,
+
+    /* The inputs that were included in a prepared transaction have since been
+     * spent or are for some other reason no longer available. */
+    PREPARED_TRANSACTION_EXPIRED = 57,
+
+    /* The prepared transaction hash specified does not exist, either because
+     * it never existed, or because the wallet was restarted and the prepared
+     * transaction state was lost */
+    PREPARED_TRANSACTION_NOT_FOUND = 58,
 };
 
 class Error

--- a/src/errors/ValidateParameters.h
+++ b/src/errors/ValidateParameters.h
@@ -21,7 +21,7 @@ Error validateFusionTransaction(
 Error validateTransaction(
     const std::vector<std::pair<std::string, uint64_t>> destinations,
     const uint64_t mixin,
-    const uint64_t fee,
+    const WalletTypes::FeeType fee,
     const std::string paymentID,
     const std::vector<std::string> subWalletsToTakeFrom,
     const std::string changeAddress,
@@ -44,7 +44,7 @@ Error validateMixin(const uint64_t mixin, const uint64_t height);
 
 Error validateAmount(
     const std::vector<std::pair<std::string, uint64_t>> destinations,
-    const uint64_t fee,
+    const WalletTypes::FeeType fee,
     const std::vector<std::string> subWalletsToTakeFrom,
     const std::shared_ptr<SubWallets> subWallets,
     const uint64_t currentHeight);

--- a/src/subwallets/SubWallet.cpp
+++ b/src/subwallets/SubWallet.cpp
@@ -343,6 +343,24 @@ void SubWallet::removeCancelledTransactions(const std::unordered_set<Crypto::Has
     }
 }
 
+bool SubWallet::haveSpendableInput(
+    const WalletTypes::TransactionInput& input,
+    const uint64_t height) const
+{
+    for (const auto i : m_unspentInputs)
+    {
+        /* Checking for .key to support view wallets */
+        if (input.keyImage == i.keyImage || input.key == i.key)
+        {
+            /* Only gonna be one input that matches so can early return false
+             * if the input is locked */
+            return Utilities::isInputUnlocked(i.unlockTime, height);
+        }
+    }
+
+    return false;
+}
+
 std::vector<WalletTypes::TxInputAndOwner> SubWallet::getSpendableInputs(const uint64_t height) const
 {
     std::vector<WalletTypes::TxInputAndOwner> inputs;

--- a/src/subwallets/SubWallet.h
+++ b/src/subwallets/SubWallet.h
@@ -79,6 +79,10 @@ class SubWallet
     std::vector<Crypto::KeyImage> removeForkedInputs(const uint64_t forkHeight, const bool isViewWallet);
 
     void removeCancelledTransactions(const std::unordered_set<Crypto::Hash> cancelledTransactions);
+    
+    bool haveSpendableInput(
+        const WalletTypes::TransactionInput &input,
+        const uint64_t height) const;
 
     /* Gets inputs that are spendable at the given height */
     std::vector<WalletTypes::TxInputAndOwner> getSpendableInputs(const uint64_t height) const;

--- a/src/subwallets/SubWallets.cpp
+++ b/src/subwallets/SubWallets.cpp
@@ -445,6 +445,22 @@ std::tuple<bool, Crypto::PublicKey> SubWallets::getKeyImageOwner(const Crypto::K
     return {false, Crypto::PublicKey()};
 }
 
+/* Determine if the input given is available for spending */
+bool SubWallets::haveSpendableInput(
+    const WalletTypes::TransactionInput& input,
+    const uint64_t height) const
+{
+    for (const auto &[pubKey, subWallet] : m_subWallets)
+    {
+        if (subWallet.haveSpendableInput(input, height))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /* Remember if the transaction suceeds, we need to remove these key images
    so we don't double spend.
 

--- a/src/subwallets/SubWallets.cpp
+++ b/src/subwallets/SubWallets.cpp
@@ -450,8 +450,7 @@ std::tuple<bool, Crypto::PublicKey> SubWallets::getKeyImageOwner(const Crypto::K
 
    This may throw if you don't validate the user has enough balance, and
    that each of the subwallets exist. */
-std::tuple<std::vector<WalletTypes::TxInputAndOwner>, uint64_t> SubWallets::getTransactionInputsForAmount(
-    const uint64_t amount,
+std::vector<WalletTypes::TxInputAndOwner> SubWallets::getSpendableTransactionInputs(
     const bool takeFromAll,
     std::vector<Crypto::PublicKey> subWalletsToTakeFrom,
     const uint64_t height) const
@@ -489,27 +488,7 @@ std::tuple<std::vector<WalletTypes::TxInputAndOwner>, uint64_t> SubWallets::getT
     /* Shuffle the inputs */
     std::shuffle(availableInputs.begin(), availableInputs.end(), std::random_device {});
 
-    uint64_t foundMoney = 0;
-
-    std::vector<WalletTypes::TxInputAndOwner> inputsToUse;
-
-    /* Loop through each input */
-    for (const auto walletAmount : availableInputs)
-    {
-        /* Add each input */
-        inputsToUse.push_back(walletAmount);
-
-        foundMoney += walletAmount.input.amount;
-
-        /* Keep adding until we have enough money for the transaction */
-        if (foundMoney >= amount)
-        {
-            return {inputsToUse, foundMoney};
-        }
-    }
-
-    /* Not enough money to cover the transaction */
-    throw std::invalid_argument("Not enough funds found!");
+    return availableInputs;
 }
 
 /* Remember if the transaction suceeds, we need to remove these key images

--- a/src/subwallets/SubWallets.h
+++ b/src/subwallets/SubWallets.h
@@ -79,6 +79,12 @@ class SubWallets
 
     void storeTransactionInput(const Crypto::PublicKey publicSpendKey, const WalletTypes::TransactionInput input);
 
+    /* Determine if the input is in the spendable container and is unlocked
+     * at this height. */
+    bool haveSpendableInput(
+        const WalletTypes::TransactionInput& input,
+        const uint64_t height) const;
+
     /* Get key images + amounts for the specified transfer amount. We
        can either take from all subwallets, or from some subset
        (usually just one address, e.g. if we're running a web wallet) */

--- a/src/subwallets/SubWallets.h
+++ b/src/subwallets/SubWallets.h
@@ -82,8 +82,7 @@ class SubWallets
     /* Get key images + amounts for the specified transfer amount. We
        can either take from all subwallets, or from some subset
        (usually just one address, e.g. if we're running a web wallet) */
-    std::tuple<std::vector<WalletTypes::TxInputAndOwner>, uint64_t> getTransactionInputsForAmount(
-        const uint64_t amount,
+    std::vector<WalletTypes::TxInputAndOwner> getSpendableTransactionInputs(
         const bool takeFromAll,
         std::vector<Crypto::PublicKey> subWalletsToTakeFrom,
         const uint64_t height) const;

--- a/src/utilities/Utilities.cpp
+++ b/src/utilities/Utilities.cpp
@@ -260,7 +260,7 @@ namespace Utilities
         const size_t OUTPUT_TAG_SIZE = sizeof(uint8_t);
         const size_t PUBLIC_KEY_SIZE = sizeof(Crypto::PublicKey);
         const size_t TRANSACTION_VERSION_SIZE = sizeof(uint8_t);
-        const size_t TRANSACTION_UNLOCK_TIME_SIZE = sizeof(uint64_t);
+        const size_t TRANSACTION_UNLOCK_TIME_SIZE = sizeof(uint64_t) + 2; // varint
         const size_t EXTRA_DATA_SIZE = extraDataSize > 0 ? extraDataSize + 4 : 0;
         const size_t PAYMENT_ID_SIZE = havePaymentID ? 34 : 0;
 
@@ -279,7 +279,7 @@ namespace Utilities
                                + SIGNATURE_SIZE
                                + GLOBAL_INDEXES_VECTOR_SIZE_SIZE
                                + GLOBAL_INDEXES_INITIAL_VALUE_SIZE
-                               + mixin * (GLOBAL_INDEXES_DIFFERENCE_SIZE + SIGNATURE_SIZE);
+                               + mixin * SIGNATURE_SIZE;
 
         const size_t inputsSize = inputSize * numInputs;
 

--- a/src/utilities/Utilities.cpp
+++ b/src/utilities/Utilities.cpp
@@ -219,15 +219,15 @@ namespace Utilities
     uint64_t getTransactionFee(
         const size_t transactionSize,
         const uint64_t height,
-        const uint64_t feePerByte)
+        const double feePerByte)
     {
-        const double numChunks = std::ceil(
+        const uint64_t numChunks = static_cast<uint64_t>(std::ceil(
             transactionSize / static_cast<double>(CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE)
+        ));
+
+        return static_cast<uint64_t>(
+            numChunks * feePerByte * CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE
         );
-
-        const uint64_t multiplier = feePerByte * CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE;
-
-        return static_cast<uint64_t>(numChunks) * multiplier;
     }
 
     uint64_t getMinimumTransactionFee(

--- a/src/utilities/Utilities.cpp
+++ b/src/utilities/Utilities.cpp
@@ -221,8 +221,11 @@ namespace Utilities
         const uint64_t height,
         const uint64_t feePerByte)
     {
-        const double numChunks = std::ceil(transactionSize / 256.0);
-        const uint64_t multiplier = feePerByte * 256;
+        const double numChunks = std::ceil(
+            transactionSize / static_cast<double>(CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE)
+        );
+
+        const uint64_t multiplier = feePerByte * CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE;
 
         return static_cast<uint64_t>(numChunks) * multiplier;
     }

--- a/src/utilities/Utilities.cpp
+++ b/src/utilities/Utilities.cpp
@@ -264,7 +264,7 @@ namespace Utilities
         const size_t EXTRA_DATA_SIZE = extraDataSize > 0 ? extraDataSize + 4 : 0;
         const size_t PAYMENT_ID_SIZE = havePaymentID ? 34 : 0;
 
-        /* The size of the transaction preamble */
+        /* The size of the transaction header */
         const size_t headerSize = TRANSACTION_VERSION_SIZE
                                 + TRANSACTION_UNLOCK_TIME_SIZE
                                 + EXTRA_TAG_SIZE

--- a/src/utilities/Utilities.h
+++ b/src/utilities/Utilities.h
@@ -36,6 +36,22 @@ namespace Utilities
 
     bool parseDaemonAddressFromString(std::string &host, uint16_t &port, std::string address);
 
+    uint64_t getTransactionFee(
+        const size_t transactionSize,
+        const uint64_t height,
+        const uint64_t feePerByte);
+
+    uint64_t getMinimumTransactionFee(
+        const size_t transactionSize,
+        const uint64_t height);
+
+    size_t estimateTransactionSize(
+        const uint64_t mixin,
+        const size_t numInputs,
+        const size_t numOutputs,
+        const bool havePaymentID,
+        const size_t extraDataSize);
+
     size_t getApproximateMaximumInputCount(
         const size_t transactionSize,
         const size_t outputCount,

--- a/src/utilities/Utilities.h
+++ b/src/utilities/Utilities.h
@@ -39,7 +39,7 @@ namespace Utilities
     uint64_t getTransactionFee(
         const size_t transactionSize,
         const uint64_t height,
-        const uint64_t feePerByte);
+        const double feePerByte);
 
     uint64_t getMinimumTransactionFee(
         const size_t transactionSize,

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -1767,7 +1767,7 @@ namespace CryptoNote
 
             if (!fee.isFixedFee)
             {
-                const uint64_t feePerByte = fee.isFeePerByte
+                const double feePerByte = fee.isFeePerByte
                     ? fee.feePerByte
                     : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
 

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -1661,8 +1661,7 @@ namespace CryptoNote
                                      << Common::makeContainerFormatter(transactionParameters.sourceAddresses) << ", to "
                                      << WalletOrderListFormatter(m_currency, transactionParameters.destinations)
                                      << ", change address '" << transactionParameters.changeDestination << '\''
-                                     << ", fee " << m_currency.formatAmount(transactionParameters.fee) << ", mixin "
-                                     << transactionParameters.mixIn << ", unlockTimestamp "
+                                     << ", mixin " << transactionParameters.mixIn << ", unlockTimestamp "
                                      << transactionParameters.unlockTimestamp;
 
         id = doTransfer(transactionParameters);
@@ -1690,7 +1689,7 @@ namespace CryptoNote
     void WalletGreen::prepareTransaction(
         std::vector<WalletOuts> &&wallets,
         const std::vector<WalletOrder> &orders,
-        uint64_t fee,
+        WalletTypes::FeeType fee,
         uint16_t mixIn,
         const std::string &extra,
         uint64_t unlockTimestamp,
@@ -1699,61 +1698,194 @@ namespace CryptoNote
         PreparedTransaction &preparedTransaction)
     {
         preparedTransaction.destinations = convertOrdersToTransfers(orders);
-        preparedTransaction.neededMoney = countNeededMoney(preparedTransaction.destinations, fee);
 
-        std::vector<OutputToTransfer> selectedTransfers;
-        uint64_t foundMoney = selectTransfers(
-            preparedTransaction.neededMoney,
-            mixIn == 0,
-            m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()),
-            std::move(wallets),
-            selectedTransfers);
+        /* To begin with, no estimate for fee per byte. We'll adjust once we
+         * have more information. */
+        uint64_t estimatedFee = fee.isFixedFee ? fee.fixedFee : 0;
+        
+        const uint64_t totalAmount = countNeededMoney(preparedTransaction.destinations, 0);
 
-        if (foundMoney < preparedTransaction.neededMoney)
+        while (true)
         {
-            m_logger(ERROR, BRIGHT_RED) << "Failed to create transaction: not enough money. Needed "
-                                        << m_currency.formatAmount(preparedTransaction.neededMoney) << ", found "
-                                        << m_currency.formatAmount(foundMoney);
-            throw std::system_error(make_error_code(error::WRONG_AMOUNT), "Not enough money");
+            /* Remove outdated change destination */
+            if (preparedTransaction.destinations.back().type == WalletTransferType::CHANGE)
+            {
+                /* Remove old change destination / amount */
+                preparedTransaction.destinations.pop_back();
+            }
+
+            preparedTransaction.neededMoney = totalAmount + estimatedFee;
+
+            std::vector<OutputToTransfer> selectedTransfers;
+
+            uint64_t foundMoney = selectTransfers(
+                preparedTransaction.neededMoney,
+                mixIn == 0,
+                m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()),
+                std::move(wallets),
+                selectedTransfers);
+
+            if (foundMoney < preparedTransaction.neededMoney)
+            {
+                m_logger(ERROR, BRIGHT_RED) << "Failed to create transaction: not enough money. Needed "
+                                            << m_currency.formatAmount(preparedTransaction.neededMoney) << ", found "
+                                            << m_currency.formatAmount(foundMoney);
+                throw std::system_error(make_error_code(error::WRONG_AMOUNT), "Not enough money");
+            }
+
+            std::vector<RandomOuts> mixinResult;
+
+            if (mixIn != 0)
+            {
+                requestMixinOuts(selectedTransfers, mixIn, mixinResult);
+            }
+
+            std::vector<InputInfo> keysInfo;
+            prepareInputs(selectedTransfers, mixinResult, mixIn, keysInfo);
+
+            preparedTransaction.changeAmount = foundMoney - preparedTransaction.neededMoney;
+
+            std::vector<ReceiverAmounts> decomposedOutputs = splitDestinations(
+                preparedTransaction.destinations,
+                m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()),
+                m_currency);
+
+            if (preparedTransaction.changeAmount != 0)
+            {
+                WalletTransfer changeTransfer;
+                changeTransfer.type = WalletTransferType::CHANGE;
+                changeTransfer.address = m_currency.accountAddressAsString(changeDestination);
+                changeTransfer.amount = static_cast<int64_t>(preparedTransaction.changeAmount);
+                preparedTransaction.destinations.emplace_back(std::move(changeTransfer));
+
+                auto splittedChange = splitAmount(
+                    preparedTransaction.changeAmount,
+                    changeDestination,
+                    m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()));
+                decomposedOutputs.emplace_back(std::move(splittedChange));
+            }
+
+            if (!fee.isFixedFee)
+            {
+                const uint64_t feePerByte = fee.isFeePerByte
+                    ? fee.feePerByte
+                    : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+
+                /* If we haven't made an estimate already */
+                if (estimatedFee == 0)
+                {
+                    const uint64_t numOutputs = std::accumulate(
+                        decomposedOutputs.begin(),
+                        decomposedOutputs.end(),
+                        0,
+                        [](const uint64_t accumulator, const auto output) { return accumulator + output.amounts.size(); });
+
+                    const std::string paymentID = Utilities::getPaymentIDFromExtra(Common::asBinaryArray(extra));
+
+                    const size_t transactionSize = Utilities::estimateTransactionSize(
+                        mixIn,
+                        keysInfo.size(),
+                        numOutputs,
+                        paymentID != "",
+                        extra.size() - paymentID.size()
+                    );
+
+                    estimatedFee = Utilities::getTransactionFee(
+                        transactionSize,
+                        m_node.getLastKnownBlockHeight(),
+                        feePerByte
+                    );
+                }
+
+                /* Update change with actual fee */
+                preparedTransaction.neededMoney = totalAmount + estimatedFee;
+
+                /* Ok, we have enough inputs to add our estimated fee, lets
+                 * go ahead and try and make the transaction. */
+                if (foundMoney >= preparedTransaction.neededMoney)
+                {
+                    preparedTransaction.changeAmount = foundMoney - preparedTransaction.neededMoney;
+
+                    const auto maybeChange = preparedTransaction.destinations.back();
+
+                    /* If we have a change destination, and the amount is incorrect */
+                    if (maybeChange.type == WalletTransferType::CHANGE
+                     && maybeChange.amount != static_cast<int64_t>(preparedTransaction.changeAmount))
+                    {
+                        /* Remove old change destination / amount */
+                        preparedTransaction.destinations.pop_back();
+                        decomposedOutputs.pop_back();
+
+                        /* Add new change destination if needed */
+                        if (preparedTransaction.changeAmount != 0)
+                        {
+                            WalletTransfer changeTransfer;
+                            changeTransfer.type = WalletTransferType::CHANGE;
+                            changeTransfer.address = m_currency.accountAddressAsString(changeDestination);
+                            changeTransfer.amount = static_cast<int64_t>(preparedTransaction.changeAmount);
+                            preparedTransaction.destinations.emplace_back(std::move(changeTransfer));
+
+                            auto splittedChange = splitAmount(
+                                preparedTransaction.changeAmount,
+                                changeDestination,
+                                m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()));
+                            decomposedOutputs.emplace_back(std::move(splittedChange));
+                        }
+                    }
+
+                    preparedTransaction.transaction = makeTransaction(decomposedOutputs, keysInfo, extra, unlockTimestamp);
+
+                    const uint64_t actualFee = Utilities::getTransactionFee(
+                        preparedTransaction.transaction->getTransactionData().size(),
+                        m_node.getLastKnownBlockHeight(),
+                        feePerByte
+                    );
+
+                    /* Great! The fee we estimated is greater than or equal
+                     * to the min/specified fee per byte for a transaction
+                     * of this size, so we can continue with sending the
+                     * transaction. */
+                    if (estimatedFee >= actualFee)
+                    {
+                        return;
+                    }
+                    /* Estimate was too low. Retry with actual fee for a transaction
+                     * of the size we just created. */
+                    else
+                    {
+                        estimatedFee = actualFee;
+                        continue;
+                    }
+                }
+                /* Didn't get enough money selecting transfers. Fee has already
+                 * been updated, so we will select more next iteration */
+                else
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                preparedTransaction.transaction = makeTransaction(decomposedOutputs, keysInfo, extra, unlockTimestamp);
+
+                const uint64_t minFee = Utilities::getMinimumTransactionFee(
+                    preparedTransaction.transaction->getTransactionData().size(),
+                    m_node.getLastKnownBlockHeight()
+                );
+
+                /* User specified fixed fee, and fee is not enough to cover
+                 * minimum fee per byte */
+                if (fee.fixedFee < minFee)
+                {
+                    std::string message = "Fee is too small. Fee " + m_currency.formatAmount(fee.fixedFee)
+                                          + ", minimum fee for a transaction of this size: " + m_currency.formatAmount(minFee);
+                    m_logger(ERROR, BRIGHT_RED) << message;
+                    throw std::system_error(make_error_code(error::FEE_TOO_SMALL), message);
+                }
+
+                return;
+            }
         }
-
-        std::vector<RandomOuts> mixinResult;
-
-        if (mixIn != 0)
-        {
-            requestMixinOuts(selectedTransfers, mixIn, mixinResult);
-        }
-
-        std::vector<InputInfo> keysInfo;
-        prepareInputs(selectedTransfers, mixinResult, mixIn, keysInfo);
-
-        uint64_t donationAmount = pushDonationTransferIfPossible(
-            donation,
-            foundMoney - preparedTransaction.neededMoney,
-            m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()),
-            preparedTransaction.destinations);
-        preparedTransaction.changeAmount = foundMoney - preparedTransaction.neededMoney - donationAmount;
-
-        std::vector<ReceiverAmounts> decomposedOutputs = splitDestinations(
-            preparedTransaction.destinations,
-            m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()),
-            m_currency);
-        if (preparedTransaction.changeAmount != 0)
-        {
-            WalletTransfer changeTransfer;
-            changeTransfer.type = WalletTransferType::CHANGE;
-            changeTransfer.address = m_currency.accountAddressAsString(changeDestination);
-            changeTransfer.amount = static_cast<int64_t>(preparedTransaction.changeAmount);
-            preparedTransaction.destinations.emplace_back(std::move(changeTransfer));
-
-            auto splittedChange = splitAmount(
-                preparedTransaction.changeAmount,
-                changeDestination,
-                m_currency.defaultDustThreshold(m_node.getLastKnownBlockHeight()));
-            decomposedOutputs.emplace_back(std::move(splittedChange));
-        }
-
-        preparedTransaction.transaction = makeTransaction(decomposedOutputs, keysInfo, extra, unlockTimestamp);
     }
 
     void WalletGreen::validateSourceAddresses(const std::vector<std::string> &sourceAddresses) const
@@ -1979,9 +2111,9 @@ namespace CryptoNote
             throw std::system_error(make_error_code(error::ZERO_DESTINATION));
         }
 
-        if (transactionParameters.fee < m_currency.minimumFee())
+        if (transactionParameters.fee.isFixedFee && transactionParameters.fee.fixedFee < m_currency.minimumFee())
         {
-            std::string message = "Fee is too small. Fee " + m_currency.formatAmount(transactionParameters.fee)
+            std::string message = "Fee is too small. Fee " + m_currency.formatAmount(transactionParameters.fee.fixedFee)
                                   + ", minimum fee " + m_currency.formatAmount(m_currency.minimumFee());
             m_logger(ERROR, BRIGHT_RED) << message;
             throw std::system_error(make_error_code(error::FEE_TOO_SMALL), message);
@@ -2107,8 +2239,7 @@ namespace CryptoNote
         m_logger(INFO, BRIGHT_WHITE) << "makeTransaction"
                                      << ", from " << Common::makeContainerFormatter(sendingTransaction.sourceAddresses)
                                      << ", to " << WalletOrderListFormatter(m_currency, sendingTransaction.destinations)
-                                     << ", change address '" << sendingTransaction.changeDestination << '\'' << ", fee "
-                                     << m_currency.formatAmount(sendingTransaction.fee) << ", mixin "
+                                     << ", change address '" << sendingTransaction.changeDestination << '\'' << ", mixin "
                                      << sendingTransaction.mixIn << ", unlockTimestamp "
                                      << sendingTransaction.unlockTimestamp;
 

--- a/src/wallet/WalletGreen.h
+++ b/src/wallet/WalletGreen.h
@@ -367,7 +367,7 @@ namespace CryptoNote
         void prepareTransaction(
             std::vector<WalletOuts> &&wallets,
             const std::vector<WalletOrder> &orders,
-            uint64_t fee,
+            WalletTypes::FeeType fee,
             uint16_t mixIn,
             const std::string &extra,
             uint64_t unlockTimestamp,

--- a/src/walletapi/ApiDispatcher.cpp
+++ b/src/walletapi/ApiDispatcher.cpp
@@ -781,7 +781,7 @@ std::tuple<Error, uint16_t> ApiDispatcher::makeAdvancedTransaction(
     }
     else if (body.find("feePerByte") != body.end())
     {
-        fee = WalletTypes::FeeType::FeePerByte(getJsonValue<uint64_t>(body, "feePerByte"));
+        fee = WalletTypes::FeeType::FeePerByte(getJsonValue<float>(body, "feePerByte"));
     }
 
     std::vector<std::string> subWalletsToTakeFrom = {};

--- a/src/walletapi/ApiDispatcher.cpp
+++ b/src/walletapi/ApiDispatcher.cpp
@@ -652,7 +652,7 @@ std::tuple<Error, uint16_t>
         paymentID = getJsonValue<std::string>(body, "paymentID");
     }
 
-    auto [error, hash] = m_walletBackend->sendTransactionBasic(address, amount, paymentID);
+    auto [error, hash, unused] = m_walletBackend->sendTransactionBasic(address, amount, paymentID);
 
     if (error)
     {
@@ -693,11 +693,15 @@ std::tuple<Error, uint16_t>
             Utilities::getMixinAllowableRange(m_walletBackend->getStatus().networkBlockCount);
     }
 
-    uint64_t fee = WalletConfig::defaultFee;
+    auto fee = WalletTypes::FeeType::MinimumFee();
 
     if (body.find("fee") != body.end())
     {
-        fee = getJsonValue<uint64_t>(body, "fee");
+        fee = WalletTypes::FeeType::FixedFee(getJsonValue<uint64_t>(body, "fee"));
+    }
+    else if (body.find("feePerByte") != body.end())
+    {
+        fee = WalletTypes::FeeType::FeePerByte(getJsonValue<uint64_t>(body, "feePerByte"));
     }
 
     std::vector<std::string> subWalletsToTakeFrom = {};
@@ -740,7 +744,7 @@ std::tuple<Error, uint16_t>
         }
     }
 
-    auto [error, hash] = m_walletBackend->sendTransactionAdvanced(
+    auto [error, hash, unused] = m_walletBackend->sendTransactionAdvanced(
         destinations, mixin, fee, paymentID, subWalletsToTakeFrom, changeAddress, unlockTime, extraData);
 
     if (error)

--- a/src/walletapi/ApiDispatcher.h
+++ b/src/walletapi/ApiDispatcher.h
@@ -128,18 +128,43 @@ class ApiDispatcher
     std::tuple<Error, uint16_t>
         importViewAddress(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
+    /* Validate an address or integrated address */
     std::tuple<Error, uint16_t>
         validateAddress(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
+    /* Send a previously prepared transaction */
+    std::tuple<Error, uint16_t>
+        sendPreparedTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
+
+    /* Prepare (don't send) a basic transaction */
+    std::tuple<Error, uint16_t>
+        prepareBasicTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
+
+    /* Send a basic transaction */
     std::tuple<Error, uint16_t>
         sendBasicTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
+    /* Make a basic transaction, optionally relaying to the network */
+    std::tuple<Error, uint16_t>
+        makeBasicTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body, const bool sendTransaction);
+
+    /* Prepare (don't send) an advanced transaction */
+    std::tuple<Error, uint16_t>
+        prepareAdvancedTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
+
+    /* Send an advanced transaction */
     std::tuple<Error, uint16_t>
         sendAdvancedTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
+    /* Make an advanced transaction, optionally relaying to the network */
+    std::tuple<Error, uint16_t>
+        makeAdvancedTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body, const bool sendTransaction);
+
+    /* Send a basic fusion transaction */
     std::tuple<Error, uint16_t>
         sendBasicFusionTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
+    /* Send a more customizable fusion transaction */
     std::tuple<Error, uint16_t>
         sendAdvancedFusionTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
@@ -153,6 +178,9 @@ class ApiDispatcher
 
     std::tuple<Error, uint16_t>
         deleteAddress(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
+
+    std::tuple<Error, uint16_t>
+        deletePreparedTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body);
 
     //////////////////
     /* PUT REQUESTS */

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -122,7 +122,7 @@ namespace SendTransaction
 
             const uint64_t unlockTime = 0;
 
-            TransactionResult txResult =
+            WalletTypes::TransactionResult txResult =
                 makeTransaction(mixin, daemon, ourInputs, paymentID, destinations, subWallets, unlockTime, extraData);
 
             tx = txResult.transaction;
@@ -157,7 +157,9 @@ namespace SendTransaction
             return {AMOUNTS_NOT_PRETTY, Crypto::Hash()};
         }
 
-        if (!verifyTransactionFee(0, tx))
+        const uint64_t actualFee = sumTransactionFee(tx);
+
+        if (!verifyTransactionFee(WalletTypes::FeeType::FixedFee(0), actualFee, tx))
         {
             return {UNEXPECTED_FEE, Crypto::Hash()};
         }
@@ -194,24 +196,24 @@ namespace SendTransaction
        default fee, default mixin, default change address
 
        WARNING: This is NOT suitable for multi wallet containers, as the change
-       address is undefined - it will return to one of the subwallets, but it
-       is not defined which, since they are not ordered by creation time or
-       anything like that.
+       will be returned to the primary subwallet address.
 
        If you want to return change to a specific wallet, use
        sendTransactionAdvanced() */
-    std::tuple<Error, Crypto::Hash> sendTransactionBasic(
+    std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionBasic(
         std::string destination,
         const uint64_t amount,
         std::string paymentID,
         const std::shared_ptr<Nigel> daemon,
-        const std::shared_ptr<SubWallets> subWallets)
+        const std::shared_ptr<SubWallets> subWallets,
+        const bool sendAll,
+        const bool sendTransaction)
     {
         std::vector<std::pair<std::string, uint64_t>> destinations = {{destination, amount}};
 
         const auto [minMixin, maxMixin, defaultMixin] = Utilities::getMixinAllowableRange(daemon->networkBlockCount());
 
-        const uint64_t fee = WalletConfig::defaultFee;
+        WalletTypes::FeeType fee = WalletTypes::FeeType::MinimumFee();
 
         /* Assumes the container has at least one subwallet - this is true as long
            as the static constructors were used */
@@ -220,20 +222,34 @@ namespace SendTransaction
         const uint64_t unlockTime = 0;
 
         return sendTransactionAdvanced(
-            destinations, defaultMixin, fee, paymentID, {}, changeAddress, daemon, subWallets, unlockTime, {});
+            destinations,
+            defaultMixin,
+            fee,
+            paymentID,
+            {},
+            changeAddress,
+            daemon,
+            subWallets,
+            unlockTime,
+            {},
+            sendAll,
+            sendTransaction
+        );
     }
 
-    std::tuple<Error, Crypto::Hash> sendTransactionAdvanced(
+    std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionAdvanced(
         std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
         const uint64_t mixin,
-        const uint64_t fee,
+        const WalletTypes::FeeType fee,
         std::string paymentID,
         const std::vector<std::string> addressesToTakeFrom,
         std::string changeAddress,
         const std::shared_ptr<Nigel> daemon,
         const std::shared_ptr<SubWallets> subWallets,
         const uint64_t unlockTime,
-        const std::vector<uint8_t> extraData)
+        const std::vector<uint8_t> extraData,
+        const bool sendAll,
+        const bool sendTransaction)
     {
         /* Append the fee transaction, if a fee is being used */
         const auto [feeAmount, feeAddress] = daemon->nodeFee();
@@ -261,7 +277,7 @@ namespace SendTransaction
 
         if (error)
         {
-            return {error, Crypto::Hash()};
+            return {error, Crypto::Hash(), WalletTypes::PreparedTransactionInfo()};
         }
 
         /* Convert integrated addresses to standard address + paymentID, if
@@ -284,52 +300,231 @@ namespace SendTransaction
         const bool takeFromAllSubWallets = addressesToTakeFrom.empty();
 
         /* The total amount we are sending */
-        const uint64_t totalAmount = Utilities::getTransactionSum(addressesAndAmounts) + fee;
+        uint64_t totalAmount = Utilities::getTransactionSum(addressesAndAmounts);
 
         /* Convert the addresses to public spend keys */
         const std::vector<Crypto::PublicKey> subWalletsToTakeFrom =
             Utilities::addressesToSpendKeys(addressesToTakeFrom);
 
-        /* The transaction 'inputs' - key images we have previously received, plus
-           their sum. The sumOfInputs is sometimes (most of the time) greater than
-           the amount we want to send, so we need to send some back to ourselves
-           as change. */
-        auto [ourInputs, sumOfInputs] = subWallets->getTransactionInputsForAmount(
-            totalAmount, takeFromAllSubWallets, subWalletsToTakeFrom, daemon->networkBlockCount());
+        /* Get inputs that are available to be spent so we can form the tx */
+        auto availableInputs = subWallets->getSpendableTransactionInputs(
+            takeFromAllSubWallets,
+            subWalletsToTakeFrom,
+            daemon->networkBlockCount()
+        );
 
-        /* If the sum of inputs is > total amount, we need to send some back to
-           ourselves. */
-        uint64_t changeRequired = sumOfInputs - totalAmount;
+        uint64_t sumOfInputs = 0;
 
-        /* Split the transfers up into an amount, a public spend+view key */
-        const auto destinations = setupDestinations(addressesAndAmounts, changeRequired, changeAddress);
+        std::vector<WalletTypes::TxInputAndOwner> ourInputs;
 
-        TransactionResult txResult =
-            makeTransaction(mixin, daemon, ourInputs, paymentID, destinations, subWallets, unlockTime, extraData);
+        if (fee.isFixedFee)
+        {
+            totalAmount += fee.fixedFee;
+        }
+
+        WalletTypes::TransactionResult txResult;
+        uint64_t changeRequired;
+        uint64_t requiredAmount = totalAmount;
+        WalletTypes::PreparedTransactionInfo txInfo;
+
+        for (const auto input : availableInputs)
+        {
+            ourInputs.push_back(input);
+            sumOfInputs += input.input.amount;
+
+            if (sumOfInputs >= totalAmount)
+            {
+                /* If the sum of inputs is > total amount, we need to send some back to
+                   ourselves. */
+                changeRequired = sumOfInputs - totalAmount;
+
+                /* Split the transfers up into an amount, a public spend+view key */
+                auto destinations = setupDestinations(addressesAndAmounts, changeRequired, changeAddress);
+
+                /* Ok, we are using a fee per byte, lets take a guess at how
+                 * large our fee is going to be, and then see if we have enough
+                 * inputs to cover it. */
+                if (!fee.isFixedFee)
+                {
+                    const size_t transactionSize = Utilities::estimateTransactionSize(
+                        mixin,
+                        ourInputs.size(),
+                        destinations.size(),
+                        paymentID != "",
+                        extraData.size()
+                    );
+
+                    const uint64_t feePerByte = fee.isFeePerByte
+                        ? fee.feePerByte
+                        : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+
+                    const uint64_t estimatedFee = Utilities::getTransactionFee(
+                        transactionSize,
+                        daemon->networkBlockCount(),
+                        feePerByte
+                    );
+
+                    if (sendAll)
+                    {
+                        const auto [address, amount] = addressesAndAmounts[0];
+
+                        if (estimatedFee > amount)
+                        {
+                            txInfo.fee = estimatedFee;
+                            return { NOT_ENOUGH_BALANCE, Crypto::Hash(), txInfo };
+                        }
+
+                        totalAmount -= estimatedFee;
+                        addressesAndAmounts[0] = { address, amount - estimatedFee };
+                        destinations = setupDestinations(addressesAndAmounts, changeRequired, changeAddress);
+                    }
+
+                    const uint64_t estimatedAmount = totalAmount + estimatedFee;
+
+                    /* Ok, we have enough inputs to add our estimated fee, lets
+                     * go ahead and try and make the transaction. */
+                    if (sumOfInputs >= estimatedAmount)
+                    {
+                        const auto [success, result, change, needed] = tryMakeFeePerByteTransaction(
+                            sumOfInputs,
+                            totalAmount,
+                            estimatedAmount,
+                            feePerByte,
+                            addressesAndAmounts,
+                            changeAddress,
+                            mixin,
+                            daemon,
+                            ourInputs,
+                            paymentID,
+                            subWallets,
+                            unlockTime,
+                            extraData,
+                            sendAll
+                        );
+
+                        if (success)
+                        {
+                            txResult = result;
+                            changeRequired = change;
+                            break;
+                        }
+                        else
+                        {
+                            requiredAmount = needed;
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        /* Need to ensure we update this so if we run out of
+                         * inputs we correctly check if we have enough balance */
+                        requiredAmount = estimatedAmount;
+                    }
+                }
+                else
+                {
+                    txResult = makeTransaction(
+                        mixin,
+                        daemon,
+                        ourInputs,
+                        paymentID,
+                        destinations,
+                        subWallets,
+                        unlockTime,
+                        extraData
+                    );
+
+                    const uint64_t minFee = Utilities::getMinimumTransactionFee(
+                        toBinaryArray(txResult.transaction).size(),
+                        daemon->networkBlockCount()
+                    );
+
+                    if (fee.fixedFee >= minFee)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        return { FEE_TOO_SMALL, Crypto::Hash(), WalletTypes::PreparedTransactionInfo() };
+                    }
+                }
+            }
+        }
+
+        if (sumOfInputs < requiredAmount)
+        {
+            txInfo.fee = requiredAmount - totalAmount;
+            return {NOT_ENOUGH_BALANCE, Crypto::Hash(), txInfo};
+        }
 
         if (txResult.error)
         {
-            return {txResult.error, Crypto::Hash()};
+            return {txResult.error, Crypto::Hash(), txInfo};
         }
 
         error = isTransactionPayloadTooBig(txResult.transaction, daemon->networkBlockCount());
 
         if (error)
         {
-            return {error, Crypto::Hash()};
+            return {error, Crypto::Hash(), txInfo};
         }
 
         if (!verifyAmounts(txResult.transaction))
         {
-            return {AMOUNTS_NOT_PRETTY, Crypto::Hash()};
+            return {AMOUNTS_NOT_PRETTY, Crypto::Hash(), txInfo};
         }
 
-        if (!verifyTransactionFee(fee, txResult.transaction))
+        const uint64_t actualFee = sumTransactionFee(txResult.transaction);
+
+        if (!verifyTransactionFee(fee, actualFee, txResult.transaction))
         {
-            return {UNEXPECTED_FEE, Crypto::Hash()};
+            return {UNEXPECTED_FEE, Crypto::Hash(), txInfo};
         }
 
-        const auto [sendError, txHash] = relayTransaction(txResult.transaction, daemon);
+        txInfo.fee = actualFee;
+        txInfo.paymentID = paymentID;
+        txInfo.inputs = ourInputs;
+        txInfo.changeAddress = changeAddress;
+        txInfo.changeRequired = changeRequired;
+        txInfo.tx = txResult;
+
+        if (sendTransaction)
+        {
+            const auto [sendError, txHash] = relayTransaction(txResult.transaction, daemon);
+
+            if (sendError)
+            {
+                return {sendError, Crypto::Hash(), WalletTypes::PreparedTransactionInfo()};
+            }
+
+            /* Store the unconfirmed transaction, update our balance */
+            storeSentTransaction(txHash, actualFee, paymentID, ourInputs, changeAddress, changeRequired, subWallets);
+
+            /* Update our locked balance with the incoming funds */
+            storeUnconfirmedIncomingInputs(subWallets, txResult.outputs, txResult.txKeyPair.publicKey, txHash);
+
+            subWallets->storeTxPrivateKey(txResult.txKeyPair.secretKey, txHash);
+
+            /* Lock the input for spending till it is confirmed as spent in a block */
+            for (const auto input : ourInputs)
+            {
+                subWallets->markInputAsLocked(input.input.keyImage, input.publicSpendKey);
+            }
+
+            return {SUCCESS, txHash, txInfo};
+        }
+        else
+        {
+            return {SUCCESS, Crypto::Hash(), txInfo};
+        }
+    }
+
+    std::tuple<Error, Crypto::Hash> sendPreparedTransaction(
+        const WalletTypes::PreparedTransactionInfo txInfo,
+        const std::shared_ptr<Nigel> daemon,
+        const std::shared_ptr<SubWallets> subWallets)
+    {
+        const auto [sendError, txHash] = relayTransaction(txInfo.tx.transaction, daemon);
 
         if (sendError)
         {
@@ -337,20 +532,113 @@ namespace SendTransaction
         }
 
         /* Store the unconfirmed transaction, update our balance */
-        storeSentTransaction(txHash, fee, paymentID, ourInputs, changeAddress, changeRequired, subWallets);
+        storeSentTransaction(
+            txHash,
+            txInfo.fee,
+            txInfo.paymentID,
+            txInfo.inputs,
+            txInfo.changeAddress,
+            txInfo.changeRequired,
+            subWallets
+        );
 
         /* Update our locked balance with the incoming funds */
-        storeUnconfirmedIncomingInputs(subWallets, txResult.outputs, txResult.txKeyPair.publicKey, txHash);
+        storeUnconfirmedIncomingInputs(
+            subWallets,
+            txInfo.tx.outputs,
+            txInfo.tx.txKeyPair.publicKey,
+            txHash
+        );
 
-        subWallets->storeTxPrivateKey(txResult.txKeyPair.secretKey, txHash);
+        subWallets->storeTxPrivateKey(txInfo.tx.txKeyPair.secretKey, txHash);
 
         /* Lock the input for spending till it is confirmed as spent in a block */
-        for (const auto input : ourInputs)
+        for (const auto input : txInfo.inputs)
         {
             subWallets->markInputAsLocked(input.input.keyImage, input.publicSpendKey);
         }
 
         return {SUCCESS, txHash};
+    }
+
+    std::tuple<bool, WalletTypes::TransactionResult, uint64_t, uint64_t> tryMakeFeePerByteTransaction(
+        const uint64_t sumOfInputs,
+        uint64_t amountPreFee,
+        uint64_t amountIncludingFee,
+        const uint64_t feePerByte,
+        std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
+        const std::string changeAddress,
+        const uint64_t mixin,
+        const std::shared_ptr<Nigel> daemon,
+        const std::vector<WalletTypes::TxInputAndOwner> ourInputs,
+        const std::string paymentID,
+        const std::shared_ptr<SubWallets> subWallets,
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData,
+        const bool sendAll)
+    {
+        while (true)
+        {
+            const uint64_t changeRequired = sumOfInputs - amountIncludingFee;
+
+            /* Need to recalculate destinations since amount of change, err, changed! */
+            const auto destinations = setupDestinations(addressesAndAmounts, changeRequired, changeAddress);
+
+            WalletTypes::TransactionResult txResult = makeTransaction(
+                mixin,
+                daemon,
+                ourInputs,
+                paymentID,
+                destinations,
+                subWallets,
+                unlockTime,
+                extraData
+            );
+
+            const size_t actualTxSize = toBinaryArray(txResult.transaction).size();
+
+            const uint64_t actualFee = Utilities::getTransactionFee(
+                actualTxSize,
+                daemon->networkBlockCount(),
+                feePerByte
+            );
+
+            /* Great! The fee we estimated is greater than or equal
+             * to the min/specified fee per byte for a transaction
+             * of this size, so we can continue with sending the
+             * transaction. */
+            if (amountIncludingFee - amountPreFee >= actualFee)
+            {
+                return { true, txResult, changeRequired, 0 };
+            }
+
+            /* If we're sending all, then we adjust the amount we're sending,
+             * rather than the change we're returning. */
+            if (sendAll)
+            {
+                amountPreFee = amountIncludingFee - actualFee;
+                const auto [address, amount] = addressesAndAmounts[0];
+                addressesAndAmounts[0] = { address, amountPreFee };
+            }
+
+            /* The actual fee required for a tx of this size is not
+             * covered by the amount of inputs we have so far, lets
+             * go select some more then try again. */
+            if (amountPreFee + actualFee > sumOfInputs)
+            {
+                return { false, txResult, changeRequired, amountPreFee + actualFee };
+            }
+            
+            /* Our fee was too low. Lets try making the transaction again,
+             * this time using the actual fee calculated. Note that this still
+             * may fail, since we are possibly adding more outputs, and so have
+             * a large transaction size. If we keep increasing the fee and keep
+             * failing, eventually we'll hit a point where we either succeed
+             * or we need to gather more inputs. */
+            amountIncludingFee = amountPreFee + actualFee;
+        }
+
+        throw std::runtime_error("Programmer error @ tryMakeFeePerByteTransaction");
     }
 
     Error isTransactionPayloadTooBig(const CryptoNote::Transaction tx, const uint64_t currentHeight)
@@ -985,7 +1273,7 @@ namespace SendTransaction
         return result;
     }
 
-    TransactionResult makeTransaction(
+    WalletTypes::TransactionResult makeTransaction(
         const uint64_t mixin,
         const std::shared_ptr<Nigel> daemon,
         const std::vector<WalletTypes::TxInputAndOwner> ourInputs,
@@ -998,7 +1286,7 @@ namespace SendTransaction
         /* Mix our inputs with fake ones from the network to hide who we are */
         const auto [mixinError, inputsAndFakes] = prepareRingParticipants(ourInputs, mixin, daemon);
 
-        TransactionResult result;
+        WalletTypes::TransactionResult result;
 
         if (mixinError)
         {
@@ -1134,7 +1422,7 @@ namespace SendTransaction
         return true;
     }
 
-    bool verifyTransactionFee(const uint64_t expectedFee, const CryptoNote::Transaction tx)
+    uint64_t sumTransactionFee(const CryptoNote::Transaction tx)
     {
         uint64_t inputTotal = 0;
         uint64_t outputTotal = 0;
@@ -1149,9 +1437,32 @@ namespace SendTransaction
             outputTotal += output.amount;
         }
 
-        uint64_t actualFee = inputTotal - outputTotal;
+        return inputTotal - outputTotal;
+    }
 
-        return expectedFee == actualFee;
+    bool verifyTransactionFee(
+        const WalletTypes::FeeType expectedFee,
+        const uint64_t actualFee,
+        const CryptoNote::Transaction tx)
+    {
+        if (expectedFee.isFixedFee)
+        {
+            return expectedFee.fixedFee == actualFee;
+        }
+        else
+        {
+            const uint64_t feePerByte = expectedFee.isFeePerByte
+                ? expectedFee.feePerByte
+                : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+
+            const size_t txSize = toBinaryArray(tx).size();
+
+            const size_t calculatedFee = feePerByte * txSize;
+
+            /* Ensure fee is greater or equal to the fee per byte specified,
+             * and no more than two times the fee per byte specified. */
+            return actualFee >= calculatedFee && actualFee <= calculatedFee * 2;
+        }
     }
 
 } // namespace SendTransaction

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -354,7 +354,7 @@ namespace SendTransaction
                         extraData.size()
                     );
 
-                    const uint64_t feePerByte = fee.isFeePerByte
+                    const double feePerByte = fee.isFeePerByte
                         ? fee.feePerByte
                         : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
 
@@ -576,7 +576,7 @@ namespace SendTransaction
         const uint64_t sumOfInputs,
         uint64_t amountPreFee,
         uint64_t amountIncludingFee,
-        const uint64_t feePerByte,
+        const double feePerByte,
         std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
         const std::string changeAddress,
         const uint64_t mixin,
@@ -1462,13 +1462,13 @@ namespace SendTransaction
         }
         else
         {
-            const uint64_t feePerByte = expectedFee.isFeePerByte
+            const double feePerByte = expectedFee.isFeePerByte
                 ? expectedFee.feePerByte
                 : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
 
             const size_t txSize = toBinaryArray(tx).size();
 
-            const size_t calculatedFee = feePerByte * txSize;
+            const size_t calculatedFee = static_cast<uint64_t>(feePerByte * txSize);
 
             /* Ensure fee is greater or equal to the fee per byte specified,
              * and no more than two times the fee per byte specified. */

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -2,6 +2,8 @@
 //
 // Please see the included LICENSE file for more information.
 
+#pragma once
+
 #include <CryptoNote.h>
 #include <WalletTypes.h>
 #include <errors/Errors.h>
@@ -23,24 +25,33 @@ namespace SendTransaction
         const std::shared_ptr<SubWallets> subWallets,
         const std::vector<uint8_t> extraData);
 
-    std::tuple<Error, Crypto::Hash> sendTransactionBasic(
+    std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionBasic(
         std::string destination,
         const uint64_t amount,
         std::string paymentID,
         const std::shared_ptr<Nigel> daemon,
-        const std::shared_ptr<SubWallets> subWallets);
+        const std::shared_ptr<SubWallets> subWallets,
+        const bool sendAll = false,
+        const bool sendTransaction = true);
 
-    std::tuple<Error, Crypto::Hash> sendTransactionAdvanced(
+    std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionAdvanced(
         std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
         const uint64_t mixin,
-        const uint64_t fee,
+        const WalletTypes::FeeType fee,
         std::string paymentID,
         const std::vector<std::string> addressesToTakeFrom,
         std::string changeAddress,
         const std::shared_ptr<Nigel> daemon,
         const std::shared_ptr<SubWallets> subWallets,
         const uint64_t unlockTime,
-        const std::vector<uint8_t> extraData);
+        const std::vector<uint8_t> extraData,
+        const bool sendAll = false,
+        const bool sendTransaction = true);
+
+    std::tuple<Error, Crypto::Hash> sendPreparedTransaction(
+        const WalletTypes::PreparedTransactionInfo txInfo,
+        const std::shared_ptr<Nigel> daemon,
+        const std::shared_ptr<SubWallets> subWallets);
 
     std::vector<WalletTypes::TransactionDestination> setupDestinations(
         std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
@@ -78,24 +89,8 @@ namespace SendTransaction
         const uint64_t mixin,
         const std::shared_ptr<Nigel> daemon,
         const std::vector<WalletTypes::TxInputAndOwner> sources);
-
-    struct TransactionResult
-    {
-        /* The error, if any */
-        Error error;
-
-        /* The raw transaction */
-        CryptoNote::Transaction transaction;
-
-        /* The transaction outputs, before converted into boost uglyness, used
-           for determining key inputs from the tx that belong to us */
-        std::vector<WalletTypes::KeyOutput> outputs;
-
-        /* The random key pair we generated */
-        CryptoNote::KeyPair txKeyPair;
-    };
-
-    TransactionResult makeTransaction(
+    
+    WalletTypes::TransactionResult makeTransaction(
         const uint64_t mixin,
         const std::shared_ptr<Nigel> daemon,
         const std::vector<WalletTypes::TxInputAndOwner> ourInputs,
@@ -117,6 +112,22 @@ namespace SendTransaction
         const uint64_t changeRequired,
         const std::shared_ptr<SubWallets> subWallets);
 
+    std::tuple<bool, WalletTypes::TransactionResult, uint64_t, uint64_t> tryMakeFeePerByteTransaction(
+        const uint64_t sumOfInputs,
+        uint64_t totalAmount,
+        uint64_t estimatedAmount,
+        const uint64_t feePerByte,
+        std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
+        const std::string changeAddress,
+        const uint64_t mixin,
+        const std::shared_ptr<Nigel> daemon,
+        const std::vector<WalletTypes::TxInputAndOwner> ourInputs,
+        const std::string paymentID,
+        const std::shared_ptr<SubWallets> subWallets,
+        const uint64_t unlockTime,
+        const std::vector<uint8_t> extraData,
+        const bool sendAll);
+
     Error isTransactionPayloadTooBig(const CryptoNote::Transaction tx, const uint64_t currentHeight);
 
     void storeUnconfirmedIncomingInputs(
@@ -131,8 +142,14 @@ namespace SendTransaction
     /* Verify all amounts given are PRETTY_AMOUNTS */
     bool verifyAmounts(const std::vector<uint64_t> amounts);
 
-    /* Verify fee is as expected */
-    bool verifyTransactionFee(const uint64_t expectedFee, CryptoNote::Transaction tx);
+    /* Compute the fee of the transaction */
+    uint64_t sumTransactionFee(const CryptoNote::Transaction tx);
+
+    /* Verify fee is as expected (or expected range, in the case of fee per byte) */
+    bool verifyTransactionFee(
+        const WalletTypes::FeeType expectedFee,
+        const uint64_t actualFee,
+        const CryptoNote::Transaction tx);
 
     /* Template so we can do transaction, and transactionprefix */
     template<typename T> Crypto::Hash getTransactionHash(T tx)

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -116,7 +116,7 @@ namespace SendTransaction
         const uint64_t sumOfInputs,
         uint64_t totalAmount,
         uint64_t estimatedAmount,
-        const uint64_t feePerByte,
+        const double feePerByte,
         std::vector<std::pair<std::string, uint64_t>> addressesAndAmounts,
         const std::string changeAddress,
         const uint64_t mixin,

--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -748,28 +748,62 @@ uint64_t WalletBackend::getTotalUnlockedBalance() const
     return unlockedBalance;
 }
 
-/* This is simply a wrapper for Transfer::sendTransactionBasic - we need to
-   pass in the daemon and subwallets instance */
-std::tuple<Error, Crypto::Hash> WalletBackend::sendTransactionBasic(
-    const std::string destination,
-    const uint64_t amount,
-    const std::string paymentID)
+std::tuple<Error, Crypto::Hash> WalletBackend::sendPreparedTransaction(
+    const WalletTypes::PreparedTransactionInfo &preparedTransaction)
 {
-    return SendTransaction::sendTransactionBasic(destination, amount, paymentID, m_daemon, m_subWallets);
+    return SendTransaction::sendPreparedTransaction(
+        preparedTransaction,
+        m_daemon,
+        m_subWallets
+    );
 }
 
-std::tuple<Error, Crypto::Hash> WalletBackend::sendTransactionAdvanced(
+/* This is simply a wrapper for Transfer::sendTransactionBasic - we need to
+   pass in the daemon and subwallets instance */
+std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> WalletBackend::sendTransactionBasic(
+    const std::string destination,
+    const uint64_t amount,
+    const std::string paymentID,
+    const bool sendAll,
+    const bool sendTransaction)
+{
+    return SendTransaction::sendTransactionBasic(
+        destination,
+        amount,
+        paymentID,
+        m_daemon,
+        m_subWallets,
+        sendAll,
+        sendTransaction
+    );
+}
+
+std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> WalletBackend::sendTransactionAdvanced(
     const std::vector<std::pair<std::string, uint64_t>> destinations,
     const uint64_t mixin,
-    const uint64_t fee,
+    const WalletTypes::FeeType fee,
     const std::string paymentID,
     const std::vector<std::string> subWalletsToTakeFrom,
     const std::string changeAddress,
     const uint64_t unlockTime,
-    const std::vector<uint8_t> extraData)
+    const std::vector<uint8_t> extraData,
+    const bool sendAll,
+    const bool sendTransaction)
 {
     return SendTransaction::sendTransactionAdvanced(
-        destinations, mixin, fee, paymentID, subWalletsToTakeFrom, changeAddress, m_daemon, m_subWallets, unlockTime, extraData);
+        destinations,
+        mixin,
+        fee,
+        paymentID,
+        subWalletsToTakeFrom,
+        changeAddress,
+        m_daemon,
+        m_subWallets,
+        unlockTime,
+        extraData,
+        sendAll,
+        sendTransaction
+    );
 }
 
 std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionBasic()

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -129,20 +129,30 @@ class WalletBackend
         const bool daemonSSL,
         const unsigned int syncThreadCount);
 
+    /* Sends a previously prepared transaction to the network */
+    std::tuple<Error, Crypto::Hash> sendPreparedTransaction(
+        const WalletTypes::PreparedTransactionInfo &preparedTransaction);
+
     /* Send a transaction of amount to destination with paymentID */
-    std::tuple<Error, Crypto::Hash>
-        sendTransactionBasic(const std::string destination, const uint64_t amount, const std::string paymentID);
+    std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionBasic(
+        const std::string destination,
+        const uint64_t amount,
+        const std::string paymentID,
+        const bool sendAll = false,
+        const bool sendTransaction = true);
 
     /* Advanced send transaction, specify mixin, change address, etc */
-    std::tuple<Error, Crypto::Hash> sendTransactionAdvanced(
+    std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionAdvanced(
         const std::vector<std::pair<std::string, uint64_t>> destinations,
         const uint64_t mixin,
-        const uint64_t fee,
+        const WalletTypes::FeeType fee,
         const std::string paymentID,
         const std::vector<std::string> subWalletsToTakeFrom,
         const std::string changeAddress,
         const uint64_t unlockTime,
-        const std::vector<uint8_t> extraData);
+        const std::vector<uint8_t> extraData,
+        const bool sendAll = false,
+        const bool sendTransaction = true);
 
     /* Send a fusion using default mixin, default destination, and
        taking from all subwallets */

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -129,6 +129,7 @@ class WalletBackend
         const bool daemonSSL,
         const unsigned int syncThreadCount);
 
+    /* Remove a previously prepared transaction. */
     bool removePreparedTransaction(const Crypto::Hash &transactionHash);
 
     /* Sends a previously prepared transaction to the network */

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -129,9 +129,11 @@ class WalletBackend
         const bool daemonSSL,
         const unsigned int syncThreadCount);
 
+    bool removePreparedTransaction(const Crypto::Hash &transactionHash);
+
     /* Sends a previously prepared transaction to the network */
     std::tuple<Error, Crypto::Hash> sendPreparedTransaction(
-        const WalletTypes::PreparedTransactionInfo &preparedTransaction);
+        const Crypto::Hash transactionHash);
 
     /* Send a transaction of amount to destination with paymentID */
     std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionBasic(
@@ -335,4 +337,7 @@ class WalletBackend
     std::shared_ptr<WalletSynchronizerRAIIWrapper> m_syncRAIIWrapper;
 
     unsigned int m_syncThreadCount;
+
+    /* Prepared, unsent transactions. */
+    std::unordered_map<Crypto::Hash, WalletTypes::PreparedTransactionInfo> m_preparedTransactions;
 };

--- a/src/walletservice/PaymentServiceJsonRpcMessages.cpp
+++ b/src/walletservice/PaymentServiceJsonRpcMessages.cpp
@@ -296,7 +296,7 @@ namespace PaymentService
         serializer(changeAddress, "changeAddress");
 
         uint64_t fixedFee;
-        uint64_t feePerByte;
+        double feePerByte;
 
         if (serializer(fixedFee, "fee"))
         {
@@ -341,7 +341,7 @@ namespace PaymentService
         serializer(changeAddress, "changeAddress");
 
         uint64_t fixedFee;
-        uint64_t feePerByte;
+        double feePerByte;
 
         if (!serializer(fixedFee, "fee"))
         {

--- a/src/walletservice/PaymentServiceJsonRpcMessages.cpp
+++ b/src/walletservice/PaymentServiceJsonRpcMessages.cpp
@@ -295,9 +295,16 @@ namespace PaymentService
 
         serializer(changeAddress, "changeAddress");
 
-        if (!serializer(fee, "fee"))
+        uint64_t fixedFee;
+        uint64_t feePerByte;
+
+        if (serializer(fixedFee, "fee"))
         {
-            throw RequestSerializationError();
+            fee = WalletTypes::FeeType::FixedFee(fixedFee);
+        }
+        else if (serializer(feePerByte, "feePerByte"))
+        {
+            fee = WalletTypes::FeeType::FeePerByte(feePerByte);
         }
 
         if (!serializer(anonymity, "anonymity"))
@@ -319,6 +326,7 @@ namespace PaymentService
     void SendTransaction::Response::serialize(CryptoNote::ISerializer &serializer)
     {
         serializer(transactionHash, "transactionHash");
+        serializer(fee, "fee");
     }
 
     void CreateDelayedTransaction::Request::serialize(CryptoNote::ISerializer &serializer, const WalletService &service)
@@ -332,9 +340,16 @@ namespace PaymentService
 
         serializer(changeAddress, "changeAddress");
 
-        if (!serializer(fee, "fee"))
+        uint64_t fixedFee;
+        uint64_t feePerByte;
+
+        if (!serializer(fixedFee, "fee"))
         {
-            throw RequestSerializationError();
+            fee = WalletTypes::FeeType::FixedFee(fixedFee);
+        }
+        else if (!serializer(feePerByte, "feePerByte"))
+        {
+            fee = WalletTypes::FeeType::FeePerByte(feePerByte);
         }
 
         if (!serializer(anonymity, "anonymity"))
@@ -356,6 +371,7 @@ namespace PaymentService
     void CreateDelayedTransaction::Response::serialize(CryptoNote::ISerializer &serializer)
     {
         serializer(transactionHash, "transactionHash");
+        serializer(fee, "fee");
     }
 
     void GetDelayedTransactionHashes::Request::serialize(CryptoNote::ISerializer &serializer) {}

--- a/src/walletservice/PaymentServiceJsonRpcMessages.h
+++ b/src/walletservice/PaymentServiceJsonRpcMessages.h
@@ -11,6 +11,7 @@
 #include <exception>
 #include <limits>
 #include <vector>
+#include <WalletTypes.h>
 
 namespace PaymentService
 {
@@ -418,7 +419,7 @@ namespace PaymentService
 
             std::string changeAddress;
 
-            uint64_t fee = 0;
+            WalletTypes::FeeType fee = WalletTypes::FeeType::MinimumFee();
 
             uint64_t anonymity;
 
@@ -434,6 +435,7 @@ namespace PaymentService
         struct Response
         {
             std::string transactionHash;
+            uint64_t fee;
 
             void serialize(CryptoNote::ISerializer &serializer);
         };
@@ -449,7 +451,7 @@ namespace PaymentService
 
             std::string changeAddress;
 
-            uint64_t fee = 0;
+            WalletTypes::FeeType fee = WalletTypes::FeeType::MinimumFee();
 
             uint64_t anonymity;
 
@@ -465,6 +467,7 @@ namespace PaymentService
         struct Response
         {
             std::string transactionHash;
+            uint64_t fee;
 
             void serialize(CryptoNote::ISerializer &serializer);
         };

--- a/src/walletservice/PaymentServiceJsonRpcServer.cpp
+++ b/src/walletservice/PaymentServiceJsonRpcServer.cpp
@@ -391,14 +391,14 @@ namespace PaymentService
         SendTransaction::Request &request,
         SendTransaction::Response &response)
     {
-        return service.sendTransaction(request, response.transactionHash);
+        return service.sendTransaction(request, response.transactionHash, response.fee);
     }
 
     std::error_code PaymentServiceJsonRpcServer::handleCreateDelayedTransaction(
         CreateDelayedTransaction::Request &request,
         CreateDelayedTransaction::Response &response)
     {
-        return service.createDelayedTransaction(request, response.transactionHash);
+        return service.createDelayedTransaction(request, response.transactionHash, response.fee);
     }
 
     std::error_code PaymentServiceJsonRpcServer::handleGetDelayedTransactionHashes(

--- a/src/walletservice/WalletService.cpp
+++ b/src/walletservice/WalletService.cpp
@@ -1219,7 +1219,7 @@ namespace PaymentService
         return std::error_code();
     }
 
-    std::error_code WalletService::sendTransaction(SendTransaction::Request &request, std::string &transactionHash)
+    std::error_code WalletService::sendTransaction(SendTransaction::Request &request, std::string &transactionHash, uint64_t &fee)
     {
         try
         {
@@ -1309,7 +1309,11 @@ namespace PaymentService
             sendParams.changeDestination = request.changeAddress;
 
             size_t transactionId = wallet.transfer(sendParams);
-            transactionHash = Common::podToHex(wallet.getTransaction(transactionId).hash);
+            const auto tx = wallet.getTransaction(transactionId);
+
+            /* Set output parameters */
+            transactionHash = Common::podToHex(tx.hash);
+            fee = tx.fee;
 
             logger(Logging::DEBUGGING) << "Transaction " << transactionHash << " has been sent";
         }
@@ -1329,7 +1333,8 @@ namespace PaymentService
 
     std::error_code WalletService::createDelayedTransaction(
         CreateDelayedTransaction::Request &request,
-        std::string &transactionHash)
+        std::string &transactionHash,
+        uint64_t &fee)
     {
         try
         {
@@ -1411,7 +1416,12 @@ namespace PaymentService
             sendParams.changeDestination = request.changeAddress;
 
             size_t transactionId = wallet.makeTransaction(sendParams);
-            transactionHash = Common::podToHex(wallet.getTransaction(transactionId).hash);
+
+            const auto tx = wallet.getTransaction(transactionId);
+
+            /* Set output parameters */
+            transactionHash = Common::podToHex(tx.hash);
+            fee = tx.fee;
 
             logger(Logging::DEBUGGING) << "Delayed transaction " << transactionHash << " has been created";
         }

--- a/src/walletservice/WalletService.h
+++ b/src/walletservice/WalletService.h
@@ -143,10 +143,15 @@ namespace PaymentService
 
         std::error_code getAddresses(std::vector<std::string> &addresses);
 
-        std::error_code sendTransaction(SendTransaction::Request &request, std::string &transactionHash);
+        std::error_code sendTransaction(
+            SendTransaction::Request &request,
+            std::string &transactionHash,
+            uint64_t &fee);
 
-        std::error_code
-            createDelayedTransaction(CreateDelayedTransaction::Request &request, std::string &transactionHash);
+        std::error_code createDelayedTransaction(
+            CreateDelayedTransaction::Request &request,
+            std::string &transactionHash,
+            uint64_t &fee);
 
         std::error_code getDelayedTransactionHashes(std::vector<std::string> &transactionHashes);
 

--- a/src/zedwallet++/Transfer.cpp
+++ b/src/zedwallet++/Transfer.cpp
@@ -214,7 +214,7 @@ void sendTransaction(
 
     Crypto::Hash hash;
 
-    std::tie(error, hash) = walletBackend->sendPreparedTransaction(preparedTransaction);
+    std::tie(error, hash) = walletBackend->sendPreparedTransaction(preparedTransaction.transactionHash);
 
     if (error)
     {

--- a/src/zedwallet++/Transfer.cpp
+++ b/src/zedwallet++/Transfer.cpp
@@ -36,31 +36,14 @@ void transfer(const std::shared_ptr<WalletBackend> walletBackend, const bool sen
        safely */
     const auto [nodeFee, nodeAddress] = walletBackend->getNodeFee();
 
-    const uint64_t fee = WalletConfig::defaultFee;
-
-    int64_t fundsRemainingAfterFee = unlockedBalance - nodeFee - fee;
-
-    /* Verify that we have enough balance to send the network fee and node fee
-     * when sending all. Don't really need to check for <= 0, but helps to be
-     * safe. */
-    if (sendAll && (fundsRemainingAfterFee <= static_cast<int64_t>(WalletConfig::minimumSend) || fundsRemainingAfterFee <= 0))
-    {
-        std::cout << WarningMsg("You don't have enough funds to cover "
-                                "this transaction!\n\n")
-                  << "Funds needed: " << InformationMsg(Utilities::formatAmount(fee + nodeFee + WalletConfig::minimumSend))
-                  << " (Includes a network fee of " << InformationMsg(Utilities::formatAmount(fee))
-                  << " and a node fee of " << InformationMsg(Utilities::formatAmount(nodeFee))
-                  << ")\nFunds available: " << SuccessMsg(Utilities::formatAmount(unlockedBalance)) << "\n\n";
-
-        return cancel();
-    }
-
+    
     std::string address =
         getAddress("What address do you want to transfer to?: ", integratedAddressesAllowed, cancelAllowed);
 
     if (address == "cancel")
     {
-        return cancel();
+        cancel();
+        return;
     }
 
     std::cout << "\n";
@@ -76,14 +59,17 @@ void transfer(const std::shared_ptr<WalletBackend> walletBackend, const bool sen
 
         if (paymentID == "cancel")
         {
-            return cancel();
+            cancel();
+            return;
         }
 
         std::cout << "\n";
     }
 
-    /* Default amount if we're sending everything */
-    uint64_t amount = static_cast<uint64_t>(fundsRemainingAfterFee);
+    /* If we're using send all, then we'll work out the max in the WalletBackend
+     * code, since we need to take into account fee per byte. For now, we'll
+     * just set the amount to all balance minus nodeFee. */
+    uint64_t amount = unlockedBalance - nodeFee;
     
     if (!sendAll)
     {
@@ -96,18 +82,33 @@ void transfer(const std::shared_ptr<WalletBackend> walletBackend, const bool sen
 
         if (!success)
         {
-            return cancel();
+            cancel();
+            return;
         }
     }
 
-    sendTransaction(walletBackend, address, amount, paymentID);
+    if (nodeFee >= unlockedBalance && sendAll)
+    {
+        std::cout << WarningMsg("\nYou don't have enough funds to cover "
+                                "this transaction!\n\n")
+                  << "Funds needed: " << InformationMsg(Utilities::formatAmount(nodeFee + WalletConfig::minimumSend))
+                  << " (Includes a node fee of " << InformationMsg(Utilities::formatAmount(nodeFee))
+                  << ")\nFunds available: " << SuccessMsg(Utilities::formatAmount(unlockedBalance)) << "\n\n";
+
+        cancel();
+
+        return;
+    }
+
+    sendTransaction(walletBackend, address, amount, paymentID, sendAll);
 }
 
 void sendTransaction(
     const std::shared_ptr<WalletBackend> walletBackend,
     const std::string address,
     const uint64_t amount,
-    const std::string paymentID)
+    const std::string paymentID,
+    const bool sendAll)
 {
     const auto unlockedBalance = walletBackend->getTotalUnlockedBalance();
 
@@ -115,40 +116,55 @@ void sendTransaction(
        safely */
     const auto [nodeFee, nodeAddress] = walletBackend->getNodeFee();
 
-    const uint64_t fee = WalletConfig::defaultFee;
-
-    /* The total balance required with fees added */
-    const uint64_t total = amount + nodeFee + fee;
+    /* The total balance required with fees added (Doesn't include network
+     * fee, since that's done per byte and is hard to guess) */
+    const uint64_t total = amount + nodeFee;
 
     if (total > unlockedBalance)
     {
         std::cout << WarningMsg("\nYou don't have enough funds to cover "
                                 "this transaction!\n\n")
-                  << "Funds needed: " << InformationMsg(Utilities::formatAmount(amount + fee + nodeFee))
-                  << " (Includes a network fee of " << InformationMsg(Utilities::formatAmount(fee))
-                  << " and a node fee of " << InformationMsg(Utilities::formatAmount(nodeFee))
+                  << "Funds needed: " << InformationMsg(Utilities::formatAmount(amount + nodeFee))
+                  << " (Includes a node fee of " << InformationMsg(Utilities::formatAmount(nodeFee))
                   << ")\nFunds available: " << SuccessMsg(Utilities::formatAmount(unlockedBalance)) << "\n\n";
 
-        return cancel();
-    }
+        cancel();
 
-    if (!confirmTransaction(walletBackend, address, amount, paymentID, nodeFee))
-    {
-        return cancel();
+        return;
     }
 
     Error error;
+    WalletTypes::PreparedTransactionInfo preparedTransaction;
 
-    Crypto::Hash hash;
+    std::tie(error, std::ignore, preparedTransaction) = walletBackend->sendTransactionBasic(
+        address,
+        amount,
+        paymentID,
+        sendAll,
+        false /* Don't relay to network */
+    );
 
-    std::tie(error, hash) = walletBackend->sendTransactionBasic(address, amount, paymentID);
+    if (error == NOT_ENOUGH_BALANCE)
+    {
+        const uint64_t actualAmount = sendAll ? WalletConfig::minimumSend : amount;
 
-    if (error == TOO_MANY_INPUTS_TO_FIT_IN_BLOCK)
+        std::cout << WarningMsg("\nYou don't have enough funds to cover "
+                                "this transaction!\n\n")
+                  << "Funds needed: " << InformationMsg(Utilities::formatAmount(actualAmount + preparedTransaction.fee + nodeFee))
+                  << " (Includes a network fee of " << InformationMsg(Utilities::formatAmount(preparedTransaction.fee))
+                  << " and a node fee of " << InformationMsg(Utilities::formatAmount(nodeFee))
+                  << ")\nFunds available: " << SuccessMsg(Utilities::formatAmount(unlockedBalance)) << "\n\n";
+
+        cancel();
+
+        return;
+    }
+    else if (error == TOO_MANY_INPUTS_TO_FIT_IN_BLOCK)
     {
         std::cout << WarningMsg("Your transaction is too large to be accepted "
                                 "by the network!\n")
                   << InformationMsg("We're attempting to optimize your wallet,\n"
-                                    "which hopefully make the transaction small "
+                                    "which hopefully will make the transaction small "
                                     "enough to fit in a block.\n"
                                     "Please wait, this will take some time...\n\n");
 
@@ -156,12 +172,24 @@ void sendTransaction(
         optimize(walletBackend);
 
         /* Resend the transaction */
-        std::tie(error, hash) = walletBackend->sendTransactionBasic(address, amount, paymentID);
+        std::tie(error, std::ignore, preparedTransaction) = walletBackend->sendTransactionBasic(
+            address,
+            amount,
+            paymentID,
+            sendAll,
+            false /* Don't relay to network */
+        );
 
         /* Still too big, split it up (with users approval) */
         if (error == TOO_MANY_INPUTS_TO_FIT_IN_BLOCK)
         {
-            splitTX(walletBackend, address, amount, paymentID);
+            std::cout << WarningMsg(
+                "Your transaction is still too large to be accepted "
+                "by the network. Try splitting your transaction up into smaller "
+                "amounts.");
+
+            cancel();
+
             return;
         }
     }
@@ -169,134 +197,32 @@ void sendTransaction(
     if (error)
     {
         std::cout << WarningMsg("Failed to send transaction: ") << WarningMsg(error) << std::endl;
+        return;
+    }
+
+    /* Figure out the actual amount if we're performing a send_all now we have
+     * the fee worked out. */
+    const uint64_t actualAmount = sendAll
+        ? unlockedBalance - nodeFee - preparedTransaction.fee
+        : amount;
+
+    if (!confirmTransaction(walletBackend, address, actualAmount, paymentID, nodeFee, preparedTransaction.fee))
+    {
+        cancel();
+        return;
+    }
+
+    Crypto::Hash hash;
+
+    std::tie(error, hash) = walletBackend->sendPreparedTransaction(preparedTransaction);
+
+    if (error)
+    {
+        std::cout << WarningMsg("Failed to send transaction: ") << WarningMsg(error) << std::endl;
     }
     else
     {
-        std::cout << SuccessMsg("Transaction has been sent!\nHash: ") << SuccessMsg(hash) << "\n";
-    }
-}
-
-void splitTX(
-    const std::shared_ptr<WalletBackend> walletBackend,
-    const std::string address,
-    const uint64_t amount,
-    const std::string paymentID)
-{
-    std::cout << InformationMsg("Transaction is still too large to send, splitting into "
-                                "multiple chunks.\n\n")
-              << WarningMsg("It will slightly raise the fee you have to pay,\n"
-                            "and hence reduce the total amount you can send if\n"
-                            "your balance cannot cover it.\n\n"
-                            "If the node you are using charges a fee,\nyou will "
-                            "have to pay this fee for each transction.\n");
-
-    if (!Utilities::confirm("Is this OK?"))
-    {
-        return cancel();
-    }
-
-    uint64_t unlockedBalance = walletBackend->getTotalUnlockedBalance();
-
-    uint64_t totalAmount = amount;
-    uint64_t sentAmount = 0;
-    uint64_t remainder = totalAmount - sentAmount;
-
-    /* How much to split the remaining balance to be sent into each individual
-       transaction. If it's 1, then we'll attempt to send the full amount,
-       if it's 2, we'll send half, and so on. */
-    uint64_t amountDivider = 1;
-
-    int txNumber = 1;
-
-    const auto [nodeFee, nodeAddress] = walletBackend->getNodeFee();
-
-    while (true)
-    {
-        uint64_t splitAmount = remainder / amountDivider;
-
-        /* If we have odd numbers, we can have an amount that is smaller
-           than the remainder to send, but the remainder is less than
-           2 * amount.
-           So, we include this amount in our current transaction to prevent
-           this change not being sent.
-           If we're trying to send more than the remaining amount, set to
-           the remaining amount. */
-        if (splitAmount != remainder && remainder < (splitAmount * 2))
-        {
-            splitAmount = remainder;
-        }
-
-        uint64_t totalNeeded = splitAmount + WalletConfig::minimumFee + nodeFee;
-
-        /* Don't have enough to cover the full transfer, just send as much
-           as we can (deduct fees which will be added later) */
-        if (totalNeeded > unlockedBalance)
-        {
-            totalNeeded = unlockedBalance - WalletConfig::minimumFee - nodeFee;
-            splitAmount = totalNeeded - WalletConfig::minimumFee + nodeFee;
-        }
-
-        if (splitAmount < WalletConfig::minimumSend)
-        {
-            std::cout << WarningMsg("Failed to split up transaction, sorry.\n");
-            return;
-        }
-
-        /* Balance is going to get locked as we send, wait for it to unlock
-           and then send */
-        while (walletBackend->getTotalUnlockedBalance() < totalNeeded)
-        {
-            std::cout << WarningMsg("Waiting for balance to unlock to send "
-                                    "next transaction.\n"
-                                    "Will try again in 15 seconds...\n\n");
-
-            std::this_thread::sleep_for(std::chrono::seconds(15));
-        }
-
-        const auto [error, hash] = walletBackend->sendTransactionBasic(address, splitAmount, paymentID);
-
-        /* Still too big, reduce amount */
-        if (error == TOO_MANY_INPUTS_TO_FIT_IN_BLOCK)
-        {
-            amountDivider *= 2;
-
-            /* This can take quite a long time getting mixins each time
-               so let them know it's not frozen */
-            std::cout << InformationMsg("Working...\n");
-
-            continue;
-        }
-        else if (error)
-        {
-            std::cout << WarningMsg("Failed to send transaction: ") << error << "\nAborting, sorry...";
-            return;
-        }
-
-        std::stringstream stream;
-
-        stream << "Transaction number " << txNumber << " has been sent!\nHash: " << hash
-               << "\nAmount: " << Utilities::formatAmount(splitAmount) << "\n\n";
-
-        std::cout << SuccessMsg(stream.str()) << std::endl;
-
-        txNumber++;
-
-        sentAmount += splitAmount;
-
-        /* Remember to remove the fee and node fee as well from balance */
-        unlockedBalance -= splitAmount - WalletConfig::minimumFee - nodeFee;
-
-        remainder = totalAmount - sentAmount;
-
-        /* We've sent the full amount required now */
-        if (sentAmount == totalAmount)
-        {
-            std::cout << InformationMsg("All transactions have been sent!\n");
-            return;
-        }
-
-        /* Went well, revert to original divider */
-        amountDivider = 1;
+        std::cout << SuccessMsg("Transaction has been sent!\nHash: ") << SuccessMsg(hash) << std::endl;
     }
 }
 
@@ -305,13 +231,17 @@ bool confirmTransaction(
     const std::string address,
     const uint64_t amount,
     const std::string paymentID,
-    const uint64_t nodeFee)
+    const uint64_t nodeFee,
+    const uint64_t fee)
 {
     std::cout << InformationMsg("\nConfirm Transaction?\n");
 
+    const uint64_t totalAmount = amount + fee + nodeFee;
+
     std::cout << "You are sending " << SuccessMsg(Utilities::formatAmount(amount)) << ", with a network fee of "
-              << SuccessMsg(Utilities::formatAmount(WalletConfig::defaultFee)) << ",\nand a node fee of "
-              << SuccessMsg(Utilities::formatAmount(nodeFee));
+              << SuccessMsg(Utilities::formatAmount(fee)) << ",\nand a node fee of "
+              << SuccessMsg(Utilities::formatAmount(nodeFee))
+              << ", for a total of " << SuccessMsg(Utilities::formatAmount(totalAmount));
 
     if (paymentID != "")
     {

--- a/src/zedwallet++/Transfer.h
+++ b/src/zedwallet++/Transfer.h
@@ -12,17 +12,13 @@ void sendTransaction(
     const std::shared_ptr<WalletBackend> walletBackend,
     const std::string address,
     const uint64_t amount,
-    const std::string paymentID);
-
-void splitTX(
-    const std::shared_ptr<WalletBackend> walletBackend,
-    const std::string address,
-    const uint64_t amount,
-    const std::string paymentID);
+    const std::string paymentID,
+    const bool sendAll = false);
 
 bool confirmTransaction(
     const std::shared_ptr<WalletBackend> walletBackend,
     const std::string address,
     const uint64_t amount,
     const std::string paymentID,
-    const uint64_t nodeFee);
+    const uint64_t nodeFee,
+    const uint64_t fee);


### PR DESCRIPTION
#### TODO:
* ~Input ordering for WalletBackend - Suggested method is picking from increasing base10 buckets in order, then wrapping back again to the smallest bucket till amount is fulfilled. This should allow a decent diversity of inputs, while allowing large transactions to be fulfilled and transaction estimates to be relatively accurate.~ Done

* Testing for edge cases

* Testing prepared/delayed transactions

* Updating both `wallet-api` and `turtle-service` documentation to mention `feePerByte` parameter, making `fee` parameter optional for `turtle-service`, updating return type to include the fee of the sent transaction.

* ~Optional: Allow fractional fee per byte to make rounder numbers for fees - since currently they are based on the amount of 256 byte chunks, they don't make for very sexy results~ Done

~Note: Currently fee per byte validation is enforced both for sent transactions and pool transactions, instantly. This could potentially be changed, but was done this way both for simpler code, and the suggestion that this may be desired.~ Fake news

By the way - the turtle-service code is kinda shitty. Could probably be simplified, but fuck it, right?