### PR TITLE
Allow parallel send transaction requests to not interfere with each other

### DIFF
--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -777,6 +777,8 @@ bool WalletBackend::removePreparedTransaction(const Crypto::Hash &transactionHas
 std::tuple<Error, Crypto::Hash> WalletBackend::sendPreparedTransaction(
     const Crypto::Hash transactionHash)
 {
+    std::scoped_lock lock(m_transactionMutex);
+
     auto it = m_preparedTransactions.find(transactionHash);
 
     if (it == m_preparedTransactions.end())
@@ -811,6 +813,8 @@ std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> WalletBack
     const bool sendAll,
     const bool sendTransaction)
 {
+    std::scoped_lock lock(m_transactionMutex);
+
     const auto [error, hash, preparedTransaction] = SendTransaction::sendTransactionBasic(
         destination,
         amount,
@@ -841,6 +845,8 @@ std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> WalletBack
     const bool sendAll,
     const bool sendTransaction)
 {
+    std::scoped_lock lock(m_transactionMutex);
+
     const auto [error, hash, preparedTransaction] = SendTransaction::sendTransactionAdvanced(
         destinations,
         mixin,
@@ -866,6 +872,8 @@ std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> WalletBack
 
 std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionBasic()
 {
+    std::scoped_lock lock(m_transactionMutex);
+
     return SendTransaction::sendFusionTransactionBasic(m_daemon, m_subWallets);
 }
 
@@ -875,6 +883,8 @@ std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionAdvanced(
     const std::string destination,
     const std::vector<uint8_t> extraData)
 {
+    std::scoped_lock lock(m_transactionMutex);
+
     return SendTransaction::sendFusionTransactionAdvanced(
         mixin, subWalletsToTakeFrom, destination, m_daemon, m_subWallets, extraData);
 }

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -341,4 +341,7 @@ class WalletBackend
 
     /* Prepared, unsent transactions. */
     std::unordered_map<Crypto::Hash, WalletTypes::PreparedTransactionInfo> m_preparedTransactions;
+
+    /* Ensure we only send one transaction in parallel, otherwise txs will likely fail. */
+    std::mutex m_transactionMutex;
 };


### PR DESCRIPTION
If you repeatedly call /transactions/send/basic or advanced, without waiting for the previous requests to complete, they will use the same inputs most likely, and later requests will all fail. This just adds a mutex to the calls so they execute sequentially.

We may want to consider expanding this (using multiple mutexes) to other non idempotent calls.