### PR TITLE
Fix Daemon `status` command when using threaded RPC

### DIFF
--- a/src/daemon/Daemon.cpp
+++ b/src/daemon/Daemon.cpp
@@ -253,7 +253,7 @@ int main(int argc, char *argv[])
             {
                 oldLogLevel = Logging::DEBUGGING;
                 logColour = Logging::DEFAULT;
-            } 
+            }
             else if (level == Logger::INFO)
             {
                 oldLogLevel = Logging::INFO;
@@ -442,7 +442,6 @@ int main(int argc, char *argv[])
         );
 
         cprotocol->set_p2p_endpoint(&(*p2psrv));
-        DaemonCommandsHandler dch(*ccore, *p2psrv, logManager, &rpcServer);
         logger(INFO) << "Initializing p2p server...";
         if (!p2psrv->init(netNodeConfig))
         {
@@ -452,15 +451,28 @@ int main(int argc, char *argv[])
 
         logger(INFO) << "P2p server initialized OK";
 
-        if (!config.noConsole)
-        {
-            dch.start_handling();
-        }
-
         // Fire up the RPC Server
         logger(INFO) << "Starting core rpc server on address " << config.rpcInterface << ":" << config.rpcPort;
 
         rpcServer.start();
+
+        /* Get the RPC IP address and port we are bound to */
+        auto [ip, port] = rpcServer.getConnectionInfo();
+
+        /* If we bound the RPC to 0.0.0.0, we can't reach that with a
+           standard HTTP client from anywhere. Instead, let's use the
+           localhost IP address to reach ourselves */
+        if (ip == "0.0.0.0")
+        {
+            ip = "127.0.0.1";
+        }
+
+        DaemonCommandsHandler dch(*ccore, *p2psrv, logManager, ip, port);
+
+        if (!config.noConsole)
+        {
+            dch.start_handling();
+        }
 
         Tools::SignalHandler::install([&dch] {
             dch.exit({});

--- a/src/daemon/DaemonCommandsHandler.cpp
+++ b/src/daemon/DaemonCommandsHandler.cpp
@@ -54,12 +54,13 @@ DaemonCommandsHandler::DaemonCommandsHandler(
     CryptoNote::Core &core,
     CryptoNote::NodeServer &srv,
     std::shared_ptr<Logging::LoggerManager> log,
-    RpcServer *prpc_server):
+    const std::string ip,
+    const uint32_t port):
     m_core(core),
     m_srv(srv),
     logger(log, "daemon"),
     m_logManager(log),
-    m_rpcServer(std::get<0>(prpc_server->getConnectionInfo()).c_str(), std::get<1>(prpc_server->getConnectionInfo()))
+    m_rpcServer(ip.c_str(), port)
 {
     m_consoleHandler.setHandler(
         "?",

--- a/src/daemon/DaemonCommandsHandler.h
+++ b/src/daemon/DaemonCommandsHandler.h
@@ -27,7 +27,8 @@ class DaemonCommandsHandler
         CryptoNote::Core &core,
         CryptoNote::NodeServer &srv,
         std::shared_ptr<Logging::LoggerManager> log,
-        RpcServer *prpc_server);
+        const std::string ip,
+        const uint32_t port);
 
     bool start_handling()
     {
@@ -48,6 +49,8 @@ class DaemonCommandsHandler
     CryptoNote::Core &m_core;
 
     CryptoNote::NodeServer &m_srv;
+
+    httplib::Client m_rpcServer;
 
     Logging::LoggerRef logger;
 
@@ -76,6 +79,4 @@ class DaemonCommandsHandler
     bool print_pool_sh(const std::vector<std::string> &args);
 
     bool status(const std::vector<std::string> &args);
-
-    httplib::Client m_rpcServer;
 };


### PR DESCRIPTION
Resolve issue whereby the `status` command in the daemon does not always return a result

This is due to binding to a non-interface IP (0.0.0.0) and the fact that we cannot make HTTP calls to 0.0.0.0 reliably and should specify an IP address to issue the RPC calls against. This commit simply replaces 0.0.0.0 with 127.0.0.1 (localhost) for purposes of routing the client RPC request. In addition, creates the http client in the method scope instead of at the class level as I did encounter a few race conditions whereby the commands handler was somehow initializing before the RpcServer instance was able to return the correct port(s).