### PR TITLE
Update gcc build instructions to match the matrix.yml

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -38,11 +38,8 @@ However, if you wish to create _portable_ binaries that can be shared between sy
 
 ##### Ubuntu with GCC
 
--   `sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y`
--   `sudo apt-get update`
--   `sudo apt-get install aptitude -y`
--   `sudo aptitude install -y build-essential g++-8 gcc-8 git libboost-all-dev python-pip libssl-dev`
--   `sudo pip install cmake`
+-   `sudo apt update`
+-   `sudo apt install -y libboost-all-dev libssl-dev gcc-8 g++-8 cmake`
 -   `export CC=gcc-8`
 -   `export CXX=g++-8`
 -   `git clone -b master --single-branch https://github.com/turtlecoin/turtlecoin`


### PR DESCRIPTION
I have tested these instructions on a fresh VM with ubuntu latest LTS, and they work fine. These seem to be the instructions the CI tests use. The cmake that ships in the default ubuntu repositories is 3.16.3 right now, so needing to install CMake from pip is no longer an issue. I'm thinking the clang instructions could probably be cleaned up significantly as well as they also use the same exact build instructions in the matrix, with the exception of the cc and ccx variables and compilers installed obviously, but I don't use clang so I didn't want to mess with it.