### PR TITLE
Fix block with final transaction with invalid public key preventing syncing

### DIFF
--- a/src/transfers/TransfersConsumer.cpp
+++ b/src/transfers/TransfersConsumer.cpp
@@ -284,13 +284,17 @@ namespace CryptoNote
                 for (const auto &tx : blocks[i].transactions)
                 {
                     auto pubKey = tx->getTransactionPublicKey();
-                    if (pubKey == Constants::NULL_PUBLIC_KEY)
+                    bool isLastTransactionInBlock = blockInfo.transactionIndex + 1 == blocks[i].transactions.size();
+
+                    /* Need to ensure we add the last tx in the block even if it
+                     * has a null pub key, as we use this to indicate when we
+                     * have finished processing a block. */
+                    if (pubKey == Constants::NULL_PUBLIC_KEY && !isLastTransactionInBlock)
                     {
                         ++blockInfo.transactionIndex;
                         continue;
                     }
 
-                    bool isLastTransactionInBlock = blockInfo.transactionIndex + 1 == blocks[i].transactions.size();
                     Tx item = {blockInfo, tx.get(), isLastTransactionInBlock};
                     inputQueue.push(item);
                     ++blockInfo.transactionIndex;


### PR DESCRIPTION
If the final transaction in a block has an invalid public key, the transaction will get skipped - this causes the wallet to think it has not full processed the blocks, as there is no longer a 'last transaction in block' transaction to be processed.

To my knowledge this has not occurred before, but this will guard against it in case it does.