### PR TITLE
Fixes Issue with GH Actions Built Windows Binaries

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -242,6 +242,9 @@ jobs:
           path: clcache
           key: clcache-windows
 
+      - name: Install OpenSSL
+        run: choco install openssl
+
       # Configure project with cmake
       - name: Configure
         run: |


### PR DESCRIPTION
The current GH Actions runners do not include the MSVC compiled copies of the OpenSSL libraries nor do they include the MT versions which are required for static linking under MSVC.

This PR downloads and installs the *full* OpenSSL builds similar to those in the README.md which includes the proper libraries and headers via [Chocolatey](https://chocolatey.org/)