### PR TITLE
NodeRpcProxy HTTP Method Fixes

### DIFF
--- a/src/http/HttpRequest.cpp
+++ b/src/http/HttpRequest.cpp
@@ -46,6 +46,11 @@ namespace CryptoNote
         }
     }
 
+    void HttpRequest::setMethod(const std::string &value)
+    {
+        method = value;
+    }
+
     void HttpRequest::setUrl(const std::string &u)
     {
         url = u;
@@ -53,7 +58,7 @@ namespace CryptoNote
 
     std::ostream &HttpRequest::printHttpRequest(std::ostream &os) const
     {
-        os << "POST " << url << " HTTP/1.1\r\n";
+        os << method << " " << url << " HTTP/1.1\r\n";
         auto host = headers.find("Host");
         if (host == headers.end())
         {

--- a/src/http/HttpRequest.h
+++ b/src/http/HttpRequest.h
@@ -28,12 +28,14 @@ namespace CryptoNote
 
         void setBody(const std::string &b);
 
+        void setMethod(const std::string &value);
+
         void setUrl(const std::string &uri);
 
       private:
         friend class HttpParser;
 
-        std::string method;
+        std::string method = "POST";
 
         std::string url;
 

--- a/src/noderpcproxy/NodeRpcProxy.cpp
+++ b/src/noderpcproxy/NodeRpcProxy.cpp
@@ -295,7 +295,7 @@ namespace CryptoNote
         CryptoNote::COMMAND_RPC_GET_INFO::request getInfoReq = AUTO_VAL_INIT(getInfoReq);
         CryptoNote::COMMAND_RPC_GET_INFO::response getInfoResp = AUTO_VAL_INIT(getInfoResp);
 
-        ec = jsonCommand("/info", getInfoReq, getInfoResp);
+        ec = jsonCommand("/info", "GET", getInfoReq, getInfoResp);
         if (!ec)
         {
             // a quirk to let wallets work with previous versions daemons.
@@ -352,7 +352,7 @@ namespace CryptoNote
         CryptoNote::COMMAND_RPC_GET_FEE_ADDRESS::request ireq = AUTO_VAL_INIT(ireq);
         CryptoNote::COMMAND_RPC_GET_FEE_ADDRESS::response iresp = AUTO_VAL_INIT(iresp);
 
-        std::error_code ec = jsonCommand("/fee", ireq, iresp);
+        std::error_code ec = jsonCommand("/fee", "GET", ireq, iresp);
 
         if (ec || iresp.status != CORE_RPC_STATUS_OK)
         {
@@ -622,7 +622,7 @@ namespace CryptoNote
         COMMAND_RPC_SEND_RAW_TX::response rsp;
         req.tx_as_hex = toHex(toBinaryArray(transaction));
         m_logger(TRACE) << "NodeRpcProxy::doRelayTransaction, tx hex " << req.tx_as_hex;
-        return jsonCommand("/sendrawtransaction", req, rsp);
+        return jsonCommand("/sendrawtransaction", "POST", req, rsp);
     }
 
     std::error_code NodeRpcProxy::doGetRandomOutsByAmounts(
@@ -636,7 +636,7 @@ namespace CryptoNote
         req.outs_count = outsCount;
 
         m_logger(TRACE) << "Send getrandom_outs request";
-        std::error_code ec = jsonCommand("/getrandom_outs", req, rsp);
+        std::error_code ec = jsonCommand("/getrandom_outs", "POST", req, rsp);
         if (!ec)
         {
             m_logger(TRACE) << "getrandom_outs complete";
@@ -659,7 +659,7 @@ namespace CryptoNote
         req.txid = transactionHash;
 
         m_logger(TRACE) << "Send get_o_indexes request, transaction " << req.txid;
-        std::error_code ec = jsonCommand("/get_o_indexes", req, rsp);
+        std::error_code ec = jsonCommand("/get_o_indexes", "POST", req, rsp);
         if (!ec)
         {
             m_logger(TRACE) << "get_o_indexes complete";
@@ -690,7 +690,7 @@ namespace CryptoNote
 
         m_logger(TRACE) << "Send get_global_indexes_for_range request";
 
-        std::error_code ec = jsonCommand("/get_global_indexes_for_range", req, rsp);
+        std::error_code ec = jsonCommand("/get_global_indexes_for_range", "POST", req, rsp);
 
         if (!ec)
         {
@@ -719,7 +719,7 @@ namespace CryptoNote
 
         m_logger(TRACE) << "Send get_transactions_status request";
 
-        std::error_code ec = jsonCommand("/get_transactions_status", req, rsp);
+        std::error_code ec = jsonCommand("/get_transactions_status", "POST", req, rsp);
 
         if (!ec)
         {
@@ -750,7 +750,7 @@ namespace CryptoNote
         req.timestamp = timestamp;
 
         m_logger(TRACE) << "Send queryblockslite request, timestamp " << req.timestamp;
-        std::error_code ec = jsonCommand("/queryblockslite", req, rsp);
+        std::error_code ec = jsonCommand("/queryblockslite", "POST", req, rsp);
         if (ec)
         {
             m_logger(TRACE) << "queryblockslite failed: " << ec << ", " << ec.message();
@@ -807,7 +807,7 @@ namespace CryptoNote
         m_logger(TRACE) << "Send getwalletsyncdata request, start timestamp: " << req.startTimestamp
                         << ", start height: " << req.startHeight;
 
-        std::error_code ec = jsonCommand("/getwalletsyncdata", req, rsp);
+        std::error_code ec = jsonCommand("/getwalletsyncdata", "POST", req, rsp);
         if (ec)
         {
             m_logger(TRACE) << "getwalletsyncdata failed: " << ec << ", " << ec.message();
@@ -835,7 +835,7 @@ namespace CryptoNote
         req.knownTxsIds = knownPoolTxIds;
 
         m_logger(TRACE) << "Send get_pool_changes_lite request, tailBlockId " << req.tailBlockId;
-        std::error_code ec = jsonCommand("/get_pool_changes_lite", req, rsp);
+        std::error_code ec = jsonCommand("/get_pool_changes_lite", "POST", req, rsp);
 
         if (ec)
         {
@@ -946,7 +946,7 @@ namespace CryptoNote
     }
 
     template<typename Request, typename Response>
-    std::error_code NodeRpcProxy::jsonCommand(const std::string &url, const Request &req, Response &res)
+    std::error_code NodeRpcProxy::jsonCommand(const std::string &url, const std::string &method, const Request &req, Response &res)
     {
         std::error_code ec;
 
@@ -954,7 +954,7 @@ namespace CryptoNote
         {
             m_logger(TRACE) << "Send " << url << " JSON request";
             EventLock eventLock(*m_httpEvent);
-            invokeJsonCommand(*m_httpClient, url, req, res);
+            invokeJsonCommand(*m_httpClient, url, method, req, res);
             ec = interpretResponseStatus(res.status);
         }
         catch (const ConnectException &)

--- a/src/noderpcproxy/NodeRpcProxy.h
+++ b/src/noderpcproxy/NodeRpcProxy.h
@@ -216,7 +216,7 @@ namespace CryptoNote
         std::error_code binaryCommand(const std::string &url, const Request &req, Response &res);
 
         template<typename Request, typename Response>
-        std::error_code jsonCommand(const std::string &url, const Request &req, Response &res);
+        std::error_code jsonCommand(const std::string &url, const std::string &method, const Request &req, Response &res);
 
         template<typename Request, typename Response>
         std::error_code jsonRpcCommand(const std::string &method, const Request &req, Response &res);

--- a/src/rpc/HttpClient.h
+++ b/src/rpc/HttpClient.h
@@ -55,7 +55,7 @@ namespace CryptoNote
     };
 
     template<typename Request, typename Response>
-    void invokeJsonCommand(HttpClient &client, const std::string &url, const Request &req, Response &res)
+    void invokeJsonCommand(HttpClient &client, const std::string &url, const std::string &method, const Request &req, Response &res)
     {
         HttpRequest hreq;
         HttpResponse hres;
@@ -69,7 +69,14 @@ namespace CryptoNote
         hreq.addHeader("User-Agent", userAgent.str());
 
         hreq.setUrl(url);
-        hreq.setBody(storeToJson(req));
+
+        hreq.setMethod(method);
+
+        if (method == "POST")
+        {
+            hreq.setBody(storeToJson(req));
+        }
+
         client.request(hreq, hres);
 
         if (hres.getStatus() != HttpResponse::STATUS_200)


### PR DESCRIPTION
Threaded RPC requires the use of the proper HTTP method verbs in the requests. This adjusts NodeRpcProxy to use them correctly.