### PR TITLE
Update COMPILE.md

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -96,7 +96,7 @@ _CentOS compile instructions provided by @brandonlehmann_
 
 -   `sudo yum update -y`
 -   `sudo yum install -y epel-release centos-release-scl`
--   `sudo yum install -y devtoolset-8 cmake3 wget git openssl-devel`
+-   `sudo yum install -y devtoolset-8 cmake cmake3 wget git openssl-devel`
 -   `sudo scl enable devtoolset-8 bash`
 -   `wget https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz`
 -   `tar xzvf boost_1_68_0.tar.gz && cd boost_1_68_0`


### PR DESCRIPTION
Both `cmake` and `cmake3` are required for compiling on CentOS 7. `cmake` is required for compiling RocksDB. I'd asked someone from the maintainers to update this previously, probably he forgot. :-)

Kind regards,