### PR TITLE
Zedwallet reset flag

### DIFF
--- a/include/ZedwalletTypes.h
+++ b/include/ZedwalletTypes.h
@@ -51,6 +51,9 @@ struct Config
     /* Was the wallet pass specified on CLI */
     bool passGiven = false;
 
+    /* Was the reset flag specified on CLI */
+    bool resetGiven = false;
+
     /* Should we log walletd logs to a file */
     bool debug = false;
 
@@ -65,6 +68,9 @@ struct Config
 
     /* The wallet password */
     std::string walletPass = "";
+
+    /* The reset startHeight */
+    int resetFromHeight = 0;
 };
 
 struct AddressBookEntry

--- a/include/ZedwalletTypes.h
+++ b/include/ZedwalletTypes.h
@@ -70,7 +70,7 @@ struct Config
     std::string walletPass = "";
 
     /* The reset startHeight */
-    int resetFromHeight = 0;
+    uint64_t resetFromHeight = 0;
 };
 
 struct AddressBookEntry

--- a/src/walletbackend/WalletBackend.cpp
+++ b/src/walletbackend/WalletBackend.cpp
@@ -460,7 +460,7 @@ std::tuple<Error, std::shared_ptr<WalletBackend>> WalletBackend::openWallet(
     std::vector<char> buffer((std::istreambuf_iterator<char>(file)), (std::istreambuf_iterator<char>()));
 
     /* Check that the decrypted data has the 'isAWallet' identifier,
-       and remove it it does. If it doesn't, return an error. */
+       and remove if it does. If it doesn't, return an error. */
     Error error = hasMagicIdentifier(buffer, Constants::IS_A_WALLET_IDENTIFIER, NOT_A_WALLET_FILE, NOT_A_WALLET_FILE);
 
     /* Not a WalletBackend wallet */

--- a/src/zedwallet++/Menu.cpp
+++ b/src/zedwallet++/Menu.cpp
@@ -49,8 +49,8 @@ std::tuple<bool, bool, std::shared_ptr<WalletBackend>> selectionScreen(const Zed
         /*Reset wallet if user requested it*/
         if (config.resetGiven) 
         {   
-            /*here the reset logic would go*/
-            std::cout << "Requested reset starting at height: " << config.resetFromHeight << "\n\n";
+            const uint64_t timestamp = 0;
+            walletBackend->reset(config.resetFromHeight, timestamp);
         }
 
         const auto [feeAmount, feeAddress] = walletBackend->getNodeFee();

--- a/src/zedwallet++/Menu.cpp
+++ b/src/zedwallet++/Menu.cpp
@@ -46,6 +46,13 @@ std::tuple<bool, bool, std::shared_ptr<WalletBackend>> selectionScreen(const Zed
             return {exit, sync, nullptr};
         }
 
+        /*Reset wallet if user requested it*/
+        if (config.resetGiven) 
+        {   
+            /*here the reset logic would go*/
+            std::cout << "Requested reset starting at height: " << config.resetFromHeight << "\n\n";
+        }
+
         const auto [feeAmount, feeAddress] = walletBackend->getNodeFee();
 
         if (feeAmount != 0)

--- a/src/zedwallet++/ParseArguments.cpp
+++ b/src/zedwallet++/ParseArguments.cpp
@@ -102,7 +102,8 @@ ZedConfig parseArguments(int argc, char **argv)
         /* check if reset flag was supplied */
         config.resetGiven = result.count("reset") != 0;
 
-        if (config.resetGiven) {
+        if (config.resetGiven) 
+        {
           config.resetFromHeight = reset;
         }
     }

--- a/src/zedwallet++/ParseArguments.cpp
+++ b/src/zedwallet++/ParseArguments.cpp
@@ -29,6 +29,7 @@ ZedConfig parseArguments(int argc, char **argv)
     std::string remoteDaemon;
 
     int logLevel;
+    int reset;
 
     unsigned int threads;
 
@@ -65,6 +66,10 @@ ZedConfig parseArguments(int argc, char **argv)
          cxxopts::value<std::string>(config.walletPass),
          "<pass>")
 
+        ("reset",
+         "Recheck the chain from a specific block for transactions",
+         cxxopts::value<int>(reset),"<block height>")
+
         ("log-level",
          "Specify log level",
          cxxopts::value<int>(logLevel)->default_value(std::to_string(config.logLevel)),
@@ -93,6 +98,13 @@ ZedConfig parseArguments(int argc, char **argv)
 
         /* We could check if the string is empty, but an empty password is valid */
         config.passGiven = result.count("password") != 0;
+
+        /* check if reset flag was supplied */
+        config.resetGiven = result.count("reset") != 0;
+
+        if (config.resetGiven) {
+          config.resetFromHeight = reset;
+        }
     }
     catch (const cxxopts::OptionException &e)
     {

--- a/src/zedwallet++/ParseArguments.h
+++ b/src/zedwallet++/ParseArguments.h
@@ -17,6 +17,9 @@ struct ZedConfig
     /* Was the wallet pass specified on CLI */
     bool passGiven = false;
 
+    /* Was the reset arg specified on CLI */
+    bool resetGiven = false;
+
     /* The daemon host */
     std::string host;
 
@@ -28,6 +31,9 @@ struct ZedConfig
 
     /* The wallet password */
     std::string walletPass;
+
+    /* The reset block height */
+    uint resetFromHeight;
 
     /* Controls what level of messages to log */
     Logger::LogLevel logLevel = Logger::FATAL;

--- a/src/zedwallet++/ParseArguments.h
+++ b/src/zedwallet++/ParseArguments.h
@@ -33,7 +33,7 @@ struct ZedConfig
     std::string walletPass;
 
     /* The reset block height */
-    uint resetFromHeight;
+    uint64_t resetFromHeight;
 
     /* Controls what level of messages to log */
     Logger::LogLevel logLevel = Logger::FATAL;


### PR DESCRIPTION
Added a an option to reset when starting the wallet with the flag `./zedwallet -w walletName -p password --reset <block height>` 