### PR TITLE
Rework output capping

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -209,9 +209,9 @@ namespace CryptoNote
            to help curtail fusion transaction spam. */
         const size_t FUSION_TX_MAX_POOL_COUNT = 20;
 
-        const size_t NORMAL_TX_MAX_OUTPUT_RATIO_V1 = 10;
+        const size_t NORMAL_TX_MAX_OUTPUT_COUNT_V1 = 90;
 
-        const size_t NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT = 2200000;
+        const size_t NORMAL_TX_MAX_OUTPUT_COUNT_V1_HEIGHT = 2200000;
 
         const uint32_t UPGRADE_HEIGHT_V2 = 1;
 

--- a/src/cryptonotecore/TransactionValidationErrors.h
+++ b/src/cryptonotecore/TransactionValidationErrors.h
@@ -127,7 +127,7 @@ namespace CryptoNote
                     case TransactionValidationError::OUTPUT_AMOUNT_TOO_LARGE:
                         return "Transaction has output exceeding max output size";
                     case TransactionValidationError::EXCESSIVE_OUTPUTS:
-                        return "Transaction has an excessive number of outputs for the input count";
+                        return "Transaction has an excessive number of outputs. Reduce the number of payees.";
                     case TransactionValidationError::WRONG_FEE:
                         return "Transaction fee is below minimum fee and is not a fusion transaction";
                     case TransactionValidationError::SIZE_TOO_LARGE:

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -362,13 +362,12 @@ bool ValidateTransaction::validateTransactionExtra()
 
 bool ValidateTransaction::validateInputOutputRatio()
 {
-    if (m_isPoolTransaction || m_blockHeight >= CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1_HEIGHT)
+    if (m_isPoolTransaction || m_blockHeight >= CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_COUNT_V1_HEIGHT)
     {
-        if (m_transaction.outputs.size()
-            > m_transaction.inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
+        if (m_transaction.outputs.size() > CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_COUNT_V1)
         {
             m_validationResult.errorCode = CryptoNote::error::TransactionValidationError::EXCESSIVE_OUTPUTS;
-            m_validationResult.errorMessage = "Transaction has excessive output/input ratio";
+            m_validationResult.errorMessage = "Transaction has excessive outputs. Reduce the number of payees.";
 
             return false;
         }

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -2825,10 +2825,9 @@ namespace CryptoNote
                 make_error_code(error::INTERNAL_WALLET_ERROR), "Failed to deserialize created transaction");
         }
 
-        if (cryptoNoteTransaction.outputs.size() > cryptoNoteTransaction.inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
+        if (cryptoNoteTransaction.outputs.size() > CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_COUNT_V1)
         {
-            m_logger(ERROR, BRIGHT_RED) << "Transaction has an excessive number of outputs "
-                                        << " for the input count";
+            m_logger(ERROR, BRIGHT_RED) << "Transaction has an excessive number of outputs";
 
             throw std::system_error(make_error_code(error::EXCESSIVE_OUTPUTS));
         }

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -1088,10 +1088,9 @@ namespace SendTransaction
            working, maybe we can work some magic. TODO */
         setupTX.outputs = keyOutputToTransactionOutput(result.outputs);
 
-        if (setupTX.outputs.size() > setupTX.inputs.size() * CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_RATIO_V1)
+        if (setupTX.outputs.size() > CryptoNote::parameters::NORMAL_TX_MAX_OUTPUT_COUNT_V1)
         {
             result.error = OUTPUT_DECOMPOSITION;
-
             return result;
         }
 


### PR DESCRIPTION
Update output cap to a fixed `30`. May need some discussion. For example, if paying 5 pool users, with an amount of `12345.67`, that's 7 * 5 outputs = 35, and then some change will of course be needed.