### PR TITLE
Daemon CORS header adjustment

### DIFF
--- a/src/daemon/Daemon.cpp
+++ b/src/daemon/Daemon.cpp
@@ -411,13 +411,6 @@ int main(int argc, char *argv[])
             logManager
         );
 
-        std::string corsDomain;
-
-        /* TODO: enable cors should not be a vector */
-        if (!config.enableCors.empty()) {
-            corsDomain = config.enableCors[0];
-        }
-
         RpcMode rpcMode = RpcMode::Default;
 
         if (config.enableBlockExplorerDetailed)
@@ -432,7 +425,7 @@ int main(int argc, char *argv[])
         RpcServer rpcServer(
             config.rpcPort,
             config.rpcInterface,
-            corsDomain,
+            config.enableCors,
             config.feeAddress,
             config.feeAmount,
             rpcMode,

--- a/src/daemon/DaemonConfiguration.cpp
+++ b/src/daemon/DaemonConfiguration.cpp
@@ -93,7 +93,7 @@ namespace DaemonConfig
             "enable-cors",
             "Adds header 'Access-Control-Allow-Origin' to the RPC responses using the <domain>. Uses the value "
             "specified as the domain. Use * for all.",
-            cxxopts::value<std::vector<std::string>>(),
+            cxxopts::value<std::string>(),
             "<domain>")(
             "fee-address",
             "Sets the convenience charge <address> for light wallets that use the daemon",
@@ -362,7 +362,7 @@ namespace DaemonConfig
 
             if (cli.count("enable-cors") > 0)
             {
-                config.enableCors = cli["enable-cors"].as<std::vector<std::string>>();
+                config.enableCors = cli["enable-cors"].as<std::string>();
             }
 
             if (cli.count("fee-address") > 0)
@@ -424,7 +424,7 @@ namespace DaemonConfig
         std::vector<std::string> priorityNodes;
         std::vector<std::string> seedNodes;
         std::vector<std::string> peers;
-        std::vector<std::string> cors;
+        std::string cors;
         bool updated = false;
 
         for (std::string line; std::getline(data, line);)
@@ -628,7 +628,7 @@ namespace DaemonConfig
                 }
                 else if (cfgKey.compare("enable-cors") == 0)
                 {
-                    cors.push_back(cfgValue);
+                    cors = cfgValue;
                     config.enableCors = cors;
                     updated = true;
                 }
@@ -848,11 +848,7 @@ namespace DaemonConfig
 
         if (j.HasMember("enable-cors"))
         {
-            const Value &va = j["enable-cors"];
-            for (auto &v : va.GetArray())
-            {
-                config.enableCors.push_back(v.GetString());
-            }
+            config.enableCors = j["enable-cors"].GetString();
         }
 
         if (j.HasMember("fee-address"))
@@ -929,15 +925,7 @@ namespace DaemonConfig
             j.AddMember("seed-node", arr, alloc);
         }
 
-        {
-            Value arr(rapidjson::kArrayType);
-            for (auto v : config.enableCors)
-            {
-                arr.PushBack(Value().SetString(StringRef(v.c_str())), alloc);
-            }
-            j.AddMember("enable-cors", arr, alloc);
-        }
-
+        j.AddMember("enable-cors", config.enableCors, alloc);
         j.AddMember("enable-blockexplorer", config.enableBlockExplorer, alloc);
         j.AddMember("enable-blockexplorer-detailed", config.enableBlockExplorerDetailed, alloc);
         j.AddMember("fee-address", config.feeAddress, alloc);

--- a/src/daemon/DaemonConfiguration.h
+++ b/src/daemon/DaemonConfiguration.h
@@ -74,7 +74,7 @@ namespace DaemonConfig
 
         std::vector<std::string> seedNodes;
 
-        std::vector<std::string> enableCors;
+        std::string enableCors;
 
         int logLevel;
 


### PR DESCRIPTION
Changes the daemon configuration option supplied by `--enable-cors` from handling an array, which is not supported in the HTTP header, to a single string for better handling.

This also solves the issue where the `--enable-cors` option was not being saved to configurations and loaded properly.