### PR TITLE
Revert "openssl is provided by windows image"

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -241,6 +241,9 @@ jobs:
           path: clcache
           key: clcache-windows
 
+      - name: Install OpenSSL
+        run: choco install openssl
+
       # Configure project with cmake
       - name: Configure
         run: |


### PR DESCRIPTION
This reverts commit 686af0ff34213d49f289ba25521283a0cf125a86.

The commit in question linked the windows build against the wrong OpenSSL binaries thus resulting in #1066 as they are not properly linked for windows. This change reverts that change to install the correct openssl development packages with the necessary *.lib files needed by MSVC.