### PR TITLE
/getblocktemplate invalid returned offset

### DIFF
--- a/src/rpc/RpcServer.cpp
+++ b/src/rpc/RpcServer.cpp
@@ -1154,7 +1154,7 @@ std::tuple<Error, uint16_t> RpcServer::getBlockTemplate(
 
         /* The reserved offset is past the transactionPublicKey, then past
          * the extra nonce tags */
-        reservedOffset = (it - blockBlob.begin()) + sizeof(transactionPublicKey) + 3;
+        reservedOffset = (it - blockBlob.begin()) + sizeof(transactionPublicKey) + 2;
 
         if (reservedOffset + reserveSize > blockBlob.size())
         {


### PR DESCRIPTION
Resolves #992

Since we switched from:

```c
res.reserved_offset = slow_memmem((void *)block_blob.data(), block_blob.size(), 
    &tx_pub_key, sizeof(tx_pub_key));

res.reserved_offset += sizeof(tx_pub_key) + 3;
```

to:

```c
const auto transactionPublicKey = Utilities::getTransactionPublicKeyFromExtra(
    blockTemplate.baseTransaction.extra
);

const auto it = std::search(
    blockBlob.begin(),
    blockBlob.end(),
    std::begin(transactionPublicKey.data),
    std::end(transactionPublicKey.data)
);
```

This is no longer +3, it's +2 -- because the iterator advanced farther than the previous value