### PR TITLE
Fix wallet-api and zedwallet reset/rewind bugs

### DIFF
--- a/include/JsonHelper.h
+++ b/include/JsonHelper.h
@@ -19,6 +19,11 @@ static const std::string kTypeNames[] = {"Null", "False", "True", "Object", "Arr
 
 template<typename T> bool hasMember(const T &j, const std::string &key)
 {
+    if (!j.IsObject())
+    {
+        return false;
+    }
+
     auto val = j.FindMember(key);
 
     return val != j.MemberEnd();

--- a/src/walletapi/ApiDispatcher.cpp
+++ b/src/walletapi/ApiDispatcher.cpp
@@ -331,7 +331,7 @@ std::optional<rapidjson::Document>
 {
     rapidjson::Document jsonBody;
 
-    if (!bodyRequired)
+    if (req.body == "")
     {
         /* Some compilers are stupid and can't figure out just `return jsonBody`
          * and we can't construct a std::optional(jsonBody) since the copy

--- a/src/zedwallet++/CommandImplementations.cpp
+++ b/src/zedwallet++/CommandImplementations.cpp
@@ -313,7 +313,12 @@ void rewind(const std::shared_ptr<WalletBackend> walletBackend)
                             "Hit enter for the default of "
                             + std::to_string(defaultRewindHeight) + " (1000 blocks ago): ";
 
-    const uint64_t scanHeight = getHeight(msg);
+    uint64_t scanHeight = getHeight(msg);
+
+    if (scanHeight == 0)
+    {
+        scanHeight = defaultRewindHeight;
+    }
 
     std::cout << std::endl
               << InformationMsg("This process may take some time to complete.") << std::endl


### PR DESCRIPTION
* Fixes the `scanHeight` argument being ignored when using the `/reset` call
* Fixes the default rewind height of -1000 blocks not being correctly used