### PR TITLE
Add optimize target parameter

### DIFF
--- a/src/errors/Errors.cpp
+++ b/src/errors/Errors.cpp
@@ -316,6 +316,11 @@ std::string Error::getErrorMessage() const
                    "Please re-prepare and re-send the transaction, ensuring you "
                    "specify the correct transaction hash.";
         }
+        case AMOUNT_UGLY:
+        {
+            return "The amount given does not have only a single significant digit. "
+                   "For example, 20000 or 100000 would be fine, but 20001 or 123456 would not.";
+        }
         /* No default case so the compiler warns us if we missed one */
     }
 

--- a/src/errors/Errors.h
+++ b/src/errors/Errors.h
@@ -233,6 +233,10 @@ enum ErrorCode
      * it never existed, or because the wallet was restarted and the prepared
      * transaction state was lost */
     PREPARED_TRANSACTION_NOT_FOUND = 58,
+
+    /* The amount given does not have only a single significant digit - i.e.,
+     * it cannot be used directly as a transaction input/output amount */
+    AMOUNT_UGLY = 59,
 };
 
 class Error

--- a/src/errors/ValidateParameters.h
+++ b/src/errors/ValidateParameters.h
@@ -16,7 +16,8 @@ Error validateFusionTransaction(
     const std::vector<std::string> subWalletsToTakeFrom,
     const std::string destinationAddress,
     const std::shared_ptr<SubWallets> subWallets,
-    const uint64_t currentHeight);
+    const uint64_t currentHeight,
+    const std::optional<uint64_t> optimizeTarget);
 
 Error validateTransaction(
     const std::vector<std::pair<std::string, uint64_t>> destinations,
@@ -54,3 +55,6 @@ Error validateDestinations(const std::vector<std::pair<std::string, uint64_t>> d
 Error validateAddresses(std::vector<std::string> addresses, const bool integratedAddressesAllowed);
 
 Error validateOurAddresses(const std::vector<std::string> addresses, const std::shared_ptr<SubWallets> subWallets);
+
+Error validateOptimizeTarget(const std::optional<uint64_t> optimizeTarget);
+

--- a/src/subwallets/SubWallets.cpp
+++ b/src/subwallets/SubWallets.cpp
@@ -555,7 +555,8 @@ std::tuple<std::vector<WalletTypes::TxInputAndOwner>, uint64_t, uint64_t> SubWal
     const bool takeFromAll,
     std::vector<Crypto::PublicKey> subWalletsToTakeFrom,
     const uint64_t mixin,
-    const uint64_t height) const
+    const uint64_t height,
+    const std::optional<uint64_t> optimizeTarget) const
 {
     /* Can't send transactions with a view wallet */
     throwIfViewWallet();
@@ -601,6 +602,14 @@ std::tuple<std::vector<WalletTypes::TxInputAndOwner>, uint64_t, uint64_t> SubWal
 
     for (const auto &walletAmount : availableInputs)
     {
+        /* If we have an optimize target, we don't make new inputs larger than
+         * the target. Therefore there is not point selecting inputs that are
+         * larger than the target. */ 
+        if (optimizeTarget && walletAmount.input.amount >= *optimizeTarget)
+        {
+            continue;
+        }
+
         /* Find out how many digits the amount has, i.e. 1337 has 4 digits,
            420 has 3 digits */
         int numberOfDigits = floor(log10(walletAmount.input.amount)) + 1;

--- a/src/subwallets/SubWallets.h
+++ b/src/subwallets/SubWallets.h
@@ -97,7 +97,8 @@ class SubWallets
         const bool takeFromAll,
         std::vector<Crypto::PublicKey> subWalletsToTakeFrom,
         const uint64_t mixin,
-        const uint64_t height) const;
+        const uint64_t height,
+        const std::optional<uint64_t> optimizeTarget) const;
 
     /* Get the owner of the key image, if any */
     std::tuple<bool, Crypto::PublicKey> getKeyImageOwner(const Crypto::KeyImage keyImage) const;

--- a/src/walletapi/ApiDispatcher.cpp
+++ b/src/walletapi/ApiDispatcher.cpp
@@ -878,7 +878,16 @@ std::tuple<Error, uint16_t>
 std::tuple<Error, uint16_t>
     ApiDispatcher::sendAdvancedFusionTransaction(const httplib::Request &req, httplib::Response &res, const nlohmann::json &body)
 {
-    const std::string destination = getJsonValue<std::string>(body, "destination");
+    std::string destination;
+
+    if (body.find("destination") != body.end())
+    {
+        destination = getJsonValue<std::string>(body, "destination");
+    }
+    else
+    {
+        destination = m_walletBackend->getPrimaryAddress();
+    }
 
     uint64_t mixin;
 
@@ -912,7 +921,20 @@ std::tuple<Error, uint16_t>
         }
     }
 
-    auto [error, hash] = m_walletBackend->sendFusionTransactionAdvanced(mixin, subWalletsToTakeFrom, destination, extraData);
+    std::optional<uint64_t> optimizeTarget;
+
+    if (body.find("optimizeTarget") != body.end())
+    {
+        optimizeTarget = getJsonValue<uint64_t>(body, "optimizeTarget");
+    }
+
+    auto [error, hash] = m_walletBackend->sendFusionTransactionAdvanced(
+        mixin,
+        subWalletsToTakeFrom,
+        destination,
+        extraData,
+        optimizeTarget
+    );
 
     if (error)
     {

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -28,7 +28,7 @@ namespace SendTransaction
            as the static constructors were used */
         const std::string defaultAddress = subWallets->getPrimaryAddress();
 
-        return sendFusionTransactionAdvanced(defaultMixin, {}, defaultAddress, daemon, subWallets, {});
+        return sendFusionTransactionAdvanced(defaultMixin, {}, defaultAddress, daemon, subWallets, {}, std::nullopt);
     }
 
     std::tuple<Error, Crypto::Hash> sendFusionTransactionAdvanced(
@@ -37,7 +37,8 @@ namespace SendTransaction
         std::string destination,
         const std::shared_ptr<Nigel> daemon,
         const std::shared_ptr<SubWallets> subWallets,
-        const std::vector<uint8_t> extraData)
+        const std::vector<uint8_t> extraData,
+        const std::optional<uint64_t> optimizeTarget)
     {
         if (destination == "")
         {
@@ -45,8 +46,14 @@ namespace SendTransaction
         }
 
         /* Validate the transaction input parameters */
-        Error error =
-            validateFusionTransaction(mixin, addressesToTakeFrom, destination, subWallets, daemon->networkBlockCount());
+        Error error = validateFusionTransaction(
+            mixin,
+            addressesToTakeFrom,
+            destination,
+            subWallets,
+            daemon->networkBlockCount(),
+            optimizeTarget
+        );
 
         if (error)
         {
@@ -62,7 +69,12 @@ namespace SendTransaction
 
         /* Grab inputs for our fusion transaction */
         auto [ourInputs, maxFusionInputs, foundMoney] = subWallets->getFusionTransactionInputs(
-            takeFromAllSubWallets, subWalletsToTakeFrom, mixin, daemon->networkBlockCount());
+            takeFromAllSubWallets,
+            subWalletsToTakeFrom,
+            mixin,
+            daemon->networkBlockCount(),
+            optimizeTarget
+        );
 
         /* Mixin is too large to get enough outputs whilst remaining in the size
            and ratio constraints */
@@ -93,8 +105,35 @@ namespace SendTransaction
 
             std::vector<WalletTypes::TransactionDestination> destinations;
 
+            uint64_t amountToSplit = foundMoney;
+
+            /* We have an optimize target, and enough money to make outputs
+             * large enough for the target, lets attempt to make some outputs
+             * of that size. */
+            /* Disabled for now as this will cause the wallet to not create valid
+             * fusion transactions as fusions are required to decompose as
+             * efficiently as possible - i.e. 12345 -> 10000 + 2000 + 300 + 40 + 5 */
+            /* if (optimizeTarget && foundMoney >= *optimizeTarget) */
+            if (false)
+            {
+                /* Max amount of optimizeTarget destinations we can make */
+                const uint64_t numTargets = foundMoney / *optimizeTarget;
+
+                /* Change remaining after making as many optimizeTarget destinations */
+                amountToSplit = foundMoney % *optimizeTarget;
+
+                WalletTypes::TransactionDestination destination;
+
+                destination.amount = *optimizeTarget;
+                destination.receiverPublicSpendKey = publicSpendKey;
+                destination.receiverPublicViewKey = publicViewKey;
+
+                /* Insert all optimizeTarget destination amounts */
+                destinations.insert(destinations.end(), numTargets, destination);
+            }
+
             /* Split transfer into denominations and create an output for each */
-            for (const auto denomination : splitAmountIntoDenominations(foundMoney))
+            for (const auto denomination : splitAmountIntoDenominations(amountToSplit))
             {
                 WalletTypes::TransactionDestination destination;
 

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -14,8 +14,9 @@
 
 namespace SendTransaction
 {
-    std::tuple<Error, Crypto::Hash>
-        sendFusionTransactionBasic(const std::shared_ptr<Nigel> daemon, const std::shared_ptr<SubWallets> subWallets);
+    std::tuple<Error, Crypto::Hash> sendFusionTransactionBasic(
+        const std::shared_ptr<Nigel> daemon,
+        const std::shared_ptr<SubWallets> subWallets);
 
     std::tuple<Error, Crypto::Hash> sendFusionTransactionAdvanced(
         const uint64_t mixin,
@@ -23,7 +24,8 @@ namespace SendTransaction
         std::string destination,
         const std::shared_ptr<Nigel> daemon,
         const std::shared_ptr<SubWallets> subWallets,
-        const std::vector<uint8_t> extraData);
+        const std::vector<uint8_t> extraData,
+        const std::optional<uint64_t> optimizeTarget);
 
     std::tuple<Error, Crypto::Hash, WalletTypes::PreparedTransactionInfo> sendTransactionBasic(
         std::string destination,

--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -881,12 +881,20 @@ std::tuple<Error, Crypto::Hash> WalletBackend::sendFusionTransactionAdvanced(
     const uint64_t mixin,
     const std::vector<std::string> subWalletsToTakeFrom,
     const std::string destination,
-    const std::vector<uint8_t> extraData)
+    const std::vector<uint8_t> extraData,
+    const std::optional<uint64_t> optimizeTarget)
 {
     std::scoped_lock lock(m_transactionMutex);
 
     return SendTransaction::sendFusionTransactionAdvanced(
-        mixin, subWalletsToTakeFrom, destination, m_daemon, m_subWallets, extraData);
+        mixin,
+        subWalletsToTakeFrom,
+        destination,
+        m_daemon,
+        m_subWallets,
+        extraData,
+        optimizeTarget
+    );
 }
 
 void WalletBackend::reset(uint64_t scanHeight, uint64_t timestamp)

--- a/src/walletbackend/WalletBackend.h
+++ b/src/walletbackend/WalletBackend.h
@@ -166,7 +166,8 @@ class WalletBackend
         const uint64_t mixin,
         const std::vector<std::string> subWalletsToTakeFrom,
         const std::string destinationAddress,
-        const std::vector<uint8_t> extraData);
+        const std::vector<uint8_t> extraData,
+        const std::optional<uint64_t> optimizeTarget);
 
     /* Get the balance for one subwallet (error, unlocked, locked) */
     std::tuple<Error, uint64_t, uint64_t> getBalance(const std::string address) const;


### PR DESCRIPTION
Adds an `optimizeTarget` parameter to `/transactions/send/fusion/advanced`. Amounts larger than this target will not be fused. Also makes the destination parameter optional.