### PR TITLE
Remove invalid transactions from pool when included in block

### DIFF
--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -1148,10 +1148,21 @@ namespace CryptoNote
             uint64_t fee = 0;
             auto transactionValidationResult =
                 validateTransaction(transaction, validatorState, cache, m_transactionValidationThreadPool, fee, previousBlockIndex, false);
+
             if (transactionValidationResult)
             {
-                logger(Logging::DEBUGGING) << "Failed to validate transaction " << transaction.getTransactionHash()
+                const auto hash = transaction.getTransactionHash();
+
+                logger(Logging::DEBUGGING) << "Failed to validate transaction " << hash
                                            << ": " << transactionValidationResult.message();
+
+                if (transactionPool->checkIfTransactionPresent(hash))
+                {
+                    logger(Logging::DEBUGGING) << "Invalid transaction " << hash << " is present in the pool, removing";
+                    transactionPool->removeTransaction(hash);
+                    notifyObservers(makeDelTransactionMessage({hash}, Messages::DeleteTransaction::Reason::NotActual));
+                }
+
                 return transactionValidationResult;
             }
 


### PR DESCRIPTION
To ensure we don't get stuck in a loop where we cannot create blocks because we have a transaction in the pool that was previously valid, but is no longer valid, we should remove invalid transactions from the pool upon failing to add a block containing the tx.