### PR TITLE
Fix turtle-service log levels not working as expected

### DIFF
--- a/src/walletservice/PaymentGateService.cpp
+++ b/src/walletservice/PaymentGateService.cpp
@@ -64,6 +64,9 @@ bool PaymentGateService::init(int argc, char **argv)
     }
 
     logger->setMaxLevel(static_cast<Logging::Level>(config.serviceConfig.logLevel));
+    consoleLogger.setMaxLevel(static_cast<Logging::Level>(config.serviceConfig.logLevel));
+    fileLogger.setMaxLevel(static_cast<Logging::Level>(config.serviceConfig.logLevel));
+
     logger->setPattern("%D %T %L ");
     logger->addLogger(consoleLogger);
 


### PR DESCRIPTION
The `--log-level` option should be applied to both the log file and the console.