### PR TITLE
Install boot 1.69 instead for Windows gha build

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -244,12 +244,21 @@ jobs:
       - name: Install OpenSSL
         run: choco install openssl
 
+      # Install boost
+      - name: Install Boost 1.69.0
+        run: |
+          $link = "https://bintray.com/boostorg/release/download_file?file_path=1.69.0%2Fbinaries%2Fboost_1_69_0-msvc-14.1-64.exe"
+          $path = "C:\boost.exe"
+          [Net.WebClient]::new().DownloadFile($link, $path)
+          Start-Process C:\boost.exe -ArgumentList "/DIR=C:\local\boost_1_69_0","/VERYSILENT" -Wait
+          Get-ChildItem C:\local\boost_1_69_0
+
       # Configure project with cmake
       - name: Configure
         run: |
           mkdir build
           cd build
-          cmake -G "Visual Studio 16 2019" -A x64 .. -DARCH=default -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0"
+          cmake -G "Visual Studio 16 2019" -A x64 .. -DARCH=default -DBOOST_ROOT=C:/local/boost_1_69_0
 
       # Build for Windows
       - name: Build


### PR DESCRIPTION
* I don't know what's wrong with installed boost 1.72.0 in github action virtual environment.
* This just should fix Windows build in gha