### PR TITLE
Use a thread safe DB access method for threaded input is spent check

### DIFF
--- a/include/IDataBase.h
+++ b/include/IDataBase.h
@@ -21,5 +21,7 @@ namespace CryptoNote
         virtual std::error_code write(IWriteBatch &batch) = 0;
 
         virtual std::error_code read(IReadBatch &batch) = 0;
+
+        virtual std::error_code readThreadSafe(IReadBatch &batch) = 0;
     };
 } // namespace CryptoNote

--- a/src/cryptonotecore/DatabaseBlockchainCache.cpp
+++ b/src/cryptonotecore/DatabaseBlockchainCache.cpp
@@ -1188,7 +1188,7 @@ namespace CryptoNote
     bool DatabaseBlockchainCache::checkIfSpent(const Crypto::KeyImage &keyImage, uint32_t blockIndex) const
     {
         auto batch = BlockchainReadBatch().requestBlockIndexBySpentKeyImage(keyImage);
-        auto res = database.read(batch);
+        auto res = database.readThreadSafe(batch);
         if (res)
         {
             logger(Logging::ERROR) << "checkIfSpent failed, request to database failed: " << res.message();

--- a/src/cryptonotecore/RocksDBWrapper.cpp
+++ b/src/cryptonotecore/RocksDBWrapper.cpp
@@ -188,6 +188,48 @@ std::error_code RocksDBWrapper::read(IReadBatch &batch)
     return std::error_code();
 }
 
+std::error_code RocksDBWrapper::readThreadSafe(IReadBatch &batch)
+{
+    if (state.load() != INITIALIZED)
+    {
+        throw std::runtime_error("Not initialized.");
+    }
+
+    rocksdb::ReadOptions readOptions;
+
+    std::vector<std::string> rawKeys(batch.getRawKeys());
+
+    std::vector<std::string> values(rawKeys.size());
+
+    std::vector<bool> resultStates;
+
+    int i = 0;
+
+    for (const std::string &key : rawKeys)
+    {
+        const rocksdb::Status status = db->Get(readOptions, rocksdb::Slice(key), &values[i]);
+
+        if (status.ok())
+        {
+            resultStates.push_back(true);
+        }
+        else
+        {
+            if (!status.IsNotFound())
+            {
+                return make_error_code(CryptoNote::error::DataBaseErrorCodes::INTERNAL_ERROR);
+            }
+
+            resultStates.push_back(false);
+        }
+
+        i++;
+    }
+
+    batch.submitRawResult(values, resultStates);
+    return std::error_code();
+}
+
 rocksdb::Options RocksDBWrapper::getDBOptions(const DataBaseConfig &config)
 {
     rocksdb::DBOptions dbOptions;

--- a/src/cryptonotecore/RocksDBWrapper.h
+++ b/src/cryptonotecore/RocksDBWrapper.h
@@ -41,6 +41,8 @@ namespace CryptoNote
 
         std::error_code read(IReadBatch &batch) override;
 
+        std::error_code readThreadSafe(IReadBatch &batch) override;
+
       private:
         std::error_code write(IWriteBatch &batch, bool sync);
 


### PR DESCRIPTION
Possible fix to #1022 

Not very tested. Idea is that `Get()` is thread safe whilst `MultiGet` is assumed to not be, so if we just use repeated `Get()`'s, it should be fine to use.