### PR TITLE
Fix Legacy RPC Responses Containing Raw TX_EXTRA

### DIFF
--- a/src/rpc/RpcServer.cpp
+++ b/src/rpc/RpcServer.cpp
@@ -2308,7 +2308,7 @@ std::tuple<Error, uint16_t> RpcServer::queryBlocksLite(
                             writer.StartObject();
                             {
                                 writer.Key("extra");
-                                writer.String(Common::podToHex(prefix.txPrefix.extra));
+                                writer.String(Common::toHex(prefix.txPrefix.extra));
 
                                 writer.Key("unlock_time");
                                 writer.Uint64(prefix.txPrefix.unlockTime);
@@ -2552,7 +2552,7 @@ std::tuple<Error, uint16_t> RpcServer::getPoolChanges(
                 writer.StartObject();
                 {
                     writer.Key("extra");
-                    writer.String(Common::podToHex(prefix.txPrefix.extra));
+                    writer.String(Common::toHex(prefix.txPrefix.extra));
 
                     writer.Key("unlock_time");
                     writer.Uint64(prefix.txPrefix.unlockTime);


### PR DESCRIPTION
This corrects an issue whereby the extra data of a transaction in legacy RPC methods was being improperly encoded after the Threaded RPC was implemented which caused problems with various applications properly syncing the chain from the daemon.